### PR TITLE
added profile bundling option

### DIFF
--- a/aquila_web/main.py
+++ b/aquila_web/main.py
@@ -904,12 +904,40 @@ async def run_status_reset():
     logger.info("Run button reset, profile reset")
     return{"ok":True}
 
+def resolve_device_profiles() -> "set[str] | None":
+    import socket
+    hostname = os.getenv("DEVICE_HOSTNAME") or socket.gethostname()
+    device_profiles_path = BASE_DIR / "config_files" / "device_profiles.json"
+    profile_groups_path = BASE_DIR / "config_files" / "profile_groups.json"
+    try:
+        device_profiles = json.loads(device_profiles_path.read_text())
+    except Exception:
+        logger.warning("Could not load device_profiles.json; showing all profiles")
+        return None
+    device_entry = device_profiles.get(hostname)
+    if device_entry is None:
+        return None
+    try:
+        profile_groups = json.loads(profile_groups_path.read_text())
+    except Exception:
+        logger.warning("Could not load profile_groups.json; showing all profiles")
+        return None
+    group_name = device_entry.get("profile_group")
+    group_value = profile_groups.get(group_name)
+    if group_value is None:
+        return None
+    allowed = list(group_value)
+    allowed.extend(device_entry.get("extra_profiles", []))
+    return set(allowed)
+
+
 @app.get("/profiles")
 async def list_profiles():
     profiles = []
     profile_dir = resolve_profile_dir()
     if not profile_dir.exists():
         return profiles
+    allowed = resolve_device_profiles()
     for path in profile_dir.rglob("*.json"):
         try:
             with path.open() as f:
@@ -918,6 +946,9 @@ async def list_profiles():
                 continue
         except Exception as e:
             logger.info("Error processing %s"%(path))
+
+        if allowed is not None and "bundled" in path.parts and path.name not in allowed:
+            continue
 
         if "configuration" in data and "name" in data:
             created_at = data.get("createdAt") or int(path.stat().st_ctime * 1000)

--- a/aquila_web/static/help.html
+++ b/aquila_web/static/help.html
@@ -272,7 +272,7 @@
 
         <!-- Footer -->
         <div class="help-footer" style="padding-bottom:16px;">
-          <span class="help-footer__meta" id="help-version-info">V 1.2.5</span>
+          <span class="help-footer__meta" id="help-version-info">V 1.2.5.1</span>
           <button class="help-exit-btn" onclick="notifyExitForce()">Exit GUI</button>
         </div>
 

--- a/config_files/device_profiles.json
+++ b/config_files/device_profiles.json
@@ -1,0 +1,23 @@
+{
+    "sn01": {
+        "profile_group": "all"
+    },
+    "sn02": {
+        "profile_group": "duke"
+    },
+    "sn03": {
+        "profile_group": "classic"
+    },
+    "sn04": {
+        "profile_group": "classic"
+    },
+    "sn05": {
+        "profile_group": "duke"
+    },
+    "sn06": {
+        "profile_group": "classic"
+    },
+    "sn07": {
+        "profile_group": "classic"
+    }
+}

--- a/config_files/profile_config.json
+++ b/config_files/profile_config.json
@@ -1,8 +1,0 @@
-{
-  "profile_bundle": [
-    "ABBA_ramp1.75_EA30.json",
-    "Hygiena_ramp1.75_EA30.json",
-    "verification_profile.json",
-    "ryan_thermal_tests.json"
-  ]
-}

--- a/config_files/profile_groups.json
+++ b/config_files/profile_groups.json
@@ -1,0 +1,16 @@
+{
+    "all": null,
+    "classic": [
+        "ABBA_ramp1.75_EA30.json",
+        "Hygiena_ramp1.75_EA30.json",
+        "ryan_thermal_tests.json",
+        "verification_profile.json"
+    ],
+    "duke": [
+        "ABBA_ramp1.75_EA30.json",
+        "O157__ESBL_full.json",
+        "ryan_thermal_tests.json",
+        "STEC_and_EPEC_Hygiena1.75_no37Cstep.json",
+        "verification_profile.json"
+    ]
+}

