### PR TITLE
Remove "Start Run" header + added profile and run name during run

### DIFF
--- a/aquila_web/static/run.html
+++ b/aquila_web/static/run.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=768, height=1024, initial-scale=1" />
   <title>Run</title>
-  <link rel="stylesheet" href="static/styles.css?v=211" />
+  <link rel="stylesheet" href="static/styles.css?v=212" />
 </head>
 <body class="app-body">
   <div class="app-shell">
@@ -47,7 +47,10 @@
       <section class="run-section run-start-card">
         <div class="run-start-header">
           <div class="run-start-title">
-            <h2>Start Run</h2>
+            <div class="run-start-summary is-hidden" id="run-start-summary">
+              <span class="run-start-summary__profile" id="run-start-profile"></span>
+              <span class="run-start-summary__runname" id="run-start-runname"></span>
+            </div>
           </div>
           <div class="run-start-status">
             <div class="run-ready-pill">
@@ -140,7 +143,7 @@
     </main>
   </div>
   <script src="static/nav.js?v=1"></script>
-  <script src="static/script.js?v=65"></script>
+  <script src="static/script.js?v=66"></script>
   <script src="static/keyboard.js?v=14"></script>
 </body>
 </html>

--- a/aquila_web/static/script.js
+++ b/aquila_web/static/script.js
@@ -182,6 +182,33 @@ const completeSection = document.getElementById("complete-section");
 const normalizedPath = window.location.pathname.replace(/\/$/, "");
 const isDashboard = normalizedPath === "/run" || Boolean(readySection);
 
