### PR TITLE
feat: emit run_complete event into SQLite queue on run completion

### DIFF
--- a/aq_lib/state_requests.py
+++ b/aq_lib/state_requests.py
@@ -106,6 +106,14 @@ def advance_run_name():
     except requests.exceptions.RequestException as e:
         logger.exception("Error advancing run name: %s", e)
 
+def emit_run_complete(run_name: str, profile: str, results_path: str) -> None:
+    url = f"{BACKEND_URL}/events/run_complete"
+    payload = {"run_name": run_name, "profile": profile, "results_path": results_path}
+    try:
+        requests.post(url, json=payload, timeout=5)
+    except requests.exceptions.RequestException as e:
+        logger.exception("Error emitting run_complete event: %s", e)
+
 def reset_exit():
     try:
         requests.post(f"{BACKEND_URL}/exit/reset", timeout=5)

--- a/aquila_web/main.py
+++ b/aquila_web/main.py
@@ -1,5 +1,6 @@
 from fastapi import FastAPI, Form, Body, HTTPException, Query
 from aq_lib.device_id import inject_hw_serial_env
+from aquila_web.local_db import enqueue_event, init_local_db
 from fastapi.responses import FileResponse, RedirectResponse, JSONResponse
 from fastapi.staticfiles import StaticFiles
 from pathlib import Path
@@ -476,6 +477,11 @@ async def _simulate_run(profile_name: str) -> None:
         "tube_names": current_tube_names
     })
     _save_history(history)
+    init_local_db()
+    enqueue_event(
+        "run_complete",
+        {"run_name": run_name, "profile": profile_name, "result": detected_summary},
+    )
 
     current_item.screen = "complete"
     state_change_event.set()
@@ -615,6 +621,23 @@ async def reset_run_complete_ack():
     global run_complete_ack
     run_complete_ack = False
     return {"ok": True}
+
+
+class _RunCompleteEventRequest(BaseModel):
+    run_name: str
+    profile: str
+    results_path: Optional[str] = None
+
+
+@app.post("/events/run_complete")
+async def events_run_complete(req: _RunCompleteEventRequest):
+    init_local_db()
+    result = _summarize_results_from_file(Path(req.results_path)) if req.results_path else ""
+    event_id = enqueue_event(
+        "run_complete",
+        {"run_name": req.run_name, "profile": req.profile, "result": result},
+    )
+    return {"ok": True, "event_id": event_id}
 
 @app.get("/results/get_path")
 async def get_path():

--- a/state_run_assay.py
+++ b/state_run_assay.py
@@ -282,7 +282,9 @@ class AssayInterface():
                     graph_path = f"/plots/{plot_filename}"
                 except Exception as e:
                     logger.error("Failed to generate plot: %s", e)
-                sr.log_history(self.thermal_profile.replace("profiles/", ""), self.run_name, results_json, graph_path)
+                profile_name = self.thermal_profile.replace("profiles/", "")
+                sr.log_history(profile_name, self.run_name, results_json, graph_path)
+                sr.emit_run_complete(self.run_name, profile_name, str(results_json))
                 sr.advance_run_name()
                 sr.change_screen("3")
 