--- a/profiles/bundled/O157__ESBL_full.json
+++ b/profiles/bundled/O157__ESBL_full.json
@@ -1,0 +1,90 @@
+{
+"output_dir": "pcr_data",
+"post_in_gui": "True",
+"title": "O157 and ESBL",
+"steps": [
+    {
+        "disable": 0,
+        "duration": 1,
+        "description": "Record equilabrion without power."
+    },
+    {
+        "ramp_rate": 1.8
+    },
+    {  
+        "pcr_fanon" : 1
+    },
+    {
+        "enable": 0, 
+        "duration": 1,
+        "description": "Turn on and record temperature for a little bit"
+    },
+    {
+	"optics":""
+    },
+    {
+        "setpoint": 25,
+        "duration": 1,
+        "description": "Presetting temperature"
+    },
+    {
+        "setpoint": 95,
+        "duration": 300,
+        "description": "Activation temperature for 5 minute"
+    },
+    {
+        "ramp_rate": 1.8
+    },
+    {
+        "repeat": [
+            {
+                "setpoint": 96.5,
+                "duration": 20,
+                "description": "Melt"
+            },
+	    {
+                "setpoint": 60.5,
+                "duration": 41,
+                "description": "Annealing"
+            },
+
+	    {
+                "setpoint": 72,
+                "duration": 54,
+                "description": "Extension pre-signal"
+            },
+	    {
+		"optics":""
+	    },
+	    {
+                "setpoint": 72,
+                "duration": 18,
+                "description": "Extension post-Signal"
+            }
+        ],
+        "cycles": 45
+    },
+    {
+        "ramp_rate": 1.8
+    },
+    {
+        "setpoint": 40,
+        "duration": 20,
+        "description": "Initial cooling"
+    },
+    {
+        "setpoint": 25,
+        "duration": 10,
+        "description": "Restoring setpoint to RT"
+    },
+    {
+        "disable": 0,
+        "duration": 5,
+        "description": "Turn off and record temperature for a little bit"
+    },
+
+    { 
+        "pcr_fanoff" : 0
+    }
+]
+}

--- a/profiles/bundled/STEC_and_EPEC_Hygiena1.75_no37Cstep.json
+++ b/profiles/bundled/STEC_and_EPEC_Hygiena1.75_no37Cstep.json
@@ -1,0 +1,84 @@
+{
+"output_dir": "pcr_data",
+"post_in_gui": "True",
+"title": "STEC and EPEC",
+"steps": [
+    {
+        "disable": 0,
+        "duration": 1,
+        "description": "Record equilabrion without power."
+    },
+    {
+        "ramp_rate": 1.6
+    },
+    {  
+        "pcr_fanon" : 1
+    },
+    {
+        "enable": 0, 
+        "duration": 1,
+        "description": "Turn on and record temperature for a little bit"
+    },
+    {
+	"optics":""
+    },
+    {
+        "setpoint": 25,
+        "duration": 1,
+        "description": "Presetting temperature"
+    },
+    {
+        "setpoint": 95,
+        "duration": 120,
+        "description": "Activation temperature for 2 minute"
+    },
+    {
+        "ramp_rate": 1.75
+    },
+    {
+        "repeat": [
+            {
+                "setpoint": 96.5,
+                "duration": 11,
+                "description": "Melt"
+            },
+	    {
+                "setpoint": 60.5,
+                "duration": 20,
+                "description": "Annealing"
+            },
+	    {
+		"optics":""
+	    },
+	    {
+                "setpoint": 60.5,
+                "duration": 18,
+                "description": "Annealing"
+            }
+        ],
+        "cycles": 40
+    },
+    {
+        "ramp_rate": 1.6
+    },
+    {
+        "setpoint": 40,
+        "duration": 20,
+        "description": "Initial cooling"
+    },
+    {
+        "setpoint": 25,
+        "duration": 10,
+        "description": "Restoring setpoint to RT"
+    },
+    {
+        "disable": 0,
+        "duration": 5,
+        "description": "Turn off and record temperature for a little bit"
+    },
+
+    { 
+        "pcr_fanoff" : 0
+    }
+]
+}