+function updateStartHeader(screen) {
+  const summary = document.getElementById("run-start-summary");
+  if (!summary) {
+    return;
+  }
+
+  const isActive = screen === "running" || screen === "complete";
+  if (isActive) {
+    const select = document.getElementById("mySelect");
+    const selectedOption = select && select.selectedOptions ? select.selectedOptions[0] : null;
+    const profileText = selectedOption ? selectedOption.textContent.trim() : "";
+    const runName = runNameInput ? runNameInput.value.trim() : "";
+
+    const profileEl = document.getElementById("run-start-profile");
+    const runNameEl = document.getElementById("run-start-runname");
+    if (profileEl) {
+      profileEl.textContent = profileText;
+    }
+    if (runNameEl) {
+      runNameEl.textContent = runName;
+    }
+    summary.classList.remove("is-hidden");
+  } else {
+    summary.classList.add("is-hidden");
+  }
+}
+
 function updateDashboardSections(screen) {
   if (!isDashboard) {
     return false;
@@ -201,6 +228,8 @@ function updateDashboardSections(screen) {
   }
 
   currentScreen = screen;
+
+  updateStartHeader(screen);
 
   const sections = [
     { key: "ready", element: readySection },

--- a/aquila_web/static/styles.css
+++ b/aquila_web/static/styles.css
@@ -666,6 +666,28 @@ a:active {
   gap: 6px;
 }
 
+.run-start-summary {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 2px;
+  margin-top: 18px;
+}
+
+.run-start-summary__profile {
+  font-size: 20px;
+  font-weight: 700;
+  line-height: 1.2;
+  color: #1a1c1c;
+}
+
+.run-start-summary__runname {
+  font-size: 18px;
+  font-weight: 700;
+  line-height: 1.2;
+  color: #64748b;
+}
+
 .run-start-status {
   display: flex;
   flex-direction: column;

--- a/specs/frontend/TEMPLATE-frontend-spec.md
+++ b/specs/frontend/TEMPLATE-frontend-spec.md
@@ -74,8 +74,6 @@ Reference the state definitions in: `aquila_web/static/[state-config-file]`
 - No hover states (touch-only)
 - No text input from virtual keyboard unless explicitly required
 - Screen must remain readable at [distance from device]
-- Profile name listed in bold above run name
-- Profile name aligned with Ready status
 
 ---
 

--- a/specs/frontend/TEMPLATE-frontend-spec.md
+++ b/specs/frontend/TEMPLATE-frontend-spec.md
@@ -74,6 +74,8 @@ Reference the state definitions in: `aquila_web/static/[state-config-file]`
 - No hover states (touch-only)
 - No text input from virtual keyboard unless explicitly required
 - Screen must remain readable at [distance from device]
+- Profile name listed in bold above run name
+- Profile name aligned with Ready status
 
 ---
 

--- a/specs/frontend/run-card-header-spec.md
+++ b/specs/frontend/run-card-header-spec.md
@@ -1,0 +1,98 @@
+# Frontend / UI Spec: Run Card Header — Live Profile & Run Name
+
+**Status:** Active
+**Author:** Jack Hu
+**Last updated:** 2026-06-02
+**GitHub issue:** #93
+**Affected screens:** `ready`, `running`, `complete`
+**Source file(s):** `aquila_web/static/run.html`, `aquila_web/static/script.js`, `aquila_web/static/styles.css`
+
+---
+
+## 1. Overview
+
+Replaces the static **"Start Run"** heading in the top-left corner of the Run Start card. The heading is removed entirely; the user never sees "Start Run". Instead, once a run begins, that corner displays the **selected profile name** (top line) and the **run name** (line below), so the operator can confirm what's running while the input controls are hidden.
+
+---
+
+## 2. Screen Inventory
+
+| Screen ID | Name | Entry condition | Exit conditions |
+|-----------|------|----------------|-----------------|
+| `ready` | Ready to Run | Hardware ready, idle | Operator taps **Run** → `running` |
+| `running` | Run In Progress | `/button/run` accepted | Run completes → `complete`; **Stop** → `ready` |
+| `complete` | Results | Run finished | New run / acknowledge → `ready` |
+
+> The card header content changes per screen; the card element is not itself toggled.
+
+---
+
+## 3. State Machine Transitions
+
+```
+[ready]    --tap Run-->            [running]   (header corner fills: profile + run name)
+[running]  --run finishes-->       [complete]  (header corner stays filled)
+[complete] --new run / ready-->    [ready]     (header corner clears to empty)
+```
+
+Driven by `updateStartHeader(screen)` in `aquila_web/static/script.js`, called from `updateDashboardSections`.
+
+---
+
+## 4. Screen Designs
+
+### Region: Run Start card header (`.run-start-header`)
+
+**Layout:**
+- Left (`.run-start-title`): summary block (`#run-start-summary`) — `#run-start-profile` over `#run-start-runname`. Hidden on `ready`.
+
+**Dynamic content:**
+- Profile: `textContent` of the selected `<option>` in `#mySelect` (display name, not raw ID).
+- Run name: current value of `#run-name-input`.
+- Both read client-side at screen-change time — no new backend endpoint.
+
+**User interactions:** None added.
+
+**Error states:**
+- If no profile/name is resolvable, the corresponding line renders empty.
+
+---
+
+## 5. Data Binding
+
+| UI Element | Data Source | Update Trigger |
+|------------|-------------|----------------|
+| `#run-start-profile` | `#mySelect` selected option text (DOM) | Screen → `running`/`complete` |
+| `#run-start-runname` | `#run-name-input` value (DOM) | Screen → `running`/`complete` |
+| Summary visibility | `screen === "running" \|\| screen === "complete"` | Each WebSocket `screen` message |
+
+---
+
+## 6. Accessibility / Kiosk Constraints
+
+- Display only — no new touch targets, no virtual keyboard interaction.
+- Profile 20px bold; run name 18px bold (matches Ready pill / Reset button font size).
+- Profile name vertically aligned with the Ready pill
+
+---
+
+## 7. Assets
+
+| Asset | Path | Format | Notes |
+|-------|------|--------|-------|
+| — | — | — | No new assets; CSS/markup only |
+
+---
+
+## 8. Acceptance Criteria
+
+- [ ] Remove the “Start Run” text label from the center run button while a run is active
+- [ ] On `ready`/`init`, the header corner is empty.
+- [ ] Display the selected profile name and run name in the area where “Start Run” previously appeared
+- [ ] Ensure the profile/run information matches the styling and formatting used throughout the rest of the application
+- [ ] Keep the active run state visually cleaner and less cluttered during execution
+
+---
+
+## 9. Open Questions
+


### PR DESCRIPTION
## What Changed

User no longer sees "Start Run" before running the device. Additionally, once the run has started, the user will be able to see the profile name and the run name in the upper left corner of the run card.

## Why

https://github.com/orgs/AcornGenetics/projects/1/views/1?pane=issue&itemId=195125402&issue=AcornGenetics%7Caquilla-main%7C93

## Spec

Link to the spec this implements or modifies:
`specs/frontend/run-card-header-specs.md`

If no spec exists and this is a non-trivial change, explain why.

## Changes Made

- [x] Source code modified
- [x] Spec updated to match implementation
- [ ] New tests written
- [x] Existing tests still pass
- [x] No secrets or `.env` files in this diff
- [ ] ADR written (if an irreversible architectural decision was made)
- [ ] `docs/debugging/known-issues.md` updated (if new edge cases were found)

## Hardware Testing

- [ ] Tested on physical device
- [x] Tested in simulation mode only — reason: [why physical not possible]
- [ ] Hardware not relevant to this change

## Reviewer Notes

Anything the reviewer should know: tricky parts, things to focus on, known limitations.
