### PR TITLE
feat: read RPi hardware serial and inject as AQ_SYNC_DEVICE_ID

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -1,0 +1,49 @@
+# Bounded Context: Aquilla Analytics
+
+This glossary defines canonical terms for the analytics domain. Terms here take precedence over informal usage in conversations and documentation.
+
+---
+
+## Glossary
+
+**Sentri**
+A single physical Aquilla PCR instrument — a Raspberry Pi running the Aquilla software stack in Docker. "Device" and "Sentri" are synonymous; prefer "Sentri" in analytics contexts to avoid ambiguity with AWS/cloud "devices."
+
+**Fleet**
+The collection of all deployed Sentri units. Analytics queries span the fleet; device-level queries scope to a single Sentri.
+
+**Device ID**
+The Raspberry Pi hardware serial number (from `/proc/cpuinfo`), used as the stable, globally unique identifier for a Sentri in analytics data. Survives reimages. Stored as `AQ_SYNC_DEVICE_ID` env var. Mapped to a human-readable `dock_name` in the AWS device registry. Do not confuse with the hostname-based config key (`sn01`, `sn02`) used for hardware configuration in `host_config.json`.
+
+**Protocol**
+A named PCR assay profile — a JSON file in `profiles/` that defines thermal steps, cycle count, and optical configuration. The `title` field in the JSON is the canonical protocol name. Protocols are the primary grouping dimension for analytics (e.g., "inconclusive rate by protocol").
+
+**Run**
+A single execution of a Protocol on a Sentri, producing results for up to 4 Wells. A Run has a start time, end time, and status (completed, aborted). A Run is the unit of event emission — one `run_complete` event per Run.
+
+**Well**
+One of 4 sample positions (numbered 1–4) in the Sentri carousel. Each Well is read independently.
+
+**Channel**
+One of 2 optical measurement channels: `fam` or `rox`. Channels are labels for optical hardware, not named biological targets. Each Well produces one Call per Channel per Run.
+
+**Call**
+The analytical outcome for a single Well × Channel pair within a Run. One of: `Detected`, `Not Detected`, `Inconclusive`, `ROX Unavailable`. A Run produces up to 8 Calls (4 wells × 2 channels).
+
+**Cq (Cycle Quantification)**
+The fractional PCR cycle at which a Well's fluorescence crosses the detection threshold. `null` when the Call is Not Detected or Inconclusive. Stored as a float rounded to 2 decimal places.
+
+**Inconclusive Rate**
+The fraction of Calls with outcome `Inconclusive`, grouped by Protocol. The primary analytics metric for v1. Denominator excludes `ROX Unavailable` calls.
+
+**Event**
+A structured JSON record enqueued in the local SQLite database (`data/db/app.db`) when a Run completes. Event type: `run_complete`. Payload contains: protocol name, run name, run timestamp, duration, and all 8 Well × Channel Calls with Cq values. Events queue offline and flush on the next successful Sync.
+
+**Sync**
+The background process (asyncio task in the FastAPI app, 15-minute interval) that batches pending Events from the local SQLite queue and POSTs them to the AWS Ingest Endpoint. Also triggered on WiFi reconnect. On success, marks events `synced_at` in SQLite. Events accumulate indefinitely if offline.
+
+**Ingest Endpoint**
+The AWS API Gateway URL that receives Event batches from Sentri devices. Authenticates via `x-api-key` header (shared fleet API key stored as `AQ_SYNC_API_KEY` env var). Backed by a Lambda function that writes to RDS PostgreSQL.
+
+**Fleet API Key**
+A shared secret (`AQ_SYNC_API_KEY`) stored in each Sentri's environment, sent as `x-api-key` on every Sync request. Rotated via Tailscale SSH fleet script when compromised or on scheduled rotation. A single key covers the entire fleet.

--- a/aq_lib/device_id.py
+++ b/aq_lib/device_id.py
@@ -1,0 +1,25 @@
+import os
+import re
+
+
+def read_rpi_serial(cpuinfo_path: str = "/proc/cpuinfo") -> str | None:
+    try:
+        with open(cpuinfo_path) as f:
+            content = f.read()
+    except OSError:
+        return None
+    match = re.search(r"^Serial\s*:\s*([0-9a-fA-F]+)", content, re.MULTILINE)
+    if not match:
+        return None
+    serial = match.group(1)
+    if not serial.lstrip("0"):
+        return None
+    return serial
+
+
+def inject_hw_serial_env(cpuinfo_path: str = "/proc/cpuinfo") -> None:
+    if os.environ.get("AQ_SYNC_DEVICE_ID"):
+        return
+    serial = read_rpi_serial(cpuinfo_path)
+    if serial:
+        os.environ["AQ_SYNC_DEVICE_ID"] = serial

--- a/aquila_web/main.py
+++ b/aquila_web/main.py
@@ -1,4 +1,5 @@
 from fastapi import FastAPI, Form, Body, HTTPException, Query
+from aq_lib.device_id import inject_hw_serial_env
 from fastapi.responses import FileResponse, RedirectResponse, JSONResponse
 from fastapi.staticfiles import StaticFiles
 from pathlib import Path
@@ -1639,6 +1640,11 @@ async def _background_update_poller() -> None:
         if _OTA_GHCR_TOKEN and _OTA_IMAGE_TAG:
             await _do_check_update()
         await asyncio.sleep(_OTA_POLL_INTERVAL)
+
+
+@app.on_event("startup")
+async def _inject_device_id() -> None:
+    inject_hw_serial_env()
 
 
 @app.on_event("startup")

--- a/docs/adr/ADR-009-analytics-ingest-api-gateway-lambda.md
+++ b/docs/adr/ADR-009-analytics-ingest-api-gateway-lambda.md
@@ -1,0 +1,88 @@
+# ADR-009: Analytics Ingest via API Gateway + Lambda, not IoT Core
+
+**Status:** Accepted
+**Date:** 2026-06-08
+**Author:** Nicole Cornell
+**Deciders:** Nicole Cornell
+
+---
+
+## Context
+
+Aquilla devices (Sentri) are Raspberry Pis deployed in the field, occasionally offline. We need to collect `run_complete` events from the fleet and store them in a queryable database to compute inconclusive rate by protocol.
+
+Fleet size: <10 now, ~100 within 12 months. At 20 runs/day per device, peak volume is ~2,000 events/day at full scale.
+
+Devices already have:
+- A local SQLite event queue (`aquila_web/local_db.py`) with offline accumulation and `synced_at` tracking
+- A sync module (`aquila_web/sync.py`) that batch-POSTs JSON to a configurable `AQ_SYNC_ENDPOINT`
+- An asyncio background task pattern (`_background_update_poller`) for periodic work
+
+AWS IoT Core is the conventional choice for IoT device telemetry. API Gateway + Lambda is the conventional web-API choice.
+
+---
+
+## Decision
+
+**We will use AWS API Gateway + Lambda as the analytics ingest endpoint, backed by RDS PostgreSQL.**
+
+- `AQ_SYNC_ENDPOINT` points to an API Gateway URL
+- `sync.py` POSTs batches of `run_complete` events unchanged — no client-side changes needed
+- A Lambda function receives the batch, validates the fleet API key, and upserts rows into RDS PostgreSQL
+- RDS PostgreSQL holds three tables: `devices`, `runs`, `run_results` (one row per Well × Channel per Run)
+- Analytics queries run directly against RDS via psql (raw SQL access)
+
+Auth: shared fleet API key sent as `x-api-key` header, validated by API Gateway's built-in usage plan. Key stored as `AQ_SYNC_API_KEY` on each device. Rotated via Tailscale SSH fleet script.
+
+Sync schedule: 15-minute asyncio background task in the FastAPI app, plus a trigger on WiFi reconnect.
+
+---
+
+## Consequences
+
+### Positive
+- No new device-side infrastructure — `sync.py` already speaks plain HTTP POST
+- API Gateway + Lambda requires zero server management vs. running an EC2 ingest server
+- RDS PostgreSQL is directly queryable with psql; no BI tool or data pipeline needed for v1
+- Lambda's `ON CONFLICT DO NOTHING` idempotency (already in `cloud_db.py`) handles duplicate syncs safely
+- Cost at 100 devices × 20 runs/day is negligible (Lambda free tier covers it; `db.t4g.micro` ~$15/month)
+
+### Negative
+- Shared fleet API key means a compromised device exposes the ingest endpoint for the whole fleet (mitigated: analytics data only, no commands flow back)
+- Key rotation requires a fleet script touching all online devices; offline devices get the new key on next connection
+- No real-time streaming — 15-minute sync interval means analytics lag by up to 15 minutes
+
+### Neutral / Tradeoffs
+- IoT Core would give per-device certificates and bi-directional messaging, but bi-directional is not needed for analytics-only data flow
+- IoT Core → Kinesis → S3 is the right architecture at 500+ devices; this decision should be revisited at that threshold
+
+---
+
+## Alternatives Considered
+
+### Option A: AWS IoT Core + Kinesis
+**Why rejected:** Significant setup overhead (device certificate provisioning, IoT policies, Kinesis shards, Glue/Athena for querying) that isn't justified at <100 devices. Revisit at 500+ devices.
+
+### Option B: Direct RDS connection from device
+**Why rejected:** Exposes database credentials on every device, requires VPC peering or public RDS endpoint, and doesn't handle offline accumulation.
+
+### Option C: S3 + Athena (data lake)
+**Why rejected:** Athena query latency and setup cost aren't worth it at this volume. Flat RDS table with a `run_timestamp` index handles years of data at this scale.
+
+---
+
+## Revisit Conditions
+
+- Fleet exceeds 500 Sentri devices → evaluate IoT Core + Kinesis
+- Need for real-time alerting (< 1 minute latency) → add EventBridge or SNS trigger from Lambda
+- Per-device audit trail becomes a compliance requirement → migrate to per-device API keys or mTLS
+
+---
+
+## References
+
+- Related ADRs: ADR-002 (Watchtower fleet updates), ADR-001 (hostname-keyed device config)
+- `aquila_web/sync.py` — existing sync client
+- `aquila_web/local_db.py` — local SQLite event queue
+- `aquila_web/cloud_db.py` — existing psycopg PostgreSQL integration
+- `CONTEXT.md` — analytics domain glossary

