### PR TITLE
Modify verification_profile.json structure and cycles

### DIFF
--- a/profiles/bundled/verification_profile.json
+++ b/profiles/bundled/verification_profile.json
@@ -66,7 +66,7 @@
                 "description": "Annealing"
             }
         ],
-        "cycles": 10
+        "cycles": 5
     },
     {
         "ramp_rate": 1.6


### PR DESCRIPTION
Updated the verification profile JSON structure, including changes to the repeat cycles and corrected the number of cycles from 10 to 5. Too long for these short tests. May be nice to have another profile like a 3 cycler with hold times of 30s (not 1 min at the front) and we can do that for debugging (i have not edited that here, merely dropped this standard verification profile to 5 cycles)