### PR TITLE
fix: WebSocket reconnect, stop-button escape, and run teardown reliab…

### DIFF
--- a/aq_lib/state_requests.py
+++ b/aq_lib/state_requests.py
@@ -124,14 +124,23 @@ def reset_stop_request() -> None:
     except requests.exceptions.RequestException as e:
         logger.exception("Error resetting stop request: %s", e)
 
+_stop_poll_failures = 0
+_STOP_POLL_FAILURE_LIMIT = 10
+
 def check_stop_request() -> bool:
+    global _stop_poll_failures
     url = f"{BACKEND_URL}/button_status/"
     try:
         ret = requests.get(url, timeout=5)
         ret.raise_for_status()
         data = ret.json()
+        _stop_poll_failures = 0
     except Exception as e:
-        logger.warning("Error polling stop request", e)
+        _stop_poll_failures += 1
+        logger.warning("Error polling stop request (%d/%d): %s", _stop_poll_failures, _STOP_POLL_FAILURE_LIMIT, e)
+        if _stop_poll_failures >= _STOP_POLL_FAILURE_LIMIT:
+            logger.error("Backend unreachable for %d consecutive polls — forcing stop", _stop_poll_failures)
+            return True
         return False
     return bool(data.get("stop_requested"))
 
@@ -199,7 +208,13 @@ def wait_for_button(include_run_complete_ack: bool = False):
         elif include_run_complete_ack and data.get("run_complete_ack"):
             logger.info("Run complete acknowledged")
             return data
-
+        elif data.get("stop_requested"):
+            logger.info("Stop requested during end wait — treating as run complete")
+            try:
+                requests.post(f"{BACKEND_URL}/stop/reset", timeout=5)
+            except Exception as e:
+                logger.warning("Error resetting stop request: %s", e)
+            return data
 
         time.sleep(0.5)
 