--- a/scripts/profile_map.py
+++ b/scripts/profile_map.py
@@ -1,0 +1,96 @@
+"""
+profile_map.py — read-only CLI showing which profiles each device sees.
+
+Usage:
+    python scripts/profile_map.py
+    python scripts/profile_map.py --device sn02
+    python scripts/profile_map.py --profile ABBA_ramp1.75_EA30.json
+    python scripts/profile_map.py --group classic
+"""
+import argparse
+import json
+from pathlib import Path
+
+CONFIG_DIR = Path(__file__).resolve().parents[1] / "config_files"
+DEVICE_PROFILES_PATH = CONFIG_DIR / "device_profiles.json"
+PROFILE_GROUPS_PATH = CONFIG_DIR / "profile_groups.json"
+
+SEP = "─" * 64
+
+
+def load_configs():
+    device_profiles = json.loads(DEVICE_PROFILES_PATH.read_text())
+    profile_groups = json.loads(PROFILE_GROUPS_PATH.read_text())
+    return device_profiles, profile_groups
+
+
+def resolve_profiles_for_device(device_entry: dict, profile_groups: dict) -> list[str] | None:
+    group_name = device_entry.get("profile_group")
+    group_value = profile_groups.get(group_name)
+    if group_value is None:
+        return None
+    result = list(group_value)
+    result.extend(device_entry.get("extra_profiles", []))
+    return result
+
+
+def print_device_row(device: str, device_entry: dict, profile_groups: dict):
+    group_name = device_entry.get("profile_group", "?")
+    profiles = resolve_profiles_for_device(device_entry, profile_groups)
+    extras = device_entry.get("extra_profiles", [])
+
+    if profiles is None:
+        print(f"{device:<10}{group_name:<20}(all profiles)")
+        return
+
+    group_profiles = [p for p in profiles if p not in extras]
+    first = True
+    for p in group_profiles:
+        if first:
+            print(f"{device:<10}{group_name:<20}{p}")
+            first = False
+        else:
+            print(f"{'':10}{'':20}{p}")
+    if extras:
+        first_extra = True
+        for p in extras:
+            if first_extra:
+                print(f"{'':10}{'+ extra':<20}{p}")
+                first_extra = False
+            else:
+                print(f"{'':10}{'':20}{p}")
+    if not profiles:
+        print(f"{device:<10}{group_name:<20}(none)")
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Show per-device profile assignments")
+    parser.add_argument("--device", help="Show only one device")
+    parser.add_argument("--profile", help="Show all devices that have a given profile")
+    parser.add_argument("--group", help="Show all devices assigned to a group")
+    args = parser.parse_args()
+
+    device_profiles, profile_groups = load_configs()
+
+    print()
+    print(f"{'Device':<10}{'Group':<20}{'Profiles'}")
+    print(SEP)
+
+    for device, entry in sorted(device_profiles.items()):
+        if args.device and device != args.device:
+            continue
+        if args.group and entry.get("profile_group") != args.group:
+            continue
+        if args.profile:
+            profiles = resolve_profiles_for_device(entry, profile_groups)
+            if profiles is not None and args.profile not in profiles:
+                continue
+            if profiles is None:
+                pass
+        print_device_row(device, entry, profile_groups)
+
+    print()
+
+
+if __name__ == "__main__":
+    main()

