### PR TITLE
Add aquila-app service to run application.py

### DIFF
--- a/fleet-config/docker-compose.yml
+++ b/fleet-config/docker-compose.yml
@@ -34,6 +34,42 @@ services:
         limits:
           memory: 1024M
 
+  app:
+    image: ghcr.io/${GHCR_REPO:-acorngenetics/aquilla-main}-api:${IMAGE_TAG}
+    env_file: ${DEVICE_ENV_FILE:-/opt/aquila/config/device.env}
+    container_name: aquila-app
+    command: ["python3", "application.py"]
+    environment:
+      DATA_DIR: "/opt/aquila"
+      PROFILE_DIR: "/opt/aquila/profiles"
+      RESULTS_PATH: "/opt/aquila/results/results.json"
+    volumes:
+      - /opt/aquila/results:/opt/aquila/results
+      - /opt/aquila/logs:/opt/aquila/logs
+      - /opt/aquila/profiles:/opt/aquila/profiles
+      - /opt/aquila/config:/opt/aquila/config
+    devices:
+      - "/dev/ttyACM0:/dev/ttyACM0"
+      - "/dev/i2c-1:/dev/i2c-1"
+      - "/dev/spidev0.0:/dev/spidev0.0"
+      - "/dev/spidev0.1:/dev/spidev0.1"
+      - "/dev/gpiomem:/dev/gpiomem"
+    privileged: true
+    depends_on:
+      - backend
+    restart: unless-stopped
+    labels:
+      - "com.centurylinklabs.watchtower.enable=true"
+    logging:
+      driver: json-file
+      options:
+        max-size: "10m"
+        max-file: "3"
+    deploy:
+      resources:
+        limits:
+          memory: 512M
+
   ui:
     image: ghcr.io/${GHCR_REPO:-acorngenetics/aquilla-main}-ui:${IMAGE_TAG}
     env_file: ${DEVICE_ENV_FILE:-/opt/aquila/config/device.env}


### PR DESCRIPTION
## Summary
- Adds `aquila-app` as a new service in `fleet-config/docker-compose.yml`
- Runs `application.py` using the same API image with a different command
- `application.py` is the state machine that polls button/drawer state and drives hardware over serial (`/dev/ttyACM0`) — without it, UI commands (open drawer, start run, etc.) were received by the backend but never executed on hardware
- Includes the same device mappings, volumes, and `privileged: true` as the backend service

## Test plan
- [ ] After merging, on the Pi: `sudo curl -o /opt/fleet/docker-compose.yml https://raw.githubusercontent.com/AcornGenetics/aquilla-main/main/fleet-config/docker-compose.yml`
- [ ] `sudo docker compose -f /opt/fleet/docker-compose.yml up -d app`
- [ ] `sudo docker logs aquila-app --follow` — confirm state machine is polling
- [ ] Press Open Drawer in UI — confirm drawer physically moves

🤖 Generated with [Claude Code](https://claude.com/claude-code)