### PR TITLE
creating an updating feature that does not auto update during run

### DIFF
--- a/aquila_web/main.py
+++ b/aquila_web/main.py
@@ -1278,3 +1278,171 @@ async def wifi_forget(body: WifiForget):
         return await _kiosk_post("/wifi/forget", {"ssid": body.ssid})
     except Exception as e:
         return {"ok": False, "error": str(e)}
+
+
+# ---------------------------------------------------------------------------
+# OTA Update — manual approval flow
+# ---------------------------------------------------------------------------
+
+import base64
+
+WATCHTOWER_URL = os.getenv("WATCHTOWER_URL", "http://aquila-watchtower:8080")
+WATCHTOWER_TOKEN = os.getenv("WATCHTOWER_HTTP_API_TOKEN", "")
+_OTA_GHCR_USER = os.getenv("GHCR_USERNAME", "")
+_OTA_GHCR_TOKEN = os.getenv("GHCR_TOKEN", "")
+_OTA_GHCR_REPO = os.getenv("GHCR_REPO", "acorngenetics/aquilla-main")
+_OTA_IMAGE_TAG = os.getenv("IMAGE_TAG", "")   # dev | pilot | prod — set by device.env
+_OTA_POLL_INTERVAL = int(os.getenv("UPDATE_CHECK_INTERVAL", "300"))  # seconds
+
+_update_available: bool = False
+_update_dismissed: bool = False
+_update_status: str = "idle"   # idle | checking | available | updating | error
+_update_error: str | None = None
+_update_last_checked: str | None = None
+_startup_image_digest: str | None = None
+
+
+async def _ghcr_bearer_token(user: str, token: str, repo: str) -> str | None:
+    """Exchange Basic credentials for a short-lived GHCR Bearer token."""
+    cred = base64.b64encode(f"{user}:{token}".encode()).decode()
+    owner = repo.split("/")[0]
+    name = "/".join(repo.split("/")[1:]) or repo
+    url = f"https://ghcr.io/token?service=ghcr.io&scope=repository:{owner}/{name}:pull"
+    try:
+        async with httpx.AsyncClient(timeout=15.0) as client:
+            r = await client.get(url, headers={"Authorization": f"Basic {cred}"})
+        if r.status_code == 200:
+            return r.json().get("token")
+    except Exception:
+        pass
+    return None
+
+
+async def _ghcr_manifest_digest(repo: str, tag: str, user: str, token: str) -> str | None:
+    """Return the manifest digest for a GHCR image tag without pulling it."""
+    bearer = await _ghcr_bearer_token(user, token, repo)
+    if bearer is None:
+        return None
+    owner = repo.split("/")[0]
+    name = "/".join(repo.split("/")[1:]) or repo
+    url = f"https://ghcr.io/v2/{owner}/{name}/manifests/{tag}"
+    headers = {
+        "Authorization": f"Bearer {bearer}",
+        "Accept": (
+            "application/vnd.oci.image.index.v1+json,"
+            "application/vnd.docker.distribution.manifest.list.v2+json,"
+            "application/vnd.docker.distribution.manifest.v2+json"
+        ),
+    }
+    try:
+        async with httpx.AsyncClient(timeout=15.0) as client:
+            r = await client.head(url, headers=headers, follow_redirects=True)
+        return r.headers.get("docker-content-digest")
+    except Exception:
+        return None
+
+
+async def _do_check_update() -> None:
+    global _update_available, _update_status, _update_error, _update_last_checked, _startup_image_digest
+    _update_status = "checking"
+    try:
+        if not _OTA_GHCR_TOKEN or not _OTA_IMAGE_TAG:
+            _update_status = "idle"
+            _update_error = "Registry credentials or IMAGE_TAG not configured"
+            return
+        latest = await _ghcr_manifest_digest(
+            _OTA_GHCR_REPO, _OTA_IMAGE_TAG, _OTA_GHCR_USER, _OTA_GHCR_TOKEN
+        )
+        _update_last_checked = datetime.utcnow().isoformat() + "Z"
+        if latest is None:
+            _update_status = "idle"
+            _update_error = "Registry unreachable or credentials invalid"
+            return
+        if _startup_image_digest is None:
+            _startup_image_digest = latest
+            _update_status = "idle"
+            _update_error = None
+            return
+        if latest != _startup_image_digest:
+            _update_available = True
+            _update_status = "available"
+        else:
+            _update_available = False
+            _update_status = "idle"
+        _update_error = None
+    except Exception as e:
+        _update_status = "error"
+        _update_error = str(e)
+
+
+@app.get("/update/status")
+async def get_update_status():
+    return {
+        "available": _update_available,
+        "dismissed": _update_dismissed,
+        "status": _update_status,
+        "error": _update_error,
+        "last_checked": _update_last_checked,
+    }
+
+
+@app.post("/update/check")
+async def trigger_update_check():
+    if not _OTA_GHCR_TOKEN or not _OTA_IMAGE_TAG:
+        return {"ok": False, "error": "Registry credentials or IMAGE_TAG not configured"}
+    asyncio.create_task(_do_check_update())
+    return {"ok": True, "message": "checking"}
+
+
+@app.post("/update/apply")
+async def apply_update():
+    global _update_status, _update_error
+    _update_status = "updating"
+    headers = {"Authorization": f"Bearer {WATCHTOWER_TOKEN}"} if WATCHTOWER_TOKEN else {}
+    try:
+        async with httpx.AsyncClient(timeout=60.0) as client:
+            r = await client.post(f"{WATCHTOWER_URL}/v1/update", headers=headers)
+        if r.status_code == 200:
+            _update_status = "updating"
+            return {"ok": True, "message": "Update triggered — containers will restart shortly."}
+        _update_status = "error"
+        _update_error = f"Watchtower returned HTTP {r.status_code}"
+        return {"ok": False, "error": _update_error}
+    except Exception as e:
+        _update_status = "error"
+        _update_error = str(e)
+        return {"ok": False, "error": str(e)}
+
+
+@app.post("/update/dismiss")
+async def dismiss_update():
+    global _update_dismissed
+    _update_dismissed = True
+    return {"ok": True}
+
+
+@app.post("/update/reset")
+async def reset_update_state():
+    """Test/dev helper — resets all update state."""
+    global _update_available, _update_dismissed, _update_status, _update_error
+    global _update_last_checked, _startup_image_digest
+    _update_available = False
+    _update_dismissed = False
+    _update_status = "idle"
+    _update_error = None
+    _update_last_checked = None
+    _startup_image_digest = None
+    return {"ok": True}
+
+
+async def _background_update_poller() -> None:
+    """Poll GHCR every UPDATE_CHECK_INTERVAL seconds. Never pulls the image."""
+    while True:
+        if _OTA_GHCR_TOKEN and _OTA_IMAGE_TAG:
+            await _do_check_update()
+        await asyncio.sleep(_OTA_POLL_INTERVAL)
+
+
+@app.on_event("startup")
+async def start_background_update_poller() -> None:
+    asyncio.create_task(_background_update_poller())