--- a/tests/unit/test_run_complete_event.py
+++ b/tests/unit/test_run_complete_event.py
@@ -1,0 +1,101 @@
+"""
+Unit tests for run_complete event emission into the SQLite queue.
+
+Behaviors tested:
+  1. POST /events/run_complete enqueues exactly one run_complete event
+  2. Event payload contains run_name and profile
+  3. Event payload includes a non-empty result field
+  4. state_requests.emit_run_complete() posts to the correct endpoint
+"""
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock
+
+# serial is a hardware-only package not installed in CI; stub it so that
+# aq_lib.state_requests (which transitively imports config_module) can be
+# imported without a physical device present.
+for _hw_mod in ("serial", "serial.tools", "serial.tools.list_ports"):
+    sys.modules.setdefault(_hw_mod, MagicMock())
+
+# config_module.Config reads a hardware-specific host_config.json that maps
+# device hostnames to hardware settings — not present on dev machines.
+# Stub the whole module so Config() construction doesn't raise KeyError.
+sys.modules.setdefault("aq_lib.config_module", MagicMock())
+
+import pytest
+from fastapi.testclient import TestClient
+
+FIXTURES_DIR = Path(__file__).parents[1] / "fixtures"
+DETECTED_RESULTS = FIXTURES_DIR / "results" / "detected.json"
+
+
+@pytest.fixture
+def db_client(tmp_path, monkeypatch):
+    """TestClient backed by an isolated, temporary SQLite DB."""
+    db_path = tmp_path / "test_events.db"
+    monkeypatch.setenv("AQ_LOCAL_DB_PATH", str(db_path))
+    from aquila_web import local_db, main as web_main
+    local_db.init_local_db()
+    with TestClient(web_main.app) as c:
+        yield c, local_db
+
+
+class TestRunCompleteEndpoint:
+    """POST /events/run_complete stores an event in the SQLite queue."""
+
+    def test_enqueues_run_complete_event(self, db_client):
+        client, local_db = db_client
+        response = client.post("/events/run_complete", json={
+            "run_name": "Run 1",
+            "profile": "basic_pcr.json",
+            "results_path": str(DETECTED_RESULTS),
+        })
+        assert response.status_code == 200
+        events = local_db.get_pending_events()
+        assert len(events) == 1
+        assert events[0]["event_type"] == "run_complete"
+
+    def test_event_payload_has_run_name_and_profile(self, db_client):
+        client, local_db = db_client
+        client.post("/events/run_complete", json={
+            "run_name": "Run 2",
+            "profile": "hotstart.json",
+            "results_path": str(DETECTED_RESULTS),
+        })
+        payload = local_db.get_pending_events()[0]["payload"]
+        assert payload["run_name"] == "Run 2"
+        assert payload["profile"] == "hotstart.json"
+
+    def test_event_payload_includes_non_empty_result(self, db_client):
+        client, local_db = db_client
+        client.post("/events/run_complete", json={
+            "run_name": "Run 1",
+            "profile": "basic_pcr.json",
+            "results_path": str(DETECTED_RESULTS),
+        })
+        payload = local_db.get_pending_events()[0]["payload"]
+        assert payload.get("result")
+
+
+class TestEmitRunComplete:
+    """state_requests.emit_run_complete() calls the correct HTTP endpoint."""
+
+    def test_posts_to_events_run_complete_endpoint(self, monkeypatch):
+        import aq_lib.state_requests as sr
+
+        calls = []
+
+        class _FakeResponse:
+            status_code = 200
+
+        def fake_post(url, json=None, timeout=None):
+            calls.append({"url": url, "json": json})
+            return _FakeResponse()
+
+        monkeypatch.setattr("aq_lib.state_requests.requests.post", fake_post)
+        sr.emit_run_complete("Run 1", "basic_pcr.json", "/logs/results/run1.json")
+        assert len(calls) == 1
+        assert calls[0]["url"].endswith("/events/run_complete")
+        assert calls[0]["json"]["run_name"] == "Run 1"
+        assert calls[0]["json"]["profile"] == "basic_pcr.json"
+        assert calls[0]["json"]["results_path"] == "/logs/results/run1.json"


### PR DESCRIPTION
## Summary

- Adds a `run_complete` event to the local SQLite events queue whenever a PCR run finishes
- Covers both the simulated dev path (`_simulate_run` in `main.py`) and the real hardware path (`state_run_assay.py`) via a new `POST /events/run_complete` endpoint
- Event payload: `{"run_name": str, "profile": str, "result": str}` — result is computed from the results JSON (e.g. "Detected: Tube 1")
- Events are automatically picked up by the existing `sync_pending_events` batch-upload to cloud

## Changes

- `aquila_web/main.py` — new `POST /events/run_complete` endpoint + direct `enqueue_event()` call in `_simulate_run`
- `aq_lib/state_requests.py` — new `emit_run_complete(run_name, profile, results_path)` following existing HTTP pattern
- `state_run_assay.py` — calls `sr.emit_run_complete()` after `sr.log_history()` on successful hardware run
- `tests/unit/test_run_complete_event.py` — 4 TDD tests (all green)

## Test plan

- [x] `tests/unit/test_run_complete_event.py` — 4 new tests pass (endpoint enqueues event, payload fields correct, result non-empty, `emit_run_complete` posts to right URL)
- [x] Full suite: 480 passed, 112 skipped, 1 pre-existing unrelated failure (`test_compose_volumes_use_opt_aquila`)

Closes #133

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)