--- a/specs/per_device_profile_filtering.md
+++ b/specs/per_device_profile_filtering.md
@@ -1,0 +1,191 @@
+# Spec: Per-Device Profile Filtering
+
+## Problem
+
+All bundled profiles in `profiles/bundled/` are currently available to every device. There is no way to restrict which profiles appear on a given device without physically removing files from the image.
+
+## Solution
+
+Two new config files baked into the image control which profiles each device sees. The device queries its own hostname at runtime, looks itself up, and the API filters the profile list accordingly.
+
+---
+
+## New Files
+
+### `config_files/profile_groups.json`
+
+Defines named groups of profiles. Edit this file to add new groups or add a profile filename to an existing group.
+
+```json
+{
+    "full": null,
+    "verification_only": [
+        "verification_profile.json"
+    ],
+    "abba": [
+        "ABBA_ramp1.75_EA30.json",
+        "verification_profile.json"
+    ],
+    "hygiena": [
+        "Hygiena_ramp1.75_EA30.json",
+        "verification_profile.json"
+    ],
+    "abba_hygiena": [
+        "ABBA_ramp1.75_EA30.json",
+        "Hygiena_ramp1.75_EA30.json",
+        "verification_profile.json"
+    ]
+}
+```
+
+- `null` means all profiles (same as no restriction)
+- Profile filenames must match the actual `.json` filenames in `profiles/bundled/`
+
+---
+
+### `config_files/device_profiles.json`
+
+Maps each device hostname to a group. This is the **primary file to edit day-to-day**.
+
+```json
+{
+    "sn02": {
+        "profile_group": "verification_only"
+    },
+    "sn07": {
+        "profile_group": "abba_hygiena"
+    },
+    "sn12": {
+        "profile_group": "abba",
+        "extra_profiles": ["ryan_thermal_tests.json"]
+    },
+    "sn99": {
+        "profile_group": "full"
+    }
+}
+```
+
+**Fields:**
+
+| Field | Required | Description |
+|---|---|---|
+| `profile_group` | Yes | Must match a key in `profile_groups.json` |
+| `extra_profiles` | No | Additional profile filenames added on top of the group |
+
+**Fallback:** If a device hostname is not present in this file, it gets all profiles. No error is raised.
+
+---
+
+## Modified File
+
+### `aquila_web/main.py`
+
+#### New function: `resolve_device_profiles() -> set[str] | None`
+
+Reads the two config files and returns the set of allowed profile filenames for the running device.
+
+Resolution logic:
+1. Read hostname from `DEVICE_HOSTNAME` env var, fall back to `socket.gethostname()`
+2. Load `config_files/device_profiles.json`
+3. If hostname not found → return `None` (no restriction)
+4. Load `config_files/profile_groups.json`, look up the device's `profile_group`
+5. If group value is `null` → return `None` (no restriction)
+6. Start with the group's filename list
+7. Append any `extra_profiles` from the device entry
+8. Return as `set[str]`
+
+If either config file is missing or malformed, log a warning and return `None` (fail open — device sees all profiles rather than none).
+
+#### Modified function: `list_profiles()` (line 898)
+
+One filter added before appending each profile to the result list:
+
+```python
+allowed = resolve_device_profiles()
+if allowed is not None and path.name not in allowed:
+    continue
+```
+
+Nothing else in `list_profiles()` changes.
+
+---
+
+## What Does Not Change
+
+| Component | Reason |
+|---|---|
+| `host_config.json` | Hardware config only, written by `deployment2.sh` |
+| `deployment2.sh` | No changes needed |
+| Docker volumes / mounts | No changes |
+| Profile execution once selected | Filtering is list-only |
+| User-created profiles | Live in `/opt/aquila/profiles/` on device disk, always visible to that device |
+| `profile_config.json` | Superseded by `profile_groups.json`; can be removed separately |
+
+---
+
+## Deployment Flow
+
+Both new files are baked into the image via the existing `COPY . .` in `docker/Dockerfile.api`. No Dockerfile changes needed.
+
+| Goal | What to edit |
+|---|---|
+| Add a new bundled profile file | Add to `profiles/bundled/`, add filename to relevant group(s) in `profile_groups.json` |
+| Give a device a different set | Change its `profile_group` in `device_profiles.json` |
+| Add one profile to one device | Add filename to `extra_profiles` in `device_profiles.json` |
+| Create a new group | Add entry to `profile_groups.json`, assign devices to it |
+| Remove a profile from all devices | Remove filename from all groups in `profile_groups.json` |
+
+All changes → merge to `main` → CI builds image → Watchtower delivers to fleet within ~5 minutes.
+
+---
+
+## Transparency Script
+
+### `scripts/profile_map.py`
+
+A read-only CLI script that prints a clear view of which profiles are assigned to which devices. It reads live data directly from `config_files/device_profiles.json` and `config_files/profile_groups.json` at runtime — the output always reflects the actual current state of those files, not hardcoded values.
+
+**Default output (all devices):**
+
+```
+$ python scripts/profile_map.py
+
+Device    Group               Profiles
+────────────────────────────────────────────────────────────────
+sn02      verification_only   verification_profile.json
+sn07      abba_hygiena        ABBA_ramp1.75_EA30.json
+                              Hygiena_ramp1.75_EA30.json
+                              verification_profile.json
+sn12      abba                ABBA_ramp1.75_EA30.json
+          + extra             ryan_thermal_tests.json
+                              verification_profile.json
+sn99      full                (all profiles)
+```
+
+(Above is illustrative of the format — actual rows and profile names come from the live config files.)
+
+**Flags:**
+
+| Flag | Description |
+|---|---|
+| `--device sn12` | Show only one device |
+| `--profile ABBA_ramp1.75_EA30.json` | Show all devices that have a given profile |
+| `--group abba` | Show all devices assigned to a group |
+
+**Location:** `scripts/profile_map.py`
+
+**Dependencies:** stdlib only (`json`, `argparse`) — no pip installs required.
+
+---
+
+## Tests to Add
+
+| Test | Expected behaviour |
+|---|---|
+| `resolve_device_profiles()` — hostname not in `device_profiles.json` | Returns `None` |
+| `resolve_device_profiles()` — group is `null` | Returns `None` |
+| `resolve_device_profiles()` — known hostname with group | Returns correct set of filenames |
+| `resolve_device_profiles()` — `extra_profiles` present | Returned set includes group filenames plus extras |
+| `resolve_device_profiles()` — config file missing | Returns `None`, logs warning |
+| `GET /profiles` — allowlist active | Only allowed profiles returned |
+| `GET /profiles` — device not in `device_profiles.json` | All profiles returned |

