### PR TITLE
feat: background sync task flushes SQLite queue to AWS every 15 min

### DIFF
--- a/aquila_web/main.py
+++ b/aquila_web/main.py
@@ -1665,6 +1665,27 @@ async def _background_update_poller() -> None:
         await asyncio.sleep(_OTA_POLL_INTERVAL)
 
 
+_SYNC_INTERVAL_SECONDS = int(os.getenv("AQ_SYNC_INTERVAL_SECONDS", "900"))
+
+
+async def _background_sync_poller() -> None:
+    """Flush SQLite event queue to AWS ingest endpoint every AQ_SYNC_INTERVAL_SECONDS."""
+    while True:
+        await asyncio.sleep(_SYNC_INTERVAL_SECONDS)
+        try:
+            from aquila_web.sync import sync_pending_events
+            sync_pending_events()
+        except Exception as exc:
+            logger.warning("Background sync error: %s", exc)
+
+
+@app.post("/sync/flush")
+async def sync_flush():
+    from aquila_web.sync import sync_pending_events
+    synced = sync_pending_events()
+    return {"synced": synced}
+
+
 @app.on_event("startup")
 async def _inject_device_id() -> None:
     inject_hw_serial_env()
@@ -1673,3 +1694,8 @@ async def _inject_device_id() -> None:
 @app.on_event("startup")
 async def start_background_update_poller() -> None:
     asyncio.create_task(_background_update_poller())
+
+
+@app.on_event("startup")
+async def start_background_sync_poller() -> None:
+    asyncio.create_task(_background_sync_poller())

--- a/aquila_web/sync.py
+++ b/aquila_web/sync.py
@@ -26,8 +26,12 @@ def sync_pending_events(
         "device_id": os.getenv("AQ_SYNC_DEVICE_ID") or os.getenv("DEVICE_ID"),
         "events": pending_events,
     }
-    response = requests.post(resolved_endpoint, json=payload, timeout=resolved_timeout)
-    response.raise_for_status()
+    try:
+        response = requests.post(resolved_endpoint, json=payload, timeout=resolved_timeout)
+        response.raise_for_status()
+    except requests.exceptions.RequestException as exc:
+        logger.warning("Sync failed (will retry next interval): %s", exc)
+        return 0
     mark_event_synced([event["id"] for event in pending_events])
     logger.info("Synced %s events", len(pending_events))
     return len(pending_events)

--- a/tests/unit/test_background_sync.py
+++ b/tests/unit/test_background_sync.py
@@ -1,0 +1,69 @@
+"""
+Unit tests for the background sync task and manual flush endpoint.
+
+Behaviors tested:
+  1. POST /sync/flush syncs pending events and returns the count
+  2. POST /sync/flush returns {"synced": 0} when no endpoint is configured
+  3. Network errors are swallowed — flush returns {"synced": 0}, events stay pending
+"""
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+from fastapi.testclient import TestClient
+
+
+@pytest.fixture
+def db_client(tmp_path, monkeypatch):
+    """TestClient with an isolated SQLite DB and a fake sync endpoint."""
+    monkeypatch.setenv("AQ_LOCAL_DB_PATH", str(tmp_path / "test_sync.db"))
+    from aquila_web import local_db, main as web_main
+    local_db.init_local_db()
+    with TestClient(web_main.app) as c:
+        yield c, local_db
+
+
+def _seed_event(local_db, tmp_path):
+    """Insert one run_complete event so there is something to sync."""
+    local_db.enqueue_event("run_complete", {"run_name": "Run 1", "profile": "p.json", "result": "ok"})
+
+
+class TestSyncFlushEndpoint:
+    """POST /sync/flush behaviour."""
+
+    def test_syncs_pending_events_and_returns_count(self, db_client, tmp_path, monkeypatch):
+        client, local_db = db_client
+        _seed_event(local_db, tmp_path)
+        monkeypatch.setenv("AQ_SYNC_ENDPOINT", "http://fake-aws/ingest")
+
+        class _OK:
+            status_code = 200
+            def raise_for_status(self): pass
+
+        monkeypatch.setattr("aquila_web.sync.requests.post", lambda *a, **kw: _OK())
+        response = client.post("/sync/flush")
+        assert response.status_code == 200
+        assert response.json()["synced"] == 1
+
+    def test_returns_zero_when_no_endpoint_configured(self, db_client, tmp_path, monkeypatch):
+        client, local_db = db_client
+        _seed_event(local_db, tmp_path)
+        monkeypatch.delenv("AQ_SYNC_ENDPOINT", raising=False)
+        response = client.post("/sync/flush")
+        assert response.status_code == 200
+        assert response.json()["synced"] == 0
+
+    def test_network_error_swallowed_returns_zero(self, db_client, tmp_path, monkeypatch):
+        import requests as _requests
+        client, local_db = db_client
+        _seed_event(local_db, tmp_path)
+        monkeypatch.setenv("AQ_SYNC_ENDPOINT", "http://fake-aws/ingest")
+        monkeypatch.setattr(
+            "aquila_web.sync.requests.post",
+            lambda *a, **kw: (_ for _ in ()).throw(_requests.exceptions.ConnectionError("offline")),
+        )
+        response = client.post("/sync/flush")
+        assert response.status_code == 200
+        assert response.json()["synced"] == 0
+        # event must still be pending — not lost
+        assert len(local_db.get_pending_events()) == 1


### PR DESCRIPTION
## Summary

- Adds `_background_sync_poller()` — async loop started at app startup that calls `sync_pending_events()` every `AQ_SYNC_INTERVAL_SECONDS` (default 900s / 15 min)
- Network and HTTP errors are caught and logged so the poller never crashes; events remain pending and retry next interval
- Adds `POST /sync/flush` for manual on-demand sync (useful for ops and testing)

## Changes

- `aquila_web/sync.py` — wrap HTTP call in `try/except RequestException`; return 0 on failure instead of raising
- `aquila_web/main.py` — add `_background_sync_poller`, `start_background_sync_poller` startup hook, and `POST /sync/flush` endpoint
- `tests/unit/test_background_sync.py` — 3 TDD tests (all green)

## Configuration

| Env var | Default | Description |
|---|---|---|
| `AQ_SYNC_ENDPOINT` | — | AWS ingest URL; sync is skipped if unset |
| `AQ_SYNC_INTERVAL_SECONDS` | `900` | Flush interval in seconds |
| `AQ_SYNC_BATCH_SIZE` | `100` | Max events per batch |
| `AQ_SYNC_TIMEOUT_SECONDS` | `10` | HTTP timeout |

## Test plan

- [x] `test_syncs_pending_events_and_returns_count` — flush with endpoint → returns synced count
- [x] `test_returns_zero_when_no_endpoint_configured` — no endpoint → `{"synced": 0}`
- [x] `test_network_error_swallowed_returns_zero` — connection error → `{"synced": 0}`, events still pending
- [x] 389 passed, 112 skipped across full unit/contract/state/pcr_curve suite

Closes #134

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)