--- a/aquila_web/static/script.js
+++ b/aquila_web/static/script.js
@@ -414,9 +414,11 @@ function acknowledgeRunComplete() {
 // Connect to WebSocket backend
 const host = window.location.host;
 const wsUrl = `ws://${host}/ws`;
-const socket = new WebSocket( wsUrl ); // adjust URL if needed
 
-socket.onmessage = function(event) {
+let socket;
+let wsReconnectTimer = null;
+
+function wsHandleMessage(event) {
   try {
     const panel = JSON.parse(event.data);
     console.log("Elapsed secs:", panel.elapsed);
@@ -509,7 +511,7 @@ socket.onmessage = function(event) {
             targetPath = "/complete";
             console.log("COMPLETE PATH", targetPath);
         }
-        
+
         if (targetPath !== window.location.pathname){
             currentScreen = screen;
             window.location.href = targetPath;
@@ -526,19 +528,32 @@ socket.onmessage = function(event) {
   } catch (e) {
     console.error("Invalid panel data", e);
   }
-};
+}
 
-socket.onopen = function() {
-  console.log("WebSocket connection established.");
-};
+function connectWebSocket() {
+  if (wsReconnectTimer) {
+    clearTimeout(wsReconnectTimer);
+    wsReconnectTimer = null;
+  }
+  if (socket) {
+    socket.onclose = null;
+    socket.close();
+  }
+  socket = new WebSocket(wsUrl);
+  socket.onmessage = wsHandleMessage;
+  socket.onopen = function() {
+    console.log("WebSocket connection established.");
+  };
+  socket.onerror = function(error) {
+    console.error("WebSocket error:", error);
+  };
+  socket.onclose = function() {
+    console.warn("WebSocket connection closed. Reconnecting in 2s...");
+    wsReconnectTimer = setTimeout(connectWebSocket, 2000);
+  };
+}
 
-socket.onerror = function(error) {
-  console.error("WebSocket error:", error);
-};
-
-socket.onclose = function() {
-  console.warn("WebSocket connection closed.");
-};
+connectWebSocket();
 
 async function notifyRun(){
     if (runButton && runButton.disabled) {

--- a/docker/Dockerfile.api
+++ b/docker/Dockerfile.api
@@ -6,6 +6,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     build-essential \
     procps \
     sudo \
+    curl \
     && rm -rf /var/lib/apt/lists/*
 
 COPY requirements-backend.txt ./requirements-backend.txt

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -13,4 +13,19 @@ if [[ -d "${bundled_profile_dir}" ]]; then
   shopt -u nullglob
 fi
 
+# If this container is running the hardware app, wait until the backend is
+# healthy before starting. This removes the race condition without needing
+# a compose-file change on each device.
+if [[ "${1:-}" == *"application.py"* ]]; then
+  backend_url="${BACKEND_URL:-http://aquila-backend:8090}"
+  echo "Waiting for backend at ${backend_url}/health ..."
+  for i in $(seq 1 30); do
+    if curl -sf "${backend_url}/health" > /dev/null 2>&1; then
+      echo "Backend ready."
+      break
+    fi
+    sleep 2
+  done
+fi
+
 exec "$@"

--- a/fleet-config/docker-compose.yml
+++ b/fleet-config/docker-compose.yml
@@ -66,6 +66,8 @@ services:
       - "host.docker.internal:host-gateway"
     pid: host
     privileged: true
+    healthcheck:
+      disable: true
     depends_on:
       - backend
     restart: unless-stopped

--- a/state_run_assay.py
+++ b/state_run_assay.py
@@ -235,8 +235,10 @@ class AssayInterface():
                 finally:
                     # Drain the executor while files are still open so capture
                     # threads cannot write to a closed file handle.
+                    # Use a generous timeout: a 40-cycle run with optics can
+                    # take several seconds per capture position.
                     self.message_queue.put("quit")
-                    execution_thread.join(timeout=5)
+                    execution_thread.join(timeout=60)
 
         except RunStopped:
             logger.info("Run stopped by user")
@@ -249,9 +251,6 @@ class AssayInterface():
             sr.change_screen("-1")
             raise ( e )
         finally:
-            stop_monitor_event.set()
-            if stop_thread.is_alive():
-                stop_thread.join(timeout=2)
             if execution_thread.is_alive():
                 # Safety net: executor did not finish within the inner timeout
                 self.message_queue.put("quit")
@@ -261,6 +260,12 @@ class AssayInterface():
             if self.run_aborted:
                 sr.timer_control("reset")
             self.drawer.open()
+            # Stop monitor only after drawer is open — keeps the stop button
+            # functional during teardown motor movement (which can take
+            # 30-90 s if the drawer missed steps and needs to re-home).
+            stop_monitor_event.set()
+            if stop_thread.is_alive():
+                stop_thread.join(timeout=2)
             sr.update_drawer_state(is_open=True, is_closed=False)
             if self.run_aborted:
                 sr.change_screen("1")
@@ -287,8 +292,9 @@ class AssayInterface():
         self.meer.setTargetObjectTemperature ( 25.0 )
         self.meer.output_stage_enable ( 0 )
 
-        #self.lid_heater_stop_event.set()
-        #self.lid_thread.join( timeout = 5 )
+        self.lid_heater_stop_event.set()
+        if hasattr(self, "lid_thread") and self.lid_thread.is_alive():
+            self.lid_thread.join( timeout = 5 )
 
 
     def end( self ):


### PR DESCRIPTION
 Frozen UI (sn02/sn03): WebSocket had no reconnect logic — any disconnect left the screen permanently stuck on stale state. Now auto-reconnects after 2s. 
  - Stop button not working (sn03): Run completed while UI was frozen, firmware entered wait_for_button waiting for an acknowledgment the user couldn't give.  
  Stop button now works as an escape hatch. Backend failures also self-abort after ~5s of consecutive errors.                                                
  - Executor timeout too short: 5s join timeout was killing the executor mid-optics-scan on long runs; increased to 60s.                                       
  - Lid heater not shutting down: hw_deinitialize had the lid heater stop commented out — re-enabled.                                                        
  - False unhealthy status: aquila-app health check was pinging port 8090 (only served by aquila-backend); disabled.                                           
  - Startup race condition: entrypoint.sh now polls /health before starting application.py, eliminating the race without per-device compose changes.