--- a/tests/contract/test_profile_device_filtering.py
+++ b/tests/contract/test_profile_device_filtering.py
@@ -1,0 +1,118 @@
+"""
+Contract tests for per-device profile filtering via GET /profiles.
+
+Tests that the allowlist from resolve_device_profiles() is correctly applied
+by list_profiles(), and that devices not in device_profiles.json see all profiles.
+"""
+import json
+import os
+import sys
+from pathlib import Path
+
+import pytest
+from fastapi.testclient import TestClient
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+os.environ.setdefault("AQ_SRC_BASEDIR", str(REPO_ROOT))
+os.environ.setdefault("AQ_DEV_SIMULATE", "1")
+sys.path.insert(0, str(REPO_ROOT))
+
+
+ABBA_FILE = "ABBA_ramp1.75_EA30.json"
+HYGIENA_FILE = "Hygiena_ramp1.75_EA30.json"
+O157_FILE = "O157__ESBL_full.json"
+STEC_FILE = "STEC_and_EPEC_Hygiena1.75_no37Cstep.json"
+VERIFICATION_FILE = "verification_profile.json"
+RYAN_FILE = "ryan_thermal_tests.json"
+
+
+@pytest.fixture
+def client_with_filtering(monkeypatch, tmp_path):
+    """
+    TestClient with BASE_DIR pointed at a tmp dir containing controlled
+    config_files/ and a profiles/bundled/ directory with two test profiles.
+    """
+    cfg = tmp_path / "config_files"
+    cfg.mkdir()
+    (cfg / "profile_groups.json").write_text(json.dumps({
+        "all": None,
+        "classic": [ABBA_FILE, HYGIENA_FILE, VERIFICATION_FILE],
+        "duke": [ABBA_FILE, O157_FILE, STEC_FILE, VERIFICATION_FILE],
+    }))
+    (cfg / "device_profiles.json").write_text(json.dumps({
+        "classic-device": {"profile_group": "classic"},
+        "duke-device": {"profile_group": "duke"},
+        "all-device": {"profile_group": "all"},
+    }))
+
+    bundled = tmp_path / "profiles" / "bundled"
+    bundled.mkdir(parents=True)
+    for fname in [ABBA_FILE, HYGIENA_FILE, O157_FILE, STEC_FILE, VERIFICATION_FILE]:
+        profile = {
+            "title": fname.replace(".json", ""),
+            "post_in_gui": "True",
+            "steps": [{"setpoint": 95, "duration": 1, "description": "step"}],
+        }
+        (bundled / fname).write_text(json.dumps(profile))
+
+    from aquila_web import main as web_main
+    monkeypatch.setattr(web_main, "BASE_DIR", tmp_path)
+
+    with TestClient(web_main.app) as c:
+        yield c, web_main
+
+
+def _profile_names(resp) -> set:
+    return {p["id"].split("/")[-1] for p in resp.json()}
+
+
+def test_classic_device_sees_only_classic_profiles(monkeypatch, client_with_filtering):
+    client, web_main = client_with_filtering
+    monkeypatch.setenv("DEVICE_HOSTNAME", "classic-device")
+    resp = client.get("/profiles")
+    assert resp.status_code == 200
+    names = _profile_names(resp)
+    assert ABBA_FILE in names
+    assert HYGIENA_FILE in names
+    assert VERIFICATION_FILE in names
+    assert O157_FILE not in names
+    assert STEC_FILE not in names
+
+
+def test_duke_device_sees_only_duke_profiles(monkeypatch, client_with_filtering):
+    client, web_main = client_with_filtering
+    monkeypatch.setenv("DEVICE_HOSTNAME", "duke-device")
+    resp = client.get("/profiles")
+    assert resp.status_code == 200
+    names = _profile_names(resp)
+    assert ABBA_FILE in names
+    assert O157_FILE in names
+    assert STEC_FILE in names
+    assert VERIFICATION_FILE in names
+    assert HYGIENA_FILE not in names
+
+
+def test_unknown_device_sees_all_profiles(monkeypatch, client_with_filtering):
+    client, web_main = client_with_filtering
+    monkeypatch.setenv("DEVICE_HOSTNAME", "unknown-device")
+    resp = client.get("/profiles")
+    assert resp.status_code == 200
+    names = _profile_names(resp)
+    assert ABBA_FILE in names
+    assert HYGIENA_FILE in names
+    assert O157_FILE in names
+    assert STEC_FILE in names
+    assert VERIFICATION_FILE in names
+
+
+def test_all_group_device_sees_all_profiles(monkeypatch, client_with_filtering):
+    client, web_main = client_with_filtering
+    monkeypatch.setenv("DEVICE_HOSTNAME", "all-device")
+    resp = client.get("/profiles")
+    assert resp.status_code == 200
+    names = _profile_names(resp)
+    assert ABBA_FILE in names
+    assert HYGIENA_FILE in names
+    assert O157_FILE in names
+    assert STEC_FILE in names
+    assert VERIFICATION_FILE in names