--- a/aquila_web/static/help.html
+++ b/aquila_web/static/help.html
@@ -164,6 +164,7 @@
           <button class="help-tab" data-target="tab-profiles">Profiles</button>
           <button class="help-tab" data-target="tab-detail">Run Detail</button>
           <button class="help-tab" data-target="tab-wifi">Wi-Fi &amp; System</button>
+          <button class="help-tab" data-target="tab-updates" id="tab-updates-btn" style="position:relative;">Updates<span id="updates-tab-dot" style="display:none;position:absolute;top:4px;right:6px;width:7px;height:7px;border-radius:50%;background:#dc2626;"></span></button>
         </div>
 
         <div class="help-scroll">
@@ -257,6 +258,15 @@
 
             </div>
 
+            <!-- Updates -->
+            <div class="help-section" id="tab-updates">
+              <h2>Software Updates</h2>
+              <p>Updates are applied only when you choose to. Nothing is downloaded or restarted automatically.</p>
+              <div id="update-status-area" style="margin-top:16px;">
+                <p style="color:#6b7280;font-size:15px;">Open this tab to check for updates.</p>
+              </div>
+            </div>
+
           </div><!-- /.help-card -->
         </div><!-- /.help-scroll -->
 
@@ -280,8 +290,119 @@
         tab.classList.add("is-active");
         document.getElementById(tab.dataset.target).classList.add("is-active");
         if (tab.dataset.target === "tab-wifi") loadWifiStatus();