--- a/docs/local-db-schema.md
+++ b/docs/local-db-schema.md
@@ -1,0 +1,875 @@
+# SENTRI Local SQLite Schema — Complete Device Logging
+
+All tables live in the on-device SQLite database (`/data/db/app.db`) with WAL mode enabled.
+Every table carries `device_id TEXT`, a timestamp column, and `synced INTEGER NOT NULL DEFAULT 0`.
+`synced = 0` means the row has not yet been pushed to Postgres. `synced = 1` means it has.
+
+---
+
+## Table Index
+
+| Table | What it logs |
+|---|---|
+| `runs` | Every PCR run — start, stop, protocol, operator |
+| `thermal_readings` | Every thermocouple sample from every well |
+| `heater_commands` | Every setpoint sent to heater zones |
+| `pcr_cycle_stages` | Stage transitions (denature/anneal/extend) per cycle |
+| `fluorescence_readings` | Optical RFU per well per cycle per channel |
+| `run_events` | State changes and milestones within a run |
+| `run_results` | Final per-well call for each target/channel |
+| `pcr_qc_flags` | Each individual QC check that failed per well |
+| `device_health` | CPU/RAM/disk/GPU/temp snapshot every ~30s |
+| `thermocouple_diagnostics` | Sensor fault codes and calibration offsets |
+| `calibration_records` | Full history of every calibration performed |
+| `network_events` | WiFi connect/disconnect/signal changes |
+| `sync_log` | Every sync attempt — rows pushed, bytes sent, errors |
+| `error_log` | Every caught exception with full stack trace |
+| `application_events` | Process start/stop, config changes, instrument connect |
+| `power_events` | Voltage, brownouts, battery, mains loss |
+| `gpio_events` | Lid switch, e-stop, door latch — every physical toggle |
+| `storage_health` | SD card health, bad blocks, wear level |
+| `operator_actions` | Every human interaction via kiosk/UI |
+| `alerts` | Threshold violations and system warnings |
+| `firmware_log` | Version history for every software component |
+| `process_health` | Heartbeat and liveness for each background thread |
+| `devices` | One record per physical instrument — assembly window, device notes |
+| `parts` | Every component installed on a device — BOM, batch, condition, known risks |
+
+---
+
+## Setup
+
+```sql
+PRAGMA journal_mode = WAL;
+PRAGMA foreign_keys = ON;
+```
+
+---
+
+## runs
+
+Top-level lifecycle record for every PCR run. Every other table references `run_id`.
+
+```sql
+CREATE TABLE IF NOT EXISTS runs (
+    id                  INTEGER PRIMARY KEY AUTOINCREMENT,
+    device_id           TEXT    NOT NULL,
+    operator_id         TEXT,
+    protocol_name       TEXT    NOT NULL,
+    protocol_version    TEXT,
+    plate_barcode       TEXT,
+    sample_count        INTEGER,
+    status              TEXT    NOT NULL DEFAULT 'pending',
+        -- pending | running | completed | aborted | error
+    started_at          TEXT    NOT NULL,
+    completed_at        TEXT,
+    aborted_at          TEXT,
+    abort_reason        TEXT,
+    total_cycles        INTEGER,
+    cycles_completed    INTEGER DEFAULT 0,
+    notes               TEXT,
+    synced              INTEGER NOT NULL DEFAULT 0,
+    created_at          TEXT    NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ','now'))
+);
+```
+
+---
+
+## thermal_readings
+
+Every thermocouple sample from every well. Written continuously during a run.
+
+```sql
+CREATE TABLE IF NOT EXISTS thermal_readings (
+    id                  INTEGER PRIMARY KEY AUTOINCREMENT,
+    run_id              INTEGER NOT NULL REFERENCES runs(id),
+    device_id           TEXT    NOT NULL,
+    well_id             TEXT    NOT NULL,           -- e.g. "A1", "B3"
+    thermocouple_index  INTEGER NOT NULL,
+    temperature_c       REAL    NOT NULL,
+    setpoint_c          REAL,
+    error_c             REAL,                       -- measured - setpoint
+    cycle_number        INTEGER,
+    stage               TEXT,                       -- denature | anneal | extend | hold
+    stage_elapsed_ms    INTEGER,
+    run_elapsed_ms      INTEGER,
+    sampled_at          TEXT    NOT NULL,
+    synced              INTEGER NOT NULL DEFAULT 0
+);
+CREATE INDEX IF NOT EXISTS idx_thermal_run    ON thermal_readings(run_id);
+CREATE INDEX IF NOT EXISTS idx_thermal_synced ON thermal_readings(synced);
+CREATE INDEX IF NOT EXISTS idx_thermal_well   ON thermal_readings(run_id, well_id);
+```
+
+---
+
+## heater_commands
+
+Every setpoint command sent to heater zones by the controller.
+
+```sql
+CREATE TABLE IF NOT EXISTS heater_commands (
+    id                  INTEGER PRIMARY KEY AUTOINCREMENT,
+    run_id              INTEGER NOT NULL REFERENCES runs(id),
+    device_id           TEXT    NOT NULL,
+    heater_zone         TEXT    NOT NULL,           -- "lid" | "block_top" | "block_bottom"
+    setpoint_c          REAL    NOT NULL,
+    ramp_rate_c_per_s   REAL,
+    hold_duration_ms    INTEGER,
+    pid_p               REAL,
+    pid_i               REAL,
+    pid_d               REAL,
+    commanded_at        TEXT    NOT NULL,
+    synced              INTEGER NOT NULL DEFAULT 0
+);
+CREATE INDEX IF NOT EXISTS idx_heater_run ON heater_commands(run_id);
+```
+
+---
+
+## pcr_cycle_stages
+
+Protocol stage transitions per cycle — timing, target temps, and overshoot.
+
+```sql
+CREATE TABLE IF NOT EXISTS pcr_cycle_stages (
+    id                  INTEGER PRIMARY KEY AUTOINCREMENT,
+    run_id              INTEGER NOT NULL REFERENCES runs(id),
+    device_id           TEXT    NOT NULL,
+    cycle_number        INTEGER NOT NULL,
+    stage               TEXT    NOT NULL,           -- denature | anneal | extend | hold | ramp
+    target_temp_c       REAL    NOT NULL,
+    actual_start_temp_c REAL,
+    stage_started_at    TEXT    NOT NULL,
+    stage_ended_at      TEXT,
+    stage_duration_ms   INTEGER,
+    ramp_time_ms        INTEGER,
+    overshoot_c         REAL,
+    synced              INTEGER NOT NULL DEFAULT 0
+);
+CREATE INDEX IF NOT EXISTS idx_stages_run ON pcr_cycle_stages(run_id);
+```
+
+---
+
+## fluorescence_readings
+
+Optical RFU measurements per well, per cycle, per channel.
+
+```sql
+CREATE TABLE IF NOT EXISTS fluorescence_readings (
+    id                  INTEGER PRIMARY KEY AUTOINCREMENT,
+    run_id              INTEGER NOT NULL REFERENCES runs(id),
+    device_id           TEXT    NOT NULL,
+    well_id             TEXT    NOT NULL,
+    cycle_number        INTEGER NOT NULL,
+    channel             TEXT    NOT NULL,           -- "FAM" | "HEX" | "ROX"
+    excitation_nm       INTEGER,
+    emission_nm         INTEGER,
+    raw_rfu             REAL    NOT NULL,
+    baseline_rfu        REAL,
+    normalized_rfu      REAL,
+    integration_time_ms INTEGER,
+    gain                REAL,
+    led_power_pct       REAL,
+    camera_temp_c       REAL,
+    measured_at         TEXT    NOT NULL,
+    synced              INTEGER NOT NULL DEFAULT 0
+);
+CREATE INDEX IF NOT EXISTS idx_fluor_run  ON fluorescence_readings(run_id);
+CREATE INDEX IF NOT EXISTS idx_fluor_well ON fluorescence_readings(run_id, well_id, cycle_number);
+```
+
+---
+
+## run_events
+
+State transitions and notable milestones within a run.
+
+```sql
+CREATE TABLE IF NOT EXISTS run_events (
+    id                  INTEGER PRIMARY KEY AUTOINCREMENT,
+    run_id              INTEGER NOT NULL REFERENCES runs(id),
+    device_id           TEXT    NOT NULL,
+    event_type          TEXT    NOT NULL,
+        -- run_started | run_completed | run_aborted
+        -- cycle_started | cycle_completed
+        -- stage_started | stage_completed
+        -- lid_opened | lid_closed
+        -- pause_requested | pause_started | resume_started
+        -- protocol_loaded | threshold_crossed | operator_note
+    cycle_number        INTEGER,
+    stage               TEXT,
+    detail              TEXT,                       -- free-text or JSON context
+    occurred_at         TEXT    NOT NULL,
+    synced              INTEGER NOT NULL DEFAULT 0
+);
+CREATE INDEX IF NOT EXISTS idx_run_events_run ON run_events(run_id);
+```
+
+---
+
+## run_results
+
+Final per-well analytical call for each target and channel. One row per well per target per channel.
+
+```sql
+CREATE TABLE IF NOT EXISTS run_results (
+    id                      INTEGER PRIMARY KEY AUTOINCREMENT,
+    run_id                  INTEGER NOT NULL REFERENCES runs(id),
+    device_id               TEXT    NOT NULL,
+    well_id                 TEXT    NOT NULL,
+    sample_id               TEXT,
+    target_name             TEXT    NOT NULL,       -- "IAV" | "IBV" | "RSV" | "IC"
+    channel                 TEXT    NOT NULL,
+    -- Call
+    call                    TEXT    NOT NULL,
+        -- positive | negative | inconclusive | invalid | no_call
+    call_confidence         REAL,
+    call_method             TEXT,                   -- "auto" | "manual_override"
+    called_by               TEXT,
+    -- Quantification
+    cq                      REAL,
+    cq_confidence           REAL,
+    efficiency_pct          REAL,
+    r_squared               REAL,
+    -- Fluorescence landmarks
+    baseline_rfu            REAL,
+    baseline_noise_rfu      REAL,
+    threshold_rfu           REAL,
+    end_rfu                 REAL,
+    max_rfu                 REAL,
+    delta_rfu               REAL,
+    relative_drop           REAL,
+    -- Curve shape
+    slope                   REAL,
+    intercept               REAL,
+    sigmoid_amplitude       REAL,
+    sigmoid_inflection      REAL,
+    sigmoid_slope           REAL,
+    -- Summary
+    inconclusive            INTEGER DEFAULT 0,      -- 1 if any hard QC flag fired
+    flag_count              INTEGER DEFAULT 0,
+    analysis_version        TEXT,
+    analyzed_at             TEXT    NOT NULL,
+    synced                  INTEGER NOT NULL DEFAULT 0
+);
+CREATE INDEX IF NOT EXISTS idx_results_run  ON run_results(run_id);
+CREATE INDEX IF NOT EXISTS idx_results_well ON run_results(run_id, well_id);
+CREATE INDEX IF NOT EXISTS idx_results_call ON run_results(call);
+```
+
+---
+
+## pcr_qc_flags
+
+One row per QC check that failed for a given well/result. Join to `run_results` on `result_id`
+to reconstruct exactly why a well went inconclusive.
+
+```sql
+CREATE TABLE IF NOT EXISTS pcr_qc_flags (
+    id                      INTEGER PRIMARY KEY AUTOINCREMENT,
+    run_id                  INTEGER NOT NULL REFERENCES runs(id),
+    result_id               INTEGER NOT NULL REFERENCES run_results(id),
+    device_id               TEXT    NOT NULL,
+    well_id                 TEXT    NOT NULL,
+    target_name             TEXT    NOT NULL,
+    channel                 TEXT,
+    -- The flag
+    flag_code               TEXT    NOT NULL,
+        -- LATE_CQ               Cq exceeded late-call threshold
+        -- NO_AMPLIFICATION      no exponential growth detected
+        -- LOW_R2                curve fit R² below minimum
+        -- HIGH_BASELINE_NOISE   std dev of baseline too high
+        -- LOW_DELTA_RFU         end - baseline below detection floor
+        -- MOUNTAIN_ARTIFACT     non-monotonic late-phase hump detected
+        -- RELATIVE_DROP         late-phase drop ratio exceeded limit
+        -- SLOPE_OUT_OF_RANGE    log-linear slope outside acceptable window
+        -- EFFICIENCY_LOW        amplification efficiency < 90%
+        -- EFFICIENCY_HIGH       amplification efficiency > 115%
+        -- SIGMOID_FIT_POOR      sigmoid residuals above threshold
+        -- INHIBITION_SUSPECTED  combined low efficiency + shape abnormality
+        -- NTC_CONTAMINATED      no-template control showed amplification
+        -- POS_CONTROL_FAILED    positive control did not amplify as expected
+        -- IC_FAILED             internal control call failed
+        -- MISSING_CYCLES        fewer cycles recorded than protocol requires
+        -- THERMOCOUPLE_FAULT    sensor fault during this well's reads
+        -- BASELINE_DRIFT        systematic upward/downward baseline slope
+        -- SATURATION_DETECTED   RFU clipped at sensor maximum
+    flag_category           TEXT    NOT NULL,
+        -- curve_quality | controls | instrument | data_integrity | threshold
+    severity                TEXT    NOT NULL,
+        -- hard (drives inconclusive/invalid) | soft (warning only)
+    observed_value          REAL,
+    threshold_value         REAL,
+    direction               TEXT,                   -- "above" | "below" | "outside_range"
+    description             TEXT,
+    analysis_module         TEXT,
+    analysis_version        TEXT,
+    flagged_at              TEXT    NOT NULL,
+    synced                  INTEGER NOT NULL DEFAULT 0
+);
+CREATE INDEX IF NOT EXISTS idx_qcflags_run    ON pcr_qc_flags(run_id);
+CREATE INDEX IF NOT EXISTS idx_qcflags_result ON pcr_qc_flags(result_id);
+CREATE INDEX IF NOT EXISTS idx_qcflags_code   ON pcr_qc_flags(flag_code);
+CREATE INDEX IF NOT EXISTS idx_qcflags_synced ON pcr_qc_flags(synced);
+```
+
+---
+
+## device_health
+
+Periodic system snapshot sampled every ~30 seconds. `run_id` is NULL when the device is idle.
+
+```sql
+CREATE TABLE IF NOT EXISTS device_health (
+    id                      INTEGER PRIMARY KEY AUTOINCREMENT,
+    device_id               TEXT    NOT NULL,
+    run_id                  INTEGER REFERENCES runs(id),
+    -- CPU
+    cpu_pct                 REAL,
+    cpu_temp_c              REAL,
+    cpu_freq_mhz            REAL,
+    cpu_core_count          INTEGER,
+    cpu_load_1m             REAL,
+    cpu_load_5m             REAL,
+    cpu_load_15m            REAL,
+    -- Memory
+    ram_total_mb            REAL,
+    ram_used_mb             REAL,
+    ram_free_mb             REAL,
+    ram_pct                 REAL,
+    swap_total_mb           REAL,
+    swap_used_mb            REAL,
+    swap_pct                REAL,
+    -- Disk (SD card)
+    disk_total_gb           REAL,
+    disk_used_gb            REAL,
+    disk_free_gb            REAL,
+    disk_pct                REAL,
+    disk_read_mb_s          REAL,
+    disk_write_mb_s         REAL,
+    -- GPU (Pi VideoCore)
+    gpu_temp_c              REAL,
+    gpu_freq_mhz            REAL,
+    gpu_mem_total_mb        REAL,
+    gpu_mem_used_mb         REAL,
+    -- Board
+    board_temp_c            REAL,
+    throttle_flags          TEXT,                   -- raw vcgencmd value e.g. "0x50000"
+    under_voltage           INTEGER,
+    arm_freq_capped         INTEGER,
+    throttled               INTEGER,
+    -- Uptime
+    uptime_seconds          INTEGER,
+    process_uptime_seconds  INTEGER,
+    active_thread_count     INTEGER,
+    sampled_at              TEXT    NOT NULL,
+    synced                  INTEGER NOT NULL DEFAULT 0
+);
+CREATE INDEX IF NOT EXISTS idx_health_device ON device_health(device_id);
+CREATE INDEX IF NOT EXISTS idx_health_run    ON device_health(run_id);
+CREATE INDEX IF NOT EXISTS idx_health_synced ON device_health(synced);
+```
+
+---
+
+## thermocouple_diagnostics
+
+Sensor self-check results and calibration offsets per thermocouple.
+
+```sql
+CREATE TABLE IF NOT EXISTS thermocouple_diagnostics (
+    id                  INTEGER PRIMARY KEY AUTOINCREMENT,
+    device_id           TEXT    NOT NULL,
+    thermocouple_index  INTEGER NOT NULL,
+    well_id             TEXT,
+    fault_code          INTEGER,
+    fault_description   TEXT,                       -- "open circuit" | "short to VCC" | "short to GND" | "ok"
+    cold_junction_c     REAL,
+    reference_voltage   REAL,
+    offset_applied_c    REAL,
+    passed_selftest     INTEGER,
+    checked_at          TEXT    NOT NULL,
+    synced              INTEGER NOT NULL DEFAULT 0
+);
+```
+
+---
+
+## calibration_records
+
+Full history of every calibration event performed on the device.
+
+```sql
+CREATE TABLE IF NOT EXISTS calibration_records (
+    id                  INTEGER PRIMARY KEY AUTOINCREMENT,
+    device_id           TEXT    NOT NULL,
+    calibration_type    TEXT    NOT NULL,           -- temperature | fluorescence | optical | pressure
+    well_id             TEXT,
+    sensor_index        INTEGER,
+    pre_offset_c        REAL,
+    post_offset_c       REAL,
+    reference_value     REAL,
+    measured_value      REAL,
+    residual_error      REAL,
+    passed              INTEGER,
+    operator_id         TEXT,
+    performed_at        TEXT    NOT NULL,
+    expires_at          TEXT,
+    notes               TEXT,
+    synced              INTEGER NOT NULL DEFAULT 0
+);
+```
+
+---
+
+## network_events
+
+WiFi and ethernet state changes.
+
+```sql
+CREATE TABLE IF NOT EXISTS network_events (
+    id                  INTEGER PRIMARY KEY AUTOINCREMENT,
+    device_id           TEXT    NOT NULL,
+    event_type          TEXT    NOT NULL,
+        -- connected | disconnected | reconnecting | ip_changed
+        -- dns_failure | internet_reachable | internet_unreachable
+    interface           TEXT,                       -- wlan0 | eth0
+    ssid                TEXT,
+    bssid               TEXT,
+    ip_address          TEXT,
+    signal_dbm          INTEGER,
+    link_speed_mbps     INTEGER,
+    reason_code         INTEGER,
+    reason_text         TEXT,
+    occurred_at         TEXT    NOT NULL,
+    synced              INTEGER NOT NULL DEFAULT 0
+);
+CREATE INDEX IF NOT EXISTS idx_net_synced ON network_events(synced);
+```
+
+---
+
+## sync_log
+
+History of every sync attempt — outcome, row counts, and errors.
+
+```sql
+CREATE TABLE IF NOT EXISTS sync_log (
+    id                  INTEGER PRIMARY KEY AUTOINCREMENT,
+    device_id           TEXT    NOT NULL,
+    target              TEXT    NOT NULL,           -- "postgres" | "s3" | "api"
+    attempted_at        TEXT    NOT NULL,
+    outcome             TEXT    NOT NULL,           -- success | failure | skipped | partial
+    rows_attempted      INTEGER DEFAULT 0,
+    rows_pushed         INTEGER DEFAULT 0,
+    rows_failed         INTEGER DEFAULT 0,
+    duration_ms         INTEGER,
+    error_code          TEXT,
+    error_message       TEXT,
+    http_status         INTEGER,
+    bytes_transferred   INTEGER
+);
+CREATE INDEX IF NOT EXISTS idx_sync_device  ON sync_log(device_id);
+CREATE INDEX IF NOT EXISTS idx_sync_outcome ON sync_log(outcome);
+```
+
+---
+
+## error_log
+
+Every caught exception and unhandled error with full stack trace.
+
+```sql
+CREATE TABLE IF NOT EXISTS error_log (
+    id                  INTEGER PRIMARY KEY AUTOINCREMENT,
+    device_id           TEXT    NOT NULL,
+    run_id              INTEGER REFERENCES runs(id),
+    severity            TEXT    NOT NULL,           -- debug | info | warning | error | critical
+    thread_name         TEXT,                       -- main | health_monitor | sync | camera
+    logger_name         TEXT,
+    module              TEXT,
+    function_name       TEXT,
+    line_number         INTEGER,
+    message             TEXT    NOT NULL,
+    exception_type      TEXT,
+    exception_message   TEXT,
+    stack_trace         TEXT,
+    context_json        TEXT,
+    occurred_at         TEXT    NOT NULL,
+    synced              INTEGER NOT NULL DEFAULT 0
+);
+CREATE INDEX IF NOT EXISTS idx_error_severity ON error_log(severity);
+CREATE INDEX IF NOT EXISTS idx_error_run      ON error_log(run_id);
+CREATE INDEX IF NOT EXISTS idx_error_synced   ON error_log(synced);
+```
+
+---
+
+## application_events
+
+Software lifecycle events — process start/stop, config changes, instrument connection.
+
+```sql
+CREATE TABLE IF NOT EXISTS application_events (
+    id                  INTEGER PRIMARY KEY AUTOINCREMENT,
+    device_id           TEXT    NOT NULL,
+    event_type          TEXT    NOT NULL,
+        -- app_start | app_stop | app_crash | watchdog_restart
+        -- thread_start | thread_stop | thread_crash | thread_restart
+        -- config_loaded | config_changed | firmware_updated
+        -- instrument_connected | instrument_disconnected
+        -- usb_inserted | usb_removed | kiosk_start | kiosk_stop | kiosk_crash
+    process_name        TEXT,
+    thread_name         TEXT,
+    firmware_version    TEXT,
+    config_key          TEXT,
+    config_old_value    TEXT,
+    config_new_value    TEXT,
+    detail              TEXT,
+    occurred_at         TEXT    NOT NULL,
+    synced              INTEGER NOT NULL DEFAULT 0
+);
+CREATE INDEX IF NOT EXISTS idx_appev_synced ON application_events(synced);
+```
+
+---
+
+## power_events
+
+Supply voltage readings, brownouts, battery state, and mains transitions.
+
+```sql
+CREATE TABLE IF NOT EXISTS power_events (
+    id                  INTEGER PRIMARY KEY AUTOINCREMENT,
+    device_id           TEXT    NOT NULL,
+    event_type          TEXT    NOT NULL,
+        -- power_on | power_off | brownout_detected | over_voltage
+        -- battery_low | battery_charging | battery_full | mains_lost | mains_restored
+    input_voltage_v     REAL,
+    rail_5v_v           REAL,
+    rail_3v3_v          REAL,
+    current_ma          REAL,
+    power_w             REAL,
+    battery_pct         REAL,
+    source              TEXT,                       -- mains | battery | poe
+    occurred_at         TEXT    NOT NULL,
+    synced              INTEGER NOT NULL DEFAULT 0
+);
+```
+
+---
+
+## gpio_events
+
+Physical hardware events — lid switch, e-stop, door latch, and other GPIO transitions.
+
+```sql
+CREATE TABLE IF NOT EXISTS gpio_events (
+    id                  INTEGER PRIMARY KEY AUTOINCREMENT,
+    device_id           TEXT    NOT NULL,
+    run_id              INTEGER REFERENCES runs(id),
+    pin_number          INTEGER,
+    pin_name            TEXT,                       -- "lid_switch" | "e_stop" | "door_latch"
+    event_type          TEXT    NOT NULL,           -- rising | falling | high | low
+    value               INTEGER,
+    occurred_at         TEXT    NOT NULL,
+    synced              INTEGER NOT NULL DEFAULT 0
+);
+```
+
+---
+
+## storage_health
+
+SD card and filesystem metrics including wear-level data where available.
+
+```sql
+CREATE TABLE IF NOT EXISTS storage_health (
+    id                  INTEGER PRIMARY KEY AUTOINCREMENT,
+    device_id           TEXT    NOT NULL,
+    filesystem          TEXT    NOT NULL,           -- "/" | "/boot" | "/data"
+    total_gb            REAL,
+    used_gb             REAL,
+    free_gb             REAL,
+    use_pct             REAL,
+    inode_total         INTEGER,
+    inode_used          INTEGER,
+    inode_free          INTEGER,
+    read_errors         INTEGER,
+    write_errors        INTEGER,
+    lifetime_writes_gb  REAL,
+    erase_count_avg     INTEGER,
+    erase_count_max     INTEGER,
+    bad_blocks          INTEGER,
+    health_pct          REAL,
+    sampled_at          TEXT    NOT NULL,
+    synced              INTEGER NOT NULL DEFAULT 0
+);
+```
+
+---
+
+## operator_actions
+
+Every human interaction via the kiosk or API — login, run control, settings changes.
+
+```sql
+CREATE TABLE IF NOT EXISTS operator_actions (
+    id                  INTEGER PRIMARY KEY AUTOINCREMENT,
+    device_id           TEXT    NOT NULL,
+    run_id              INTEGER REFERENCES runs(id),
+    operator_id         TEXT,
+    action              TEXT    NOT NULL,
+        -- login | logout | run_start | run_abort | run_pause | run_resume
+        -- protocol_selected | barcode_scanned | note_added
+        -- settings_changed | calibration_started | export_requested
+        -- emergency_stop | door_override
+    target              TEXT,
+    old_value           TEXT,
+    new_value           TEXT,
+    input_method        TEXT,                       -- touch | keyboard | barcode_scanner | api
+    occurred_at         TEXT    NOT NULL,
+    synced              INTEGER NOT NULL DEFAULT 0
+);
+CREATE INDEX IF NOT EXISTS idx_opact_run ON operator_actions(run_id);
+```
+
+---
+
+## alerts
+
+Threshold violations and system warnings, with acknowledgement tracking.
+
+```sql
+CREATE TABLE IF NOT EXISTS alerts (
+    id                  INTEGER PRIMARY KEY AUTOINCREMENT,
+    device_id           TEXT    NOT NULL,
+    run_id              INTEGER REFERENCES runs(id),
+    alert_type          TEXT    NOT NULL,
+        -- temp_overshoot | temp_undershoot | temp_sensor_fault
+        -- cpu_overheat | disk_full | ram_critical | battery_low
+        -- sync_lag | run_overdue | protocol_timeout
+        -- lid_open_during_run | unexpected_stop
+    severity            TEXT    NOT NULL,           -- info | warning | critical
+    well_id             TEXT,
+    sensor_index        INTEGER,
+    threshold_value     REAL,
+    actual_value        REAL,
+    message             TEXT    NOT NULL,
+    acknowledged        INTEGER DEFAULT 0,
+    acknowledged_by     TEXT,
+    acknowledged_at     TEXT,
+    auto_resolved       INTEGER DEFAULT 0,
+    resolved_at         TEXT,
+    triggered_at        TEXT    NOT NULL,
+    synced              INTEGER NOT NULL DEFAULT 0
+);
+CREATE INDEX IF NOT EXISTS idx_alerts_run      ON alerts(run_id);
+CREATE INDEX IF NOT EXISTS idx_alerts_severity ON alerts(severity);
+CREATE INDEX IF NOT EXISTS idx_alerts_synced   ON alerts(synced);
+```
+
+---
+
+## firmware_log
+
+Version history for every software component on the device.
+
+```sql
+CREATE TABLE IF NOT EXISTS firmware_log (
+    id                  INTEGER PRIMARY KEY AUTOINCREMENT,
+    device_id           TEXT    NOT NULL,
+    component           TEXT    NOT NULL,           -- "aquila_app" | "kiosk" | "pi_os" | "instrument_fw"
+    previous_version    TEXT,
+    new_version         TEXT    NOT NULL,
+    update_method       TEXT,                       -- "ota" | "manual" | "factory_flash"
+    update_source       TEXT,
+    checksum            TEXT,
+    update_status       TEXT    NOT NULL,           -- success | failed | rolled_back
+    error_message       TEXT,
+    applied_at          TEXT    NOT NULL,
+    synced              INTEGER NOT NULL DEFAULT 0
+);
+```
+
+---
+
+## process_health
+
+Per-thread liveness, heartbeat status, and loop timing metrics.
+
+```sql
+CREATE TABLE IF NOT EXISTS process_health (
+    id                  INTEGER PRIMARY KEY AUTOINCREMENT,
+    device_id           TEXT    NOT NULL,
+    thread_name         TEXT    NOT NULL,           -- main | health_monitor | sync | camera | watchdog
+    status              TEXT    NOT NULL,           -- alive | dead | hung | restarting
+    last_heartbeat_at   TEXT,
+    heartbeat_interval_s INTEGER,
+    missed_heartbeats   INTEGER DEFAULT 0,
+    cpu_pct             REAL,
+    memory_mb           REAL,
+    open_file_handles   INTEGER,
+    loop_latency_ms     REAL,
+    queue_depth         INTEGER,
+    sampled_at          TEXT    NOT NULL,
+    synced              INTEGER NOT NULL DEFAULT 0
+);
+```
+
+---
+
+## Useful Diagnostic Queries
+
+```sql
+-- How many rows are waiting to sync across all tables?
+SELECT 'thermal_readings'    AS tbl, COUNT(*) AS pending FROM thermal_readings    WHERE synced = 0
+UNION ALL
+SELECT 'fluorescence_readings',      COUNT(*) FROM fluorescence_readings      WHERE synced = 0
+UNION ALL
+SELECT 'run_results',                COUNT(*) FROM run_results                WHERE synced = 0
+UNION ALL
+SELECT 'pcr_qc_flags',               COUNT(*) FROM pcr_qc_flags               WHERE synced = 0
+UNION ALL
+SELECT 'device_health',              COUNT(*) FROM device_health              WHERE synced = 0
+UNION ALL
+SELECT 'error_log',                  COUNT(*) FROM error_log                  WHERE synced = 0;
+
+-- Why did a specific well go inconclusive?
+SELECT flag_code, severity, observed_value, threshold_value, direction, description
+FROM pcr_qc_flags
+WHERE result_id = ?
+ORDER BY severity DESC, flag_code;
+
+-- All hard QC failures across the fleet (Postgres side)
+SELECT device_id, run_id, well_id, target_name, flag_code, COUNT(*) AS occurrences
+FROM pcr_qc_flags
+WHERE severity = 'hard'
+GROUP BY device_id, flag_code
+ORDER BY occurrences DESC;
+
+-- Runs that had any errors during execution
+SELECT r.id, r.device_id, r.protocol_name, r.status, r.started_at,
+       COUNT(e.id) AS error_count
+FROM runs r
+LEFT JOIN error_log e ON e.run_id = r.id
+GROUP BY r.id
+HAVING error_count > 0;
+
+-- Device health during a specific run
+SELECT sampled_at, cpu_pct, cpu_temp_c, ram_pct, throttled
+FROM device_health
+WHERE run_id = ?
+ORDER BY sampled_at;
+```
+
+---
+
+## devices
+
+One record per physical instrument. Captures the assembly window and any device-level observations
+that apply to the unit as a whole rather than a specific part.
+
+```sql
+CREATE TABLE IF NOT EXISTS devices (
+    id                  TEXT    PRIMARY KEY,        -- serial number e.g. "SN03"
+    assembled_start     TEXT,                       -- ISO8601 date assembly began
+    assembled_end       TEXT,                       -- ISO8601 date assembly completed
+    assembly_technician TEXT,                       -- who assembled it
+    assembly_location   TEXT,                       -- lab or facility name
+    hw_revision         TEXT,                       -- hardware revision of this unit e.g. "rev_B"
+    notes               TEXT,                       -- device-level observations e.g. "screen flickers during recipe runs"
+    retired             INTEGER NOT NULL DEFAULT 0, -- 1 if unit is no longer in service
+    retired_at          TEXT,
+    retired_reason      TEXT,
+    synced              INTEGER NOT NULL DEFAULT 0,
+    created_at          TEXT    NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ','now')),
+    updated_at          TEXT    NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ','now'))
+);
+```
+
+---
+
+## parts
+
+Every component installed on a device. One row per part per installation event —
+if a part is replaced, the old row gets `removed_at` filled in and a new row is inserted.
+
+Series classification follows the AQU-XXXX numbering convention:
+- **2000s** — purchased components (LEDs, springs, o-rings)
+- **3000s** — custom machined and molded parts
+- **4000s** — electrical components and PCBs
+- **7000s** — purchased assemblies (motors, terminated sensors)
+
+```sql
+CREATE TABLE IF NOT EXISTS parts (
+    id                  TEXT    PRIMARY KEY,        -- UUID generated locally
+    device_id           TEXT    NOT NULL REFERENCES devices(id),
+    part_number         TEXT    NOT NULL,           -- e.g. "AQU-3003"
+    series              INTEGER NOT NULL,           -- 2000 | 3000 | 4000 | 7000
+    description         TEXT    NOT NULL,           -- full part description
+    material            TEXT,                       -- e.g. "Al 6061 (Black Anodized II)", "PTFE"
+    supplier_part_number TEXT,                      -- supplier catalog number e.g. "SP-05-B3", "TEC-1089-SV-PT100"
+    supplier_url        TEXT,                       -- link to supplier listing
+    quantity            INTEGER NOT NULL DEFAULT 1,
+    batch_number        TEXT,                       -- e.g. "Arete Provided", "Ours", "Ours at present"
+    date_received       TEXT,                       -- ISO8601
+    installed_at        TEXT,                       -- ISO8601 — when this instance was installed
+    removed_at          TEXT,                       -- ISO8601 — NULL if still installed
+    removal_reason      TEXT,                       -- "failed" | "replaced" | "upgraded" | "returned"
+    -- Condition and risk tracking
+    install_condition   TEXT,
+        -- "ok" | "slightly bent during assembly" | "had to cut screw ourselves"
+        -- free text — whatever the technician observed at install time
+    known_risk          INTEGER NOT NULL DEFAULT 0, -- 1 if note flags a potential future failure
+    known_risk_detail   TEXT,
+        -- e.g. "U7 may have been stressed and could fail in future"
+        -- e.g. "lid power connection is loose on the board and wobbling"
+        -- e.g. "motor sticks at home and must be physically pushed"
+    risk_resolved       INTEGER NOT NULL DEFAULT 0, -- 1 if the risk was later addressed
+    risk_resolved_at    TEXT,
+    risk_resolved_notes TEXT,
+    -- Who did what
+    installed_by        TEXT,
+    inspected_by        TEXT,
+    inspected_at        TEXT,
+    notes               TEXT,                       -- general free-text notes
+    synced              INTEGER NOT NULL DEFAULT 0,
+    created_at          TEXT    NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ','now')),
+    updated_at          TEXT    NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ','now'))
+);
+CREATE INDEX IF NOT EXISTS idx_parts_device      ON parts(device_id);
+CREATE INDEX IF NOT EXISTS idx_parts_number      ON parts(part_number);
+CREATE INDEX IF NOT EXISTS idx_parts_known_risk  ON parts(device_id, known_risk) WHERE known_risk = 1;
+CREATE INDEX IF NOT EXISTS idx_parts_installed   ON parts(device_id, removed_at);
+```
+
+### Useful parts queries
+
+```sql
+-- All currently installed parts on a device
+SELECT part_number, series, description, material, batch_number, installed_at, install_condition
+FROM parts
+WHERE device_id = 'SN03' AND removed_at IS NULL
+ORDER BY series, part_number;
+
+-- All active known risks across the fleet
+SELECT device_id, part_number, description, known_risk_detail, installed_at
+FROM parts
+WHERE known_risk = 1 AND risk_resolved = 0 AND removed_at IS NULL
+ORDER BY device_id, part_number;
+
+-- Part replacement history for a specific component
+SELECT device_id, installed_at, removed_at, removal_reason, install_condition, notes
+FROM parts
+WHERE part_number = 'AQU-4001'
+ORDER BY device_id, installed_at;
+
+-- All parts received on a given date
+SELECT device_id, part_number, description, batch_number, quantity
+FROM parts
+WHERE date_received = '2026-03-05'
+ORDER BY series, part_number;
+```