--- a/unit_tests/test_device_profile_filtering.py
+++ b/unit_tests/test_device_profile_filtering.py
@@ -1,0 +1,136 @@
+"""
+Unit tests for resolve_device_profiles() in aquila_web/main.py.
+"""
+import json
+import os
+import sys
+from pathlib import Path
+
+import pytest
+
+# Stub heavy dependencies before importing main
+import types
+
+for mod in ("RPi", "RPi.GPIO"):
+    if mod not in sys.modules:
+        sys.modules[mod] = types.ModuleType(mod)
+
+if "serial" not in sys.modules:
+    _s = types.ModuleType("serial")
+    _st = types.ModuleType("serial.tools")
+    _lp = types.ModuleType("serial.tools.list_ports")
+    _lp.comports = lambda: []
+    _s.tools = _st
+    _st.list_ports = _lp
+    sys.modules.update({"serial": _s, "serial.tools": _st, "serial.tools.list_ports": _lp})
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(REPO_ROOT))
+sys.path.insert(0, str(REPO_ROOT / "aquila_web"))
+
+os.environ.setdefault("AQ_DEV_SIMULATE", "1")
+os.environ.setdefault("AQ_SRC_BASEDIR", str(REPO_ROOT))
+
+
+def _make_configs(tmp_path, device_profiles: dict, profile_groups: dict) -> Path:
+    cfg = tmp_path / "config_files"
+    cfg.mkdir()
+    (cfg / "device_profiles.json").write_text(json.dumps(device_profiles))
+    (cfg / "profile_groups.json").write_text(json.dumps(profile_groups))
+    return tmp_path
+
+
+@pytest.fixture(autouse=True)
+def patch_base_dir(monkeypatch, tmp_path):
+    _make_configs(
+        tmp_path,
+        {
+            "sn01": {"profile_group": "all"},
+            "sn02": {"profile_group": "duke"},
+            "sn03": {"profile_group": "classic"},
+        },
+        {
+            "all": None,
+            "classic": ["ABBA_ramp1.75_EA30.json", "Hygiena_ramp1.75_EA30.json", "verification_profile.json"],
+            "duke": ["ABBA_ramp1.75_EA30.json", "O157__ESBL_full.json", "STEC_and_EPEC_Hygiena1.75_no37Cstep.json", "verification_profile.json"],
+        },
+    )
+    import aquila_web.main as web_main
+    monkeypatch.setattr(web_main, "BASE_DIR", tmp_path)
+    return tmp_path
+
+
+def _call(monkeypatch, hostname):
+    monkeypatch.setenv("DEVICE_HOSTNAME", hostname)
+    from aquila_web import main as web_main
+    import importlib
+    importlib.reload(web_main)
+    monkeypatch.setattr(web_main, "BASE_DIR", monkeypatch._patches[-2].temp if hasattr(monkeypatch, "_patches") else web_main.BASE_DIR)
+    return web_main.resolve_device_profiles()
+
+
+def test_unknown_hostname_returns_none(monkeypatch, tmp_path):
+    monkeypatch.setenv("DEVICE_HOSTNAME", "sn99")
+    import aquila_web.main as web_main
+    monkeypatch.setattr(web_main, "BASE_DIR", tmp_path)
+    result = web_main.resolve_device_profiles()
+    assert result is None
+
+
+def test_group_null_returns_none(monkeypatch, tmp_path):
+    monkeypatch.setenv("DEVICE_HOSTNAME", "sn01")
+    import aquila_web.main as web_main
+    monkeypatch.setattr(web_main, "BASE_DIR", tmp_path)
+    result = web_main.resolve_device_profiles()
+    assert result is None
+
+
+def test_known_hostname_returns_correct_set(monkeypatch, tmp_path):
+    monkeypatch.setenv("DEVICE_HOSTNAME", "sn03")
+    import aquila_web.main as web_main
+    monkeypatch.setattr(web_main, "BASE_DIR", tmp_path)
+    result = web_main.resolve_device_profiles()
+    assert result == {"ABBA_ramp1.75_EA30.json", "Hygiena_ramp1.75_EA30.json", "verification_profile.json"}
+
+
+def test_extra_profiles_included(monkeypatch, tmp_path):
+    (tmp_path / "config_files" / "device_profiles.json").write_text(json.dumps({
+        "sn03": {"profile_group": "classic", "extra_profiles": ["ryan_thermal_tests.json"]}
+    }))
+    monkeypatch.setenv("DEVICE_HOSTNAME", "sn03")
+    import aquila_web.main as web_main
+    monkeypatch.setattr(web_main, "BASE_DIR", tmp_path)
+    result = web_main.resolve_device_profiles()
+    assert "ryan_thermal_tests.json" in result
+    assert "ABBA_ramp1.75_EA30.json" in result
+
+
+def test_missing_device_profiles_file_returns_none(monkeypatch, tmp_path):
+    (tmp_path / "config_files" / "device_profiles.json").unlink()
+    monkeypatch.setenv("DEVICE_HOSTNAME", "sn03")
+    import aquila_web.main as web_main
+    monkeypatch.setattr(web_main, "BASE_DIR", tmp_path)
+    result = web_main.resolve_device_profiles()
+    assert result is None
+
+
+def test_missing_profile_groups_file_returns_none(monkeypatch, tmp_path):
+    (tmp_path / "config_files" / "profile_groups.json").unlink()
+    monkeypatch.setenv("DEVICE_HOSTNAME", "sn03")
+    import aquila_web.main as web_main
+    monkeypatch.setattr(web_main, "BASE_DIR", tmp_path)
+    result = web_main.resolve_device_profiles()
+    assert result is None
+
+
+def test_duke_bundle(monkeypatch, tmp_path):
+    monkeypatch.setenv("DEVICE_HOSTNAME", "sn02")
+    import aquila_web.main as web_main
+    monkeypatch.setattr(web_main, "BASE_DIR", tmp_path)
+    result = web_main.resolve_device_profiles()
+    assert result == {
+        "ABBA_ramp1.75_EA30.json",
+        "O157__ESBL_full.json",
+        "STEC_and_EPEC_Hygiena1.75_no37Cstep.json",
+        "verification_profile.json",
+    }