+        if (tab.dataset.target === "tab-updates") openUpdateTab();
       });
     });
+
+    // ── OTA Updates ──────────────────────────────────────────────
+    let _updateCheckPollTimer = null;
+
+    async function openUpdateTab() {
+      const area = document.getElementById("update-status-area");
+      const r = await fetch("/update/status").catch(() => null);
+      const data = r ? await r.json().catch(() => null) : null;
+      if (data && (data.available || data.status === "available")) {
+        renderUpdateStatus(data);
+        return;
+      }
+      if (data && data.status === "updating") {
+        renderUpdateStatus(data);
+        return;
+      }
+      area.innerHTML = '<p style="color:#6b7280;font-size:15px;">Checking for updates…</p>';
+      const cr = await fetch("/update/check", { method: "POST" }).catch(() => null);
+      if (!cr || !cr.ok) {
+        const cd = cr ? await cr.json().catch(() => ({})) : {};
+        renderUpdateStatus({ status: "error", error: cd.error || "Check request failed" });
+        return;
+      }
+      _pollUpdateStatus(0);
+    }
+
+    function _pollUpdateStatus(attempt) {
+      if (_updateCheckPollTimer) clearTimeout(_updateCheckPollTimer);
+      if (attempt > 20) {
+        renderUpdateStatus({ status: "error", error: "Check timed out" });
+        return;
+      }
+      _updateCheckPollTimer = setTimeout(async () => {
+        const r = await fetch("/update/status").catch(() => null);
+        const data = r ? await r.json().catch(() => null) : null;
+        if (!data || data.status === "checking") {
+          _pollUpdateStatus(attempt + 1);
+        } else {
+          renderUpdateStatus(data);
+        }
+      }, 1500);
+    }
+
+    function renderUpdateStatus(data) {
+      const area = document.getElementById("update-status-area");
+      const dot = document.getElementById("updates-tab-dot");
+      if (data.available || data.status === "available") {
+        if (dot) dot.style.display = "block";
+        area.innerHTML = `
+          <p style="font-size:15px;color:#1a1c1c;line-height:1.6;margin:0 0 18px;">
+            A software update is available. Do you want to update now?
+          </p>
+          <div style="display:flex;gap:10px;flex-wrap:wrap;">
+            <button id="update-now-btn"
+              style="padding:10px 22px;border-radius:8px;border:none;background:var(--icon-dark-green);color:var(--icon-acorn-green);font-size:15px;font-weight:600;cursor:pointer;"
+              onclick="applyUpdate()">Update Now</button>
+            <button
+              style="padding:10px 22px;border-radius:8px;border:1.5px solid #cbd5e1;background:transparent;font-size:15px;color:#475569;cursor:pointer;"
+              onclick="dismissUpdate()">Later</button>
+          </div>
+        `;
+      } else if (data.status === "updating") {
+        area.innerHTML = '<p style="font-size:15px;color:#1a1c1c;">Downloading update… the device will restart automatically when complete.</p>';
+      } else if (data.status === "error") {
+        area.innerHTML = `
+          <p style="color:#dc2626;font-size:15px;">Could not check for updates: ${_escHtml(data.error || "unknown error")}</p>
+          <button onclick="openUpdateTab()"
+            style="margin-top:12px;padding:8px 18px;border-radius:8px;border:1px solid #cbd5e1;background:#fff;font-size:14px;cursor:pointer;color:#374151;">Try again</button>
+        `;
+      } else {
+        if (dot) dot.style.display = "none";
+        let html = '<p style="color:#16a34a;font-size:15px;font-weight:600;">✓ Software is up to date.</p>';
+        if (data.last_checked) html += `<p style="font-size:12px;color:#6b7280;margin-top:6px;">Last checked: ${_escHtml(data.last_checked.replace("T"," ").replace("Z"," UTC"))}</p>`;
+        area.innerHTML = html;
+      }
+    }
+
+    async function applyUpdate() {
+      const btn = document.getElementById("update-now-btn");
+      if (btn) { btn.disabled = true; btn.textContent = "Starting…"; }
+      const area = document.getElementById("update-status-area");
+      const r = await fetch("/update/apply", { method: "POST" }).catch(() => null);
+      const d = r ? await r.json().catch(() => ({})) : {};
+      if (d.ok) {
+        area.innerHTML = '<p style="font-size:15px;color:#1a1c1c;">Downloading update… the device will restart automatically when complete.</p>';
+        document.querySelectorAll(".help-badge").forEach(b => b.remove());
+      } else {
+        area.innerHTML = `<p style="color:#dc2626;font-size:15px;">Update failed: ${_escHtml(d.error || "unknown error")}</p>`;
+      }
+    }
+
+    async function dismissUpdate() {
+      await fetch("/update/dismiss", { method: "POST" }).catch(() => {});
+      document.getElementById("update-status-area").innerHTML =
+        '<p style="color:#6b7280;font-size:15px;">Update reminder dismissed. You can check again by reopening this tab.</p>';
+      const dot = document.getElementById("updates-tab-dot");
+      if (dot) dot.style.display = "none";
+      document.querySelectorAll(".help-badge").forEach(b => b.remove());
+    }
+
+    function _escHtml(str) {
+      return String(str).replace(/&/g,"&amp;").replace(/</g,"&lt;").replace(/>/g,"&gt;");
+    }
+
+    // Show tab dot if update is already known available on page load
+    fetch("/update/status").then(r => r.ok ? r.json() : null).then(data => {
+      if (!data || !data.available || data.dismissed) return;
+      const dot = document.getElementById("updates-tab-dot");
+      if (dot) dot.style.display = "block";
+    }).catch(() => {});
 
     // ── WiFi ──────────────────────────────────────────────
     let wifiSelectedForm = null;

