### PR TITLE
Fix multi-arch image promotion and UI updates

### DIFF
--- a/.github/workflows/promote-images.yml
+++ b/.github/workflows/promote-images.yml
@@ -30,6 +30,9 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
       - name: Retag and push ring images
         run: |
           set -euo pipefail
@@ -37,16 +40,10 @@ jobs:
           source_tag="${{ inputs.source_tag }}"
           target_tag="${{ inputs.target_tag }}"
 
-          api_source="${repo}-api:${source_tag}"
-          api_target="${repo}-api:${target_tag}"
-          ui_source="${repo}-ui:${source_tag}"
-          ui_target="${repo}-ui:${target_tag}"
+          docker buildx imagetools create \
+            --tag "${repo}-api:${target_tag}" \
+            "${repo}-api:${source_tag}"
 
-          docker pull "$api_source"
-          docker pull "$ui_source"
-
-          docker tag "$api_source" "$api_target"
-          docker tag "$ui_source" "$ui_target"
-
-          docker push "$api_target"
-          docker push "$ui_target"
+          docker buildx imagetools create \
+            --tag "${repo}-ui:${target_tag}" \
+            "${repo}-ui:${source_tag}"

--- a/aquila_web/static/index.html
+++ b/aquila_web/static/index.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=768, height=1024, initial-scale=1" />
   <title>Ready Screen</title>
-  <link rel="stylesheet" href="static/styles.css?v=206" />
+  <link rel="stylesheet" href="static/styles.css?v=207" />
 </head>
 <body class="app-body">
   <div class="screen">

--- a/aquila_web/static/styles.css
+++ b/aquila_web/static/styles.css
@@ -649,7 +649,7 @@ a:active {
   width: 10px;
   height: 10px;
   border-radius: 999px;
-  background-color: #ec4899;
+  background-color: #3b82f6;
 }
 
 .run-ready-pill {


### PR DESCRIPTION
## Summary
- **Fix promote-images workflow**: replaced `docker pull/tag/push` with `docker buildx imagetools create` so promoting images to a ring tag (dev/pilot/prod) no longer strips the `arm64` variant — this was causing the Pi to pull `amd64` images
- **Blue run-start dot**: changed `.run-start-dot` color from pink to blue
- **CSS cache bump**: styles.css version bumped to v207

## Test plan
- [ ] Run `promote-images` workflow with `source_tag=latest` and `target_tag=dev`, then verify on Pi that `docker pull` resolves to `arm64`
- [ ] Verify blue dot appears under Start Run on device UI

🤖 Generated with [Claude Code](https://claude.com/claude-code)