### PR DESCRIPTION
                                                                                                                                                         
  Added per-device profile filtering: bundled profiles in profiles/bundled/ are now filtered at the /profiles API endpoint based on the device's hostname,   
  using two new config files (device_profiles.json, profile_groups.json) to control which profiles each device sees.                                         
                                                                                                                     
  Spec                                                                                                                                                       
                                                                                                                                                           
  specs/per_device_profile_filtering.md                                                                                                                      
                                                   
  Changes Made                                                                                                                                               
                                                                                                                                                           
  - Source code modified — aquila_web/main.py: added resolve_device_profiles() and filtering logic in /profiles endpoint                                     
  - Spec updated to match implementation — specs/per_device_profile_filtering.md written
  - New tests written — tests/contract/test_profile_device_filtering.py, unit_tests/test_device_profile_filtering.py                                         
  - Existing tests still pass — (verify with pytest tests unit_tests -v)                                                                                     
  - No secrets or .env files in this diff                                                                                                                    
  - ADR written — (not required; this is a reversible config-driven approach)                                                                                
  - docs/debugging/known-issues.md updated — (no new edge cases discovered)                                                                                  
                                                                                                                                                             
  Hardware Testing                                                                                                                                           
                                                                                                                                                             
  - Tested on physical device                                                                                                                                
  - Tested in simulation mode only — reason: filtering is hostname-based; can be simulated by setting DEVICE_HOSTNAME env var                              
  - Hardware not relevant to this change — (pure API/config logic)                                                                                           
                                                                                                                                                             
  Reviewer Notes                                                                                                                                             
                                                                                                                                                             
  - resolve_device_profiles() reads the device's hostname via socket.gethostname() or the DEVICE_HOSTNAME env var (the env var override makes testing easy   
  without a real device).                                                                             
  - If either config file is missing or the hostname isn't listed, the function returns None and all profiles are shown — safe fallback, no behavior change  
  for unregistered devices.                                                                                                                                  
  - Filtering only applies to profiles under a bundled/ directory in their path; user-created profiles are always shown.                                   
  - Two bundled profiles (O157__ESBL_full.json, STEC_and_EPEC_Hygiena1.75_no37Cstep.json) are included as examples in profiles/bundled/.                     
  - scripts/profile_map.py is a utility for visualizing which devices see which profiles — not deployed, just a dev tool.    