--- a/aquila_web/static/nav.js
+++ b/aquila_web/static/nav.js
@@ -13,3 +13,23 @@ document.addEventListener("click", (event) => {
 
   link.blur();
 });
+
+// Show a red "1" badge on the ? help icon when an OTA update is available
+(function checkUpdateBadge() {
+  const links = document.querySelectorAll("a.help-link");
+  if (!links.length) return;
+  fetch("/update/status")
+    .then(r => r.ok ? r.json() : null)
+    .then(data => {
+      if (!data || !data.available || data.dismissed) return;
+      links.forEach(link => {
+        if (!link.querySelector(".help-badge")) {
+          const badge = document.createElement("span");
+          badge.className = "help-badge";
+          badge.textContent = "1";
+          link.appendChild(badge);
+        }
+      });
+    })
+    .catch(() => {});
+})();

--- a/aquila_web/static/styles.css
+++ b/aquila_web/static/styles.css
@@ -287,6 +287,25 @@ a:active {
   transform: translateY(0);
 }
 
+.help-badge {
+  position: absolute;
+  top: -4px;
+  right: -4px;
+  width: 16px;
+  height: 16px;
+  border-radius: 50%;
+  background: #dc2626;
+  color: #fff;
+  font-size: 10px;
+  font-weight: 700;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  line-height: 1;
+  pointer-events: none;
+  border: 1.5px solid #f8fafc;
+}
+
 .help-content {
   max-width: 680px;
   font-family: "Segoe UI", "Helvetica Neue", Arial, sans-serif;

--- a/fleet-config/docker-compose.yml
+++ b/fleet-config/docker-compose.yml
@@ -11,6 +11,7 @@ services:
       RESULTS_PATH: "/opt/aquila/results/results.json"
       CONFIG_DIR: "/opt/aquila/config"
       KIOSK_CONTROL_URL: "http://host.docker.internal:9191"
+      WATCHTOWER_URL: "http://aquila-watchtower:8080"
     volumes:
       - /opt/aquila/results:/opt/aquila/results
       - /opt/aquila/logs:/opt/aquila/logs
@@ -118,7 +119,7 @@ services:
       WATCHTOWER_HTTP_API_UPDATE: "true"
       WATCHTOWER_CLEANUP: "true"
       WATCHTOWER_CONFIG_FILE: "/config.json"
-    command: --label-enable --http-api-update --http-api-periodic-polls --cleanup --api-version 1.54 --interval 300
+    command: --label-enable --http-api-update --cleanup --api-version 1.54 --interval 300
     restart: unless-stopped
     logging:
       driver: json-file

--- a/tests/contract/test_update_endpoints.py
+++ b/tests/contract/test_update_endpoints.py
@@ -1,0 +1,179 @@
+"""
+Contract tests for OTA update endpoints.
+
+Run with:
+    pytest tests/contract/test_update_endpoints.py -m contract -v
+"""
+import pytest
+from unittest.mock import patch, AsyncMock
+
+
+def reset_update(client):
+    client.post("/update/reset")
+
+
+# ---------------------------------------------------------------------------
+# GET /update/status
+# ---------------------------------------------------------------------------
+
+@pytest.mark.contract
+def test_update_status_default_structure(client):
+    """GET /update/status returns expected fields with safe defaults."""
+    reset_update(client)
+    response = client.get("/update/status")
+    assert response.status_code == 200
+    data = response.json()
+    assert "available" in data
+    assert "dismissed" in data
+    assert "status" in data
+    assert data["available"] is False
+    assert data["dismissed"] is False
+
+
+@pytest.mark.contract
+def test_update_status_reflects_dismiss(client):
+    """POST /update/dismiss marks update as dismissed."""
+    reset_update(client)
+    client.post("/update/dismiss")
+    response = client.get("/update/status")
+    assert response.status_code == 200
+    assert response.json()["dismissed"] is True
+
+
+# ---------------------------------------------------------------------------
+# POST /update/check
+# ---------------------------------------------------------------------------
+
+@pytest.mark.contract
+def test_update_check_returns_error_when_no_credentials(client):
+    """POST /update/check returns ok=False when GHCR credentials are not configured."""
+    reset_update(client)
+    import aquila_web.main as web_main
+    with patch.object(web_main, "_OTA_GHCR_TOKEN", ""), \
+         patch.object(web_main, "_OTA_IMAGE_TAG", "prod"):
+        response = client.post("/update/check")
+    assert response.status_code == 200
+    data = response.json()
+    assert data["ok"] is False
+    assert "error" in data
+
+
+@pytest.mark.contract
+def test_update_check_returns_error_when_no_image_tag(client):
+    """POST /update/check returns ok=False when IMAGE_TAG is not set."""
+    reset_update(client)
+    import aquila_web.main as web_main
+    with patch.object(web_main, "_OTA_GHCR_TOKEN", "sometoken"), \
+         patch.object(web_main, "_OTA_IMAGE_TAG", ""):
+        response = client.post("/update/check")
+    assert response.status_code == 200
+    assert response.json()["ok"] is False
+
+
+@pytest.mark.contract
+def test_update_check_spawns_background_task_when_credentialed(client):
+    """POST /update/check returns ok=True and starts background check when credentials exist."""
+    reset_update(client)
+    import aquila_web.main as web_main
+    with patch.object(web_main, "_OTA_GHCR_TOKEN", "tok"), \
+         patch.object(web_main, "_OTA_IMAGE_TAG", "prod"), \
+         patch("asyncio.create_task") as mock_create:
+        response = client.post("/update/check")
+    assert response.status_code == 200
+    assert response.json()["ok"] is True
+    mock_create.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# POST /update/apply
+# ---------------------------------------------------------------------------
+
+@pytest.mark.contract
+def test_update_apply_calls_watchtower_api(client):
+    """POST /update/apply calls Watchtower HTTP API and returns ok=True on success."""
+    reset_update(client)
+    mock_response = AsyncMock()
+    mock_response.status_code = 200
+    with patch("aquila_web.main.httpx.AsyncClient") as mock_client_cls:
+        mock_client_cls.return_value.__aenter__.return_value.post = AsyncMock(return_value=mock_response)
+        response = client.post("/update/apply")
+    assert response.status_code == 200
+    assert response.json()["ok"] is True
+
+
+@pytest.mark.contract
+def test_update_apply_returns_error_on_watchtower_failure(client):
+    """POST /update/apply returns ok=False when Watchtower returns non-200."""
+    reset_update(client)
+    mock_response = AsyncMock()
+    mock_response.status_code = 500
+    with patch("aquila_web.main.httpx.AsyncClient") as mock_client_cls:
+        mock_client_cls.return_value.__aenter__.return_value.post = AsyncMock(return_value=mock_response)
+        response = client.post("/update/apply")
+    assert response.status_code == 200
+    data = response.json()
+    assert data["ok"] is False
+    assert "error" in data
+
+
+@pytest.mark.contract
+def test_update_apply_returns_error_on_network_failure(client):
+    """POST /update/apply returns ok=False when Watchtower is unreachable."""
+    reset_update(client)
+    with patch("aquila_web.main.httpx.AsyncClient") as mock_client_cls:
+        mock_client_cls.return_value.__aenter__.return_value.post = AsyncMock(
+            side_effect=Exception("connection refused")
+        )
+        response = client.post("/update/apply")
+    assert response.status_code == 200
+    data = response.json()
+    assert data["ok"] is False
+    assert "error" in data
+
+
+@pytest.mark.contract
+def test_update_apply_does_not_restart_without_user_action(client):
+    """Containers must not restart unless /update/apply is explicitly called."""
+    reset_update(client)
+    status = client.get("/update/status").json()
+    # Status must remain idle / not-updating without an explicit apply call
+    assert status["status"] in ("idle", "checking", "available", "error")
+    assert status["status"] != "updating"
+
+
+# ---------------------------------------------------------------------------
+# POST /update/dismiss
+# ---------------------------------------------------------------------------
+
+@pytest.mark.contract
+def test_update_dismiss_sets_dismissed_flag(client):
+    """POST /update/dismiss sets dismissed=True."""
+    reset_update(client)
+    resp = client.post("/update/dismiss")
+    assert resp.status_code == 200
+    assert resp.json()["ok"] is True
+    assert client.get("/update/status").json()["dismissed"] is True
+
+
+@pytest.mark.contract
+def test_update_dismiss_idempotent(client):
+    """POST /update/dismiss called twice still returns ok=True."""
+    reset_update(client)
+    client.post("/update/dismiss")
+    resp = client.post("/update/dismiss")
+    assert resp.json()["ok"] is True
+
+
+# ---------------------------------------------------------------------------
+# POST /update/reset (test helper)
+# ---------------------------------------------------------------------------
+
+@pytest.mark.contract
+def test_update_reset_clears_state(client):
+    """POST /update/reset clears all update state back to defaults."""
+    client.post("/update/dismiss")
+    client.post("/update/reset")
+    data = client.get("/update/status").json()
+    assert data["available"] is False
+    assert data["dismissed"] is False
+    assert data["status"] == "idle"


### PR DESCRIPTION
Summary
	•	Adds an Updates tab to help.html
	•	Adds a notification badge (1) on the ? help icon when an update is available
	•	Prevents Watchtower from automatically pulling/applying updates
	•	Introduces a manual approval flow:
	•	“Update now” → triggers update
	•	“Later/Dismiss” → keeps current version running
	•	Adds backend support for:
	•	checking update availability
	•	manually triggering updates
	•	reporting update state/progress

Expected Behavior
	•	Devices should only detect updates automatically
	•	No container pulls/restarts should happen without explicit user approval
	•	UI should clearly indicate when an update is available
	•	Existing kiosk functionality should remain unaffected

Notes

Please pay close attention to:
	•	Watchtower configuration changes
	•	Any unintended automatic container restarts
	•	UI behavior in kiosk/fullscreen mode
	•	Failure/recovery behavior if update attempts fail
	•	Whether the notification state persists correctly after dismissal/update