--- a/specs/Data-pipline/analytics-pipeline-prd.md
+++ b/specs/Data-pipline/analytics-pipeline-prd.md
@@ -1,0 +1,171 @@
+# PRD: Sentri Analytics Pipeline — Device-Side Data Collection
+
+## Problem Statement
+
+Aquilla runs PCR assays on Sentri devices deployed in the field. There is currently no way to observe how those devices are performing across the fleet. When a protocol produces a high rate of inconclusive results — meaning the analysis engine cannot determine Detected or Not Detected — there is no signal to investigate whether the issue is with the protocol configuration, a specific device, or a systemic problem. Run results exist only locally on each Sentri and are not collected or queryable in aggregate.
+
+## Solution
+
+Build an offline-first analytics data pipeline that collects a structured `run_complete` event from each Sentri after every assay, queues it locally in the existing SQLite event store, and syncs it periodically to an AWS-hosted ingest endpoint. On the cloud side, a Lambda function writes structured run and result records into a PostgreSQL database that can be queried directly with SQL.
+
+The first analytics capability enabled by this pipeline is **inconclusive rate by protocol**: the fraction of Well × Channel Calls with outcome `Inconclusive`, grouped by Protocol name, queryable across the fleet.
+
+## User Stories
+
+1. As a fleet operator, I want inconclusive rates aggregated by protocol, so that I can identify which assay protocols are producing unreliable results across all Sentri devices.
+2. As a fleet operator, I want inconclusive rates broken down per Sentri device, so that I can detect whether a single device is performing worse than the rest of the fleet.
+3. As a fleet operator, I want run data to be collected even when a Sentri is temporarily offline, so that I don't lose analytics history during connectivity gaps.
+4. As a fleet operator, I want the pipeline to retry failed syncs automatically, so that I don't have to manually intervene when a device loses internet mid-sync.
+5. As a fleet operator, I want each run's Cq values stored alongside the Call outcome, so that I can detect subtle reagent degradation or optical drift before it causes inconclusive calls.
+6. As a fleet operator, I want to identify which Sentri device produced each run result, so that I can correlate performance with device age, location, or firmware version.
+7. As a fleet operator, I want run timestamps in the cloud database, so that I can query trends over time (e.g., is the inconclusive rate increasing this month?).
+8. As a fleet operator, I want the analytics pipeline to not interfere with assay execution, so that a sync failure or cloud outage never blocks a run.
+9. As a fleet operator, I want the sync to happen automatically in the background, so that I don't need to manually trigger data uploads from each device.
+10. As a fleet operator, I want the sync to attempt upload after a WiFi reconnect, so that events collected during an offline period are flushed promptly when connectivity is restored.
+11. As a fleet operator, I want each device's identity to be stable across reimages and hostname changes, so that analytics history is not fragmented when a device is reconfigured.
+12. As a fleet operator, I want the cloud endpoint to be protected so that only authenticated Sentri devices can write run data.
+13. As a fleet operator, I want to be able to rotate the fleet authentication key without taking devices offline, so that key management doesn't disrupt operations.
+14. As a fleet operator, I want duplicate events (from a retry after a partial sync) to be ignored safely, so that run counts in the database are accurate.
+15. As a fleet operator, I want the number of calls per run and the protocol name stored together, so that I can compute inconclusive rate with a single SQL query without joining multiple sources.
+16. As a fleet operator, I want ROX Unavailable calls excluded from the inconclusive rate denominator, so that the metric reflects real analytical failures rather than hardware configuration choices.
+17. As a fleet operator, I want run abort events distinguished from completed runs, so that I can separately track abort rates without them skewing the inconclusive rate.
+18. As a data analyst, I want to query run results with plain SQL against a PostgreSQL database, so that I can write ad-hoc analytics without learning a specialized query interface.
+19. As a data analyst, I want one row per Well × Channel pair per Run in the results table, so that I can slice by well, channel, device, or protocol independently.
+20. As a data analyst, I want the device's human-readable name (dock name) available in the database alongside its hardware serial, so that query results are interpretable without a lookup table.
+
+## Implementation Decisions
+
+### Device Identity
+
+Each Sentri uses its Raspberry Pi hardware serial number (read from `/proc/cpuinfo` at startup) as its canonical Device ID. This is injected as the `AQ_SYNC_DEVICE_ID` environment variable and stored on every event. The hardware serial survives reimages and is globally unique. The existing hostname-based config key (`sn01`, `sn02`, etc.) continues to be used for hardware configuration lookup only and is not the analytics identifier. A human-readable `dock_name` (from `host_config.json`) is registered in a cloud-side `devices` table alongside the hardware serial.
+
+### Event Schema
+
+One `run_complete` event is emitted per completed Run. The payload is a JSON object containing:
+- `protocol`: the Protocol title string (the `title` field from the profile JSON)
+- `run_name`: the run label
+- `run_timestamp`: ISO-8601 UTC datetime when the run completed
+- `duration_seconds`: integer run duration
+- `aborted`: boolean; `true` if the run was stopped before completion
+- `calls`: an array of 8 objects, each with `{ well: int, channel: "fam"|"rox", call: "Detected"|"Not Detected"|"Inconclusive"|"ROX Unavailable", cq: float|null }`
+
+Aborted runs emit the event with `aborted: true` and empty `calls`. They are stored but excluded from inconclusive rate calculations.
+
+### Enqueue Point
+
+The event is enqueued inside the FastAPI `/history/append` endpoint handler, which is already called by the assay loop after every run (completed or aborted). At that point the handler has the protocol name, run name, and results file path. It loads the results JSON, transforms it into the `calls` array, and calls `enqueue_event('run_complete', payload)`. No changes to `state_run_assay.py` or the assay loop are required.
+
+### Local Queue
+
+The existing SQLite event queue (`local_db.py`) is used without schema changes. Events accumulate with `synced_at = NULL` and are retained for 7 days after successful sync. The queue handles offline accumulation transparently — the assay loop is unaffected by connectivity state.
+
+### Sync Schedule
+
+A new asyncio background task in the FastAPI app calls `sync_pending_events()` on a 15-minute interval, following the existing `_background_update_poller` pattern. A separate trigger fires on WiFi reconnect (detected via the kiosk control service's `/wifi/status` endpoint). Sync failures are silent — events remain in the queue and retry on the next interval.
+
+### AWS Ingest Architecture
+
+- **Ingest endpoint**: AWS API Gateway (HTTP API), single POST route receiving event batches
+- **Auth**: `x-api-key` header containing the Fleet API Key, validated by API Gateway's built-in usage plan — no custom Lambda auth logic
+- **Processing**: Lambda function receives the batch, validates structure, and upserts into RDS PostgreSQL using `ON CONFLICT DO NOTHING` for idempotency
+- **Storage**: RDS PostgreSQL `db.t4g.micro`, three tables (see schema below), flat (no partitioning), indefinite retention
+- **Query access**: Raw SQL via psql; no BI tool for v1
+
+IoT Core was evaluated and rejected: the connection management overhead and per-device certificate provisioning are not justified at <100 devices. See ADR-009.
+
+### PostgreSQL Schema
+
+Three tables:
+
+**`devices`** — one row per physical Sentri:
+- `device_id` (TEXT PK) — RPi hardware serial
+- `dock_name` (TEXT) — human-readable label from `host_config.json`
+- `registered_at` (TIMESTAMPTZ)
+
+**`runs`** — one row per Run:
+- `run_id` (UUID PK, generated by Lambda)
+- `device_id` (TEXT FK → devices)
+- `protocol` (TEXT)
+- `run_name` (TEXT)
+- `run_timestamp` (TIMESTAMPTZ) — indexed
+- `duration_seconds` (INTEGER)
+- `aborted` (BOOLEAN)
+- `received_at` (TIMESTAMPTZ)
+
+**`run_results`** — one row per Well × Channel per Run:
+- `result_id` (BIGSERIAL PK)
+- `run_id` (UUID FK → runs)
+- `device_id` (TEXT)
+- `protocol` (TEXT) — denormalized for query convenience
+- `well` (SMALLINT, 1–4)
+- `channel` (TEXT, `fam` or `rox`)
+- `call` (TEXT)
+- `cq` (NUMERIC(6,2), nullable)
+- `run_timestamp` (TIMESTAMPTZ) — denormalized, indexed
+
+Unique constraint on `(run_id, well, channel)` for idempotency.
+
+### Authentication and Key Rotation
+
+A single shared Fleet API Key is stored as `AQ_SYNC_API_KEY` on each Sentri. It is sent as an `x-api-key` HTTP header on every sync request. Rotation procedure: generate a new key in API Gateway, push `AQ_SYNC_API_KEY` to all reachable devices via a Tailscale SSH fleet script, wait 24 hours for offline devices to reconnect and receive the update, then retire the old key in API Gateway.
+
+### Inconclusive Rate Query
+
+The primary analytics query:
+
+```sql
+SELECT
+    protocol,
+    COUNT(*) FILTER (WHERE call = 'Inconclusive') AS inconclusive_count,
+    COUNT(*) FILTER (WHERE call != 'ROX Unavailable') AS eligible_count,
+    ROUND(
+        COUNT(*) FILTER (WHERE call = 'Inconclusive')::numeric /
+        NULLIF(COUNT(*) FILTER (WHERE call != 'ROX Unavailable'), 0),
+        4
+    ) AS inconclusive_rate
+FROM run_results
+WHERE aborted = false  -- joined from runs
+GROUP BY protocol
+ORDER BY inconclusive_rate DESC;
+```
+
+## Testing Decisions
+
+**What makes a good test here:** Tests should assert observable external behavior — what ends up in the SQLite queue and what gets sent over the wire — not implementation details like which internal function was called. Tests should not mock the SQLite database; use a real in-memory or temp-file SQLite. The sync HTTP call should be mocked.
+
+### Modules to test
+
+**`/history/append` endpoint — enqueue behavior (contract test)**
+Test that after a successful POST to `/history/append` with a valid results file, the SQLite event queue contains exactly one `run_complete` event with the correct `protocol`, correct number of `calls` entries (8), and correct `call` values matching the results file. Test the aborted case produces an event with `aborted: true` and empty `calls`. Prior art: `tests/contract/` using the FastAPI test client via `httpx`.
+
+**`sync_pending_events()` — sync behavior (unit test)**
+Test that pending events are POSTed to the configured endpoint with the correct shape (`device_id` at top level, `events` array), that events are marked `synced_at` on HTTP 200, and that events remain unsynced on HTTP 500 or connection error. Use `responses` or `httpx` mock transport for the HTTP call.
+
+**`local_db` queue — idempotency (unit test)**
+Test that `cleanup_synced_events()` removes events older than the retention window and leaves recent ones. Test that `mark_event_synced` with an empty list is a no-op.
+
+**Lambda handler — upsert behavior (unit test)**
+Test that a valid batch inserts rows into `run_results`, that a duplicate batch (same `run_id`, `well`, `channel`) does not duplicate rows, and that an aborted run inserts a `runs` row with `aborted = true` and zero `run_results` rows.
+
+**Device ID extraction (unit test)**
+Test that the RPi serial extraction from `/proc/cpuinfo` returns the expected string, and that a missing file falls back gracefully (e.g., returns hostname).
+
+## Out of Scope
+
+- **Operator identity / login**: No user authentication on the Sentri; runs are attributed to a device, not a named operator. Operator-level analytics is a future phase.
+- **Device utilization metrics**: CPU, RAM, disk, and temperature telemetry are not collected in v1. See `docs/local-db-schema.md` for the future schema.
+- **Real-time alerting**: No CloudWatch alarms or SNS notifications in v1. Monitoring is pull-based (run a SQL query).
+- **BI tool or dashboard**: Raw SQL access via psql only for v1.
+- **Per-device API keys**: Shared fleet key only for v1. Per-device keys or mTLS are a future security hardening option.
+- **Raw fluorescence data**: The optics log files (per-cycle RFU readings) are not synced. Only the final calls and Cq values are collected.
+- **IoT Core**: Explicitly out of scope until fleet exceeds 500 devices (see ADR-009).
+- **S3 / Athena data lake**: Out of scope for v1; revisit if query volume outgrows RDS.
+- **Sync from the assay loop process**: All event emission happens in the FastAPI web process. The assay loop (`state_run_assay.py`) is not modified.
+
+## Further Notes
+
+- The existing `cloud_db.py` module contains a partial PostgreSQL integration (`psycopg`, bulk insert with `ON CONFLICT DO NOTHING`). The Lambda function can adopt this idempotency pattern directly.
+- The existing `AQ_SYNC_ENDPOINT`, `AQ_SYNC_DEVICE_ID`, `AQ_SYNC_BATCH_SIZE`, and `AQ_SYNC_TIMEOUT_SECONDS` env vars are the complete device-side configuration surface. The new `AQ_SYNC_API_KEY` is the only addition.
+- Devices that have never synced will have a backlog in SQLite. On first successful sync after pipeline deployment, the Lambda should handle potentially large initial batches gracefully (the existing 100-event batch size cap in `sync.py` limits per-request size).
+- See `CONTEXT.md` for the canonical analytics domain glossary.
+- See `docs/adr/ADR-009-analytics-ingest-api-gateway-lambda.md` for the architecture decision record covering the API Gateway + Lambda choice.

--- a/specs/local-db-spec.md
+++ b/specs/local-db-spec.md
@@ -1,0 +1,651 @@
+# SENTRI Local SQLite — DB Layer Spec
+
+**Schema reference:** [local-db-schema.md](../docs/local-db-schema.md)
+
+This document specifies the Python database access layer that sits between the instrument
+code and the local SQLite file. It covers initialization, one write function per table,
+the sync handoff, and implementation priority order.
+
+---
+
+## Overview
+
+```
+Instrument code          DB layer (this spec)       SQLite file
+─────────────────        ────────────────────       ──────────────────────
+meerstetter.py      ──►  insert_thermal_reading()  ──►  /data/db/app.db
+thermal_engine.py   ──►  insert_heater_command()
+adc_class.py        ──►  insert_fluorescence()
+hw_api.py           ──►  insert_run() / close_run()
+background threads  ──►  insert_device_health()
+                         insert_error()
+                         insert_network_event()
+                         ...                        ──►  sync thread  ──►  Postgres
+```
+
+The entire DB layer lives in one module: `src/local_db.py`.
+All functions accept plain Python values (no ORM objects).
+All timestamps are ISO8601 UTC strings: `datetime.utcnow().strftime("%Y-%m-%dT%H:%M:%S.%f")[:-3] + "Z"`.
+
+---
+
+## 1. Setup and Initialization
+
+### File location
+
+| Environment | Path |
+|---|---|
+| Pi (production) | `/data/db/app.db` |
+| Dev / CI | `$LOCAL_DB_PATH` env var, defaults to `data/db/app.db` |
+
+### `init_db(path=None) -> sqlite3.Connection`
+
+Called once at application startup. Creates all tables if they do not exist, enables WAL
+mode, and returns a connection that is shared across threads.
+
+```python
+def init_db(path: str = None) -> sqlite3.Connection:
+    db_path = path or os.environ.get("LOCAL_DB_PATH", "data/db/app.db")
+    os.makedirs(os.path.dirname(db_path), exist_ok=True)
+    conn = sqlite3.connect(db_path, check_same_thread=False)
+    conn.execute("PRAGMA journal_mode=WAL")
+    conn.execute("PRAGMA foreign_keys=ON")
+    _create_tables(conn)
+    return conn
+```
+
+`_create_tables(conn)` runs every `CREATE TABLE IF NOT EXISTS` statement from the schema.
+Because of `IF NOT EXISTS`, this is safe to call on an existing database — it is a no-op
+if the tables are already there.
+
+### Thread safety
+
+One connection is created at startup and passed to all threads. WAL mode allows concurrent
+reads during writes. A single `threading.Lock` (`_write_lock`) is acquired before any
+`INSERT` or `UPDATE`. Reads do not need the lock.
+
+```python
+_write_lock = threading.Lock()
+```
+
+---
+
+## 2. Write Endpoints
+
+Each function below takes the specific values needed for that table, acquires `_write_lock`,
+executes the `INSERT`, releases the lock, and returns the new row `id`.
+
+---
+
+### `insert_run`
+
+Called when a run starts. Returns `run_id` which is passed to all subsequent inserts.
+
+```python
+def insert_run(
+    conn,
+    device_id: str,
+    protocol_name: str,
+    protocol_version: str = None,
+    operator_id: str = None,
+    plate_barcode: str = None,
+    sample_count: int = None,
+    total_cycles: int = None,
+    notes: str = None,
+) -> int
+```
+
+**Called from:** `hw_api.py:DockInterface` — replace `generate_runid()` with this.
+**Returns:** integer `run_id` used as foreign key in all other tables.
+
+---
+
+### `update_run_status`
+
+Called when a run completes, aborts, or errors.
+
+```python
+def update_run_status(
+    conn,
+    run_id: int,
+    status: str,               # "completed" | "aborted" | "error"
+    cycles_completed: int = None,
+    abort_reason: str = None,
+) -> None
+```
+
+---
+
+### `insert_thermal_reading`
+
+Called inside `meerstetter.py:log()` on every polling loop iteration, once per channel.
+
+```python
+def insert_thermal_reading(
+    conn,
+    run_id: int,
+    device_id: str,
+    well_id: str,
+    thermocouple_index: int,
+    temperature_c: float,
+    setpoint_c: float = None,
+    cycle_number: int = None,
+    stage: str = None,
+    stage_elapsed_ms: int = None,
+    run_elapsed_ms: int = None,
+    sampled_at: str = None,     # ISO8601 UTC — defaults to now if omitted
+) -> int
+```
+
+**Called from:** `meerstetter.py:log()` — add a call here alongside the existing `print()`.
+**Volume:** high — every ~50ms during a run. Use `executemany` if batching multiple channels.
+
+---
+
+### `insert_heater_command`
+
+Called every time a setpoint or ramp rate is sent to the Meerstetter.
+
+```python
+def insert_heater_command(
+    conn,
+    run_id: int,
+    device_id: str,
+    heater_zone: str,           # "lid" | "block_top" | "block_bottom"
+    setpoint_c: float,
+    ramp_rate_c_per_s: float = None,
+    hold_duration_ms: int = None,
+) -> int
+```
+
+**Called from:** `thermal_engine.py` — add calls at the `meer.change_setpoint()` and
+`meer.change_ramprate()` lines.
+
+---
+
+### `insert_pcr_cycle_stage`
+
+Called at the start of each ramp/hold stage from the thermal parser output.
+
+```python
+def insert_pcr_cycle_stage(
+    conn,
+    run_id: int,
+    device_id: str,
+    cycle_number: int,
+    stage: str,                 # "denature" | "anneal" | "extend" | "hold" | "ramp"
+    target_temp_c: float,
+    actual_start_temp_c: float = None,
+    stage_started_at: str = None,
+) -> int
+```
+
+`close_pcr_cycle_stage(conn, stage_id, stage_ended_at, overshoot_c)` fills in the
+end time and overshoot once the stage completes.
+
+**Called from:** `thermal_engine.py` — at the top of each `if name == "hold":` /
+`elif name == "ramp":` branch.
+
+---
+
+### `insert_fluorescence_reading`
+
+Called in `adc_class.py:OpticalRead` after each ADC conversion, replacing the current
+`print_result()` stdout output.
+
+```python
+def insert_fluorescence_reading(
+    conn,
+    run_id: int,
+    device_id: str,
+    well_id: str,
+    cycle_number: int,
+    channel: str,               # "FAM" | "HEX" | "ROX"
+    raw_rfu: float,
+    led_power_pct: float = None,
+    integration_time_ms: int = None,
+    gain: float = None,
+    measured_at: str = None,
+) -> int
+```
+
+**Called from:** `adc_class.py:capture_blink()` — replace or supplement `print_result()`.
+
+---
+
+### `insert_run_event`
+
+Called at any state transition or notable moment during a run.
+
+```python
+def insert_run_event(
+    conn,
+    run_id: int,
+    device_id: str,
+    event_type: str,
+    cycle_number: int = None,
+    stage: str = None,
+    detail: str = None,         # free text or JSON string
+) -> int
+```
+
+**Called from:** `thermal_engine.py` at run start/stop/abort, cycle boundaries, lid events.
+
+---
+
+### `insert_run_result`
+
+Called once per well per target after the analysis module produces a call.
+
+```python
+def insert_run_result(
+    conn,
+    run_id: int,
+    device_id: str,
+    well_id: str,
+    target_name: str,
+    channel: str,
+    call: str,                  # "positive" | "negative" | "inconclusive" | "invalid"
+    cq: float = None,
+    r_squared: float = None,
+    efficiency_pct: float = None,
+    baseline_rfu: float = None,
+    end_rfu: float = None,
+    delta_rfu: float = None,
+    relative_drop: float = None,
+    slope: float = None,
+    flag_count: int = 0,
+    inconclusive: int = 0,
+    analysis_version: str = None,
+    analyzed_at: str = None,
+) -> int
+```
+
+**Called from:** PCR analysis module (to be built). Returns `result_id` needed by
+`insert_qc_flag`.
+
+---
+
+### `insert_qc_flag`
+
+Called once per failed QC check, linked to a `result_id`.
+
+```python
+def insert_qc_flag(
+    conn,
+    run_id: int,
+    result_id: int,
+    device_id: str,
+    well_id: str,
+    target_name: str,
+    flag_code: str,             # see flag_code list in schema doc
+    flag_category: str,
+    severity: str,              # "hard" | "soft"
+    observed_value: float = None,
+    threshold_value: float = None,
+    direction: str = None,
+    description: str = None,
+    analysis_module: str = None,
+    analysis_version: str = None,
+) -> int
+```
+
+---
+
+### `insert_device_health`
+
+Called by the background health monitor thread every ~30 seconds.
+
+```python
+def insert_device_health(
+    conn,
+    device_id: str,
+    run_id: int = None,         # None when idle
+    cpu_pct: float = None,
+    cpu_temp_c: float = None,
+    ram_pct: float = None,
+    ram_used_mb: float = None,
+    disk_pct: float = None,
+    disk_free_gb: float = None,
+    gpu_temp_c: float = None,
+    throttled: int = None,
+    under_voltage: int = None,
+    uptime_seconds: int = None,
+    sampled_at: str = None,
+) -> int
+```
+
+**Requires:** `psutil` for CPU/RAM. `vcgencmd measure_temp` or `/sys/class/thermal` for
+board temp. `vcgencmd get_throttled` for throttle flags.
+**New subsystem needed:** `src/health_monitor.py` — a daemon thread that calls this on a
+30s interval.
+
+---
+
+### `insert_thermocouple_diagnostic`
+
+Called at startup, before each run, and on any serial fault.
+
+```python
+def insert_thermocouple_diagnostic(
+    conn,
+    device_id: str,
+    thermocouple_index: int,
+    well_id: str = None,
+    fault_code: int = None,
+    fault_description: str = None,   # "ok" | "open circuit" | "short to VCC" | "short to GND"
+    cold_junction_c: float = None,
+    reference_voltage: float = None,
+    offset_applied_c: float = None,
+    passed_selftest: int = None,
+) -> int
+```
+
+**Called from:** `meerstetter.py` — in the `except SerialException` block and on a
+pre-run self-check call.
+
+---
+
+### `insert_network_event`
+
+Called by a network monitor whenever interface state changes.
+
+```python
+def insert_network_event(
+    conn,
+    device_id: str,
+    event_type: str,            # "connected" | "disconnected" | "ip_changed" etc.
+    interface: str = None,
+    ssid: str = None,
+    ip_address: str = None,
+    signal_dbm: int = None,
+    reason_text: str = None,
+) -> int
+```
+
+**New subsystem needed:** `src/network_monitor.py` — polls `ip link` / `iwconfig` or
+listens to NetworkManager D-Bus signals.
+
+---
+
+### `insert_sync_log`
+
+Called by the sync thread after every attempt, whether it succeeded or failed.
+
+```python
+def insert_sync_log(
+    conn,
+    device_id: str,
+    target: str,                # "postgres"
+    outcome: str,               # "success" | "failure" | "skipped" | "partial"
+    rows_attempted: int = 0,
+    rows_pushed: int = 0,
+    rows_failed: int = 0,
+    duration_ms: int = None,
+    error_message: str = None,
+    http_status: int = None,
+    bytes_transferred: int = None,
+) -> int
+```
+
+**Called from:** `aquila_web/sync.py` — wrap the existing `sync_pending_events()` call
+to record the outcome here.
+
+---
+
+### `insert_error`
+
+Called from a custom logging handler that intercepts the Python `logging` module.
+
+```python
+def insert_error(
+    conn,
+    device_id: str,
+    severity: str,              # "debug" | "info" | "warning" | "error" | "critical"
+    message: str,
+    run_id: int = None,
+    thread_name: str = None,
+    module: str = None,
+    function_name: str = None,
+    line_number: int = None,
+    exception_type: str = None,
+    exception_message: str = None,
+    stack_trace: str = None,
+) -> int
+```
+
+**How to wire it:** add a `SQLiteHandler(logging.Handler)` subclass that calls
+`insert_error()` in its `emit()` method and attach it to the root logger in
+`utils.py:LOGGING_CONFIG`. This captures every `logger.error()` / `logger.critical()`
+call site without changing any of them.
+
+---
+
+### `insert_application_event`
+
+```python
+def insert_application_event(
+    conn,
+    device_id: str,
+    event_type: str,
+    process_name: str = None,
+    thread_name: str = None,
+    firmware_version: str = None,
+    detail: str = None,
+) -> int
+```
+
+---
+
+### `insert_alert`
+
+```python
+def insert_alert(
+    conn,
+    device_id: str,
+    alert_type: str,
+    severity: str,              # "info" | "warning" | "critical"
+    message: str,
+    run_id: int = None,
+    well_id: str = None,
+    threshold_value: float = None,
+    actual_value: float = None,
+) -> int
+```
+
+`acknowledge_alert(conn, alert_id, acknowledged_by)` and
+`resolve_alert(conn, alert_id)` update the existing row.
+
+---
+
+### `insert_gpio_event`
+
+```python
+def insert_gpio_event(
+    conn,
+    device_id: str,
+    pin_name: str,              # "lid_switch" | "e_stop" | "door_latch"
+    event_type: str,            # "rising" | "falling"
+    value: int,
+    run_id: int = None,
+    pin_number: int = None,
+) -> int
+```
+
+**Called from:** `hw_api.py` GPIO interrupt callbacks.
+
+---
+
+### `insert_storage_health`
+
+```python
+def insert_storage_health(
+    conn,
+    device_id: str,
+    filesystem: str,
+    total_gb: float,
+    used_gb: float,
+    free_gb: float,
+    use_pct: float,
+    read_errors: int = None,
+    write_errors: int = None,
+) -> int
+```
+
+---
+
+### `insert_operator_action`
+
+```python
+def insert_operator_action(
+    conn,
+    device_id: str,
+    action: str,
+    run_id: int = None,
+    operator_id: str = None,
+    target: str = None,
+    old_value: str = None,
+    new_value: str = None,
+    input_method: str = None,
+) -> int
+```
+
+---
+
+### `insert_firmware_log`
+
+```python
+def insert_firmware_log(
+    conn,
+    device_id: str,
+    component: str,             # "aquila_app" | "kiosk" | "pi_os" | "instrument_fw"
+    new_version: str,
+    update_status: str,         # "success" | "failed" | "rolled_back"
+    previous_version: str = None,
+    update_method: str = None,
+    error_message: str = None,
+) -> int
+```
+
+---
+
+### `insert_process_health`
+
+```python
+def insert_process_health(
+    conn,
+    device_id: str,
+    thread_name: str,
+    status: str,                # "alive" | "dead" | "hung" | "restarting"
+    last_heartbeat_at: str = None,
+    missed_heartbeats: int = 0,
+    loop_latency_ms: float = None,
+    cpu_pct: float = None,
+    memory_mb: float = None,
+) -> int
+```
+
+---
+
+## 3. Read / Query Endpoints
+
+These are used by the sync thread and the kiosk UI.
+
+```python
+def get_unsynced_rows(conn, table: str, limit: int = 500) -> list[dict]
+    # SELECT * FROM {table} WHERE synced = 0 LIMIT {limit}
+
+def mark_synced(conn, table: str, ids: list[int]) -> None
+    # UPDATE {table} SET synced = 1 WHERE id IN (...)
+
+def get_run(conn, run_id: int) -> dict
+
+def get_run_results(conn, run_id: int) -> list[dict]
+
+def get_qc_flags_for_result(conn, result_id: int) -> list[dict]
+
+def get_active_alerts(conn, device_id: str) -> list[dict]
+    # WHERE acknowledged = 0 AND auto_resolved = 0
+
+def get_pending_sync_count(conn) -> dict
+    # Returns {table_name: unsynced_row_count} for all tables
+```
+
+---
+
+## 4. Sync Thread Integration
+
+The sync thread in `aquila_web/sync.py` currently pushes a single `events` table.
+With the new schema, it iterates over all syncable tables:
+
+```python
+SYNCABLE_TABLES = [
+    "runs", "thermal_readings", "heater_commands", "pcr_cycle_stages",
+    "fluorescence_readings", "run_events", "run_results", "pcr_qc_flags",
+    "device_health", "thermocouple_diagnostics", "calibration_records",
+    "network_events", "error_log", "application_events", "power_events",
+    "gpio_events", "storage_health", "operator_actions", "alerts",
+    "firmware_log", "process_health",
+]
+
+def sync_cycle(conn, pg_conn):
+    for table in SYNCABLE_TABLES:
+        rows = get_unsynced_rows(conn, table, limit=500)
+        if not rows:
+            continue
+        try:
+            push_to_postgres(pg_conn, table, rows)
+            mark_synced(conn, table, [r["id"] for r in rows])
+            insert_sync_log(conn, ..., outcome="success", rows_pushed=len(rows))
+        except Exception as e:
+            insert_sync_log(conn, ..., outcome="failure", error_message=str(e))
+```
+
+`runs` must always be synced before any table that references `run_id`, so keep it first
+in `SYNCABLE_TABLES`.
+
+---
+
+## 5. Implementation Priority
+
+### Phase 1 — Wire existing data sources (no new subsystems)
+
+These tables have data in memory right now. They just need the DB layer inserted.
+
+| Priority | Table | Change needed |
+|---|---|---|
+| 1 | `runs` | Replace `generate_runid()` in `hw_api.py` with `insert_run()` |
+| 2 | `thermal_readings` | Add `insert_thermal_reading()` call inside `meerstetter.py:log()` |
+| 3 | `heater_commands` | Add inserts at `change_setpoint()` / `change_ramprate()` in `thermal_engine.py` |
+| 4 | `pcr_cycle_stages` | Add inserts at stage transitions in `thermal_engine.py` |
+| 5 | `fluorescence_readings` | Add inserts in `adc_class.py:capture_blink()` |
+| 6 | `run_events` | Add inserts at run start/stop/abort and cycle boundaries |
+| 7 | `error_log` | Add `SQLiteHandler` to root logger in `utils.py` |
+
+### Phase 2 — New background subsystems
+
+| Priority | Table | New file needed |
+|---|---|---|
+| 8 | `device_health` | `src/health_monitor.py` — `psutil` daemon thread, 30s interval |
+| 9 | `thermocouple_diagnostics` | Pre-run self-check in `meerstetter.py` |
+| 10 | `network_events` | `src/network_monitor.py` — poll interface state |
+| 11 | `process_health` | Watchdog heartbeat per thread |
+| 12 | `sync_log` | Wrap `aquila_web/sync.py` outcome recording |
+
+### Phase 3 — Requires new analytical modules
+
+| Priority | Table | Depends on |
+|---|---|---|
+| 13 | `run_results` | PCR analysis module (curve fitting, Cq calling) |
+| 14 | `pcr_qc_flags` | Same analysis module |
+| 15 | `calibration_records` | Calibration workflow UI + logic |
+| 16 | `alerts` | Alert threshold engine |
+
+### Phase 4 — Manual / operational data entry
+
+| Priority | Table | Notes |
+|---|---|---|
+| 17 | `devices` | One-time insert per unit at assembly |
+| 18 | `parts` | Entered at assembly, updated on part replacement |
+| 19 | `operator_actions` | Wire to kiosk UI events |
+| 20 | `firmware_log` | Insert on OTA update completion |

--- a/tests/unit/test_device_id.py
+++ b/tests/unit/test_device_id.py
@@ -1,0 +1,62 @@
+import os
+import pytest
+
+from aq_lib.device_id import inject_hw_serial_env, read_rpi_serial
+
+CPUINFO_WITH_SERIAL = (
+    "processor\t: 0\n"
+    "model name\t: ARMv7 Processor rev 4 (v7l)\n"
+    "Hardware\t: BCM2711\n"
+    "Revision\t: b03115\n"
+    "Serial\t\t: 10000000a6b7d43e\n"
+    "Model\t: Raspberry Pi 4 Model B Rev 1.5\n"
+)
+
+CPUINFO_NO_SERIAL = (
+    "processor\t: 0\n"
+    "model name\t: x86_64\n"
+    "vendor_id\t: GenuineIntel\n"
+)
+
+CPUINFO_ZERO_SERIAL = "Serial\t\t: 0000000000000000\n"
+
+
+class TestReadRpiSerial:
+    def test_parses_serial_from_cpuinfo(self, tmp_path):
+        f = tmp_path / "cpuinfo"
+        f.write_text(CPUINFO_WITH_SERIAL)
+        assert read_rpi_serial(str(f)) == "10000000a6b7d43e"
+
+    def test_returns_none_when_serial_line_absent(self, tmp_path):
+        f = tmp_path / "cpuinfo"
+        f.write_text(CPUINFO_NO_SERIAL)
+        assert read_rpi_serial(str(f)) is None
+
+    def test_returns_none_for_all_zero_serial(self, tmp_path):
+        f = tmp_path / "cpuinfo"
+        f.write_text(CPUINFO_ZERO_SERIAL)
+        assert read_rpi_serial(str(f)) is None
+
+    def test_returns_none_when_file_missing(self, tmp_path):
+        assert read_rpi_serial(str(tmp_path / "nonexistent")) is None
+
+
+class TestInjectHwSerialEnv:
+    def test_sets_aq_sync_device_id_from_hardware_serial(self, tmp_path, monkeypatch):
+        monkeypatch.delenv("AQ_SYNC_DEVICE_ID", raising=False)
+        f = tmp_path / "cpuinfo"
+        f.write_text(CPUINFO_WITH_SERIAL)
+        inject_hw_serial_env(str(f))
+        assert os.environ["AQ_SYNC_DEVICE_ID"] == "10000000a6b7d43e"
+
+    def test_does_not_overwrite_existing_env_var(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("AQ_SYNC_DEVICE_ID", "manually-set-id")
+        f = tmp_path / "cpuinfo"
+        f.write_text(CPUINFO_WITH_SERIAL)
+        inject_hw_serial_env(str(f))
+        assert os.environ["AQ_SYNC_DEVICE_ID"] == "manually-set-id"
+
+    def test_noop_when_serial_cannot_be_read(self, tmp_path, monkeypatch):
+        monkeypatch.delenv("AQ_SYNC_DEVICE_ID", raising=False)
+        inject_hw_serial_env(str(tmp_path / "nonexistent"))
+        assert "AQ_SYNC_DEVICE_ID" not in os.environ


### PR DESCRIPTION
## Summary

- Adds `aq_lib/device_id.py` with two public functions: `read_rpi_serial()` parses the hardware serial from `/proc/cpuinfo`, and `inject_hw_serial_env()` sets `AQ_SYNC_DEVICE_ID` in the process environment at startup
- Wires `inject_hw_serial_env()` into the FastAPI startup event in `aquila_web/main.py` so it runs once per container start (once per device boot)
- Existing consumers (`local_db.enqueue_event` and `sync.sync_pending_events`) already read `AQ_SYNC_DEVICE_ID` — no changes needed there

**Priority order at runtime:**
1. Explicit `AQ_SYNC_DEVICE_ID` in `device.env` — never overwritten
2. Hardware serial from `/proc/cpuinfo` — injected automatically on real Pi hardware
3. `DEVICE_ID` fallback — existing behaviour unchanged

Closes #132

## Test plan

- [ ] `pytest tests/unit/test_device_id.py -v` — 7 unit tests, no hardware required, all pass in CI
- [ ] Full unit suite: `pytest tests/unit/ -v` — 228 passed, zero regressions
- [ ] On real Pi: confirm `AQ_SYNC_DEVICE_ID` is set to the board serial after container start (`docker exec <container> printenv AQ_SYNC_DEVICE_ID`)
- [ ] With explicit `AQ_SYNC_DEVICE_ID=my-id` in `device.env`: confirm value is not overwritten

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)