### PR TITLE
Implemented log parser script

### DIFF
--- a/scripts/diagnostics/scan_cancel_logs.py
+++ b/scripts/diagnostics/scan_cancel_logs.py
@@ -1,0 +1,171 @@
+#!/usr/bin/env python3
+"""Scan controller + web-app logs and classify each SENTRI self-cancel.
+
+Part of the self-cancellation study. Stdlib-only, pure logic — runs anywhere.
+See specs/analysis/scan-cancel-logs.md.
+"""
+import argparse
+import re
+import sys
+from collections import Counter, namedtuple
+from datetime import datetime, timedelta
+
+_TS = re.compile(r"^(\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2},\d{3})")
+
+Verdict = namedtuple("Verdict", ["code", "label", "evidence"])
+
+_LIVE = re.compile(r"live=(\d+)")
+
+
+def _has(lines, substr):
+    return any(substr in line for line in lines)
+
+
+def _max_live(lid_lines):
+    """Highest concurrent lid-worker count seen in the lid log (0 if none)."""
+    counts = [int(m.group(1)) for line in lid_lines for m in [_LIVE.search(line)] if m]
+    return max(counts) if counts else 0
+
+
+def parse_timestamp(line):
+    """Parse the leading 'YYYY-MM-DD HH:MM:SS,mmm'; None if absent."""
+    m = _TS.match(line)
+    if not m:
+        return None
+    return datetime.strptime(m.group(1), "%Y-%m-%d %H:%M:%S,%f")
+
+
+def find_cancels(logger_lines):
+    """Indices of self-cancel events (the canonical 'Stop request detected')."""
+    return [i for i, line in enumerate(logger_lines) if "Stop request detected" in line]
+
+
+def classify_window(logger_lines, app_lines, lid_lines=None):
+    """Classify one cancel's window against the study fingerprints (§3)."""
+    app_lines = app_lines or []
+    evidence = []
+
+    if _has(app_lines, "Stop button pressed"):
+        evidence.append("'Stop button pressed' in app log with no human tap")
+        return Verdict("H3", "Trigger 1 — phantom touch / frontend re-fire", evidence)
+
+    peak = _max_live(lid_lines or [])
+    if peak > 1:
+        evidence.append("lid workers live peaked at %d (leak)" % peak)
+        return Verdict("H1", "Threading — lid-heater thread leak", evidence)
+
+    if _has(logger_lines, "Backend unreachable") and not _has(app_lines, "Stop button pressed"):
+        evidence.append("forced-stop safety net fired with no 'Stop button pressed'")
+        return Verdict("TRIGGER2", "Safety net — web app unreachable (H2/H4/H5/H6)", evidence)
+
+    if _has(logger_lines, "Stop request detected"):
+        evidence.append("cancel fired with no press, safety net, leak, or restart")
+        return Verdict("H8", "Trigger 1 — stale stop flag / failed reset", evidence)
+
+    return Verdict("H0", "Unknown — no fingerprint matched", evidence)
+
+
+def coincidence_delta(app_lines, cancel_ts):
+    """Seconds the web app was silent before the cancel.
+
+    The gap between the last app-log line at/before ``cancel_ts`` and the cancel.
+    A large gap means the web app went quiet right as the controller gave up.
+    None if no timestamped app line precedes the cancel.
+    """
+    befores = [
+        ts for line in app_lines
+        for ts in [parse_timestamp(line)]
+        if ts is not None and ts <= cancel_ts
+    ]
+    if not befores:
+        return None
+    return (cancel_ts - max(befores)).total_seconds()
+
+
+CancelReport = namedtuple(
+    "CancelReport", ["timestamp", "verdict", "coincidence_delta", "last_app_line"]
+)
+
+
+def _read_lines(path):
+    if not path:
+        return []
+    try:
+        with open(path, errors="replace") as fh:
+            return fh.readlines()
+    except FileNotFoundError:
+        return []
+
+
+def _window(lines, center_ts, window_s):
+    """Timestamped lines within +/- window_s of center_ts."""
+    lo = center_ts - timedelta(seconds=window_s)
+    hi = center_ts + timedelta(seconds=window_s)
+    out = []
+    for line in lines:
+        ts = parse_timestamp(line)
+        if ts is not None and lo <= ts <= hi:
+            out.append(line)
+    return out
+
+
+def scan(logger_path, app_path, lid_path=None, window=30):
+    """Read the logs, classify each self-cancel, return CancelReports."""
+    logger_lines = _read_lines(logger_path)
+    app_lines = _read_lines(app_path)
+    lid_lines = _read_lines(lid_path)
+
+    reports = []
+    for idx in find_cancels(logger_lines):
+        cancel_ts = parse_timestamp(logger_lines[idx])
+        if cancel_ts is None:
+            continue
+        log_win = _window(logger_lines, cancel_ts, window)
+        app_win = _window(app_lines, cancel_ts, window)
+        lid_win = _window(lid_lines, cancel_ts, window) if lid_lines else []
+        verdict = classify_window(log_win, app_win, lid_lines=lid_win)
+        delta = coincidence_delta(app_lines, cancel_ts)
+        last_app = next(
+            (l.rstrip("\n") for l in reversed(app_lines)
+             if (parse_timestamp(l) or cancel_ts) <= cancel_ts and parse_timestamp(l)),
+            None,
+        )
+        reports.append(CancelReport(cancel_ts, verdict, delta, last_app))
+    return reports
+
+
+def main(argv=None):
+    parser = argparse.ArgumentParser(description="Classify SENTRI self-cancels from logs.")
+    parser.add_argument("--logger", required=True, help="path to logger.log (controller)")
+    parser.add_argument("--app", required=True, help="path to app_logger.log (web app)")
+    parser.add_argument("--lid", default=None, help="path to lid_heater_logger.log (optional)")
+    parser.add_argument("--window", type=int, default=30, help="seconds around each cancel")
+    args = parser.parse_args(argv)
+
+    reports = scan(args.logger, args.app, args.lid, args.window)
+    if not reports:
+        print("No self-cancels detected.")
+        return 0
+    if not args.lid:
+        print("(note: --lid not provided; H1 lid-thread-leak detection disabled)\n")
+
+    for r in reports:
+        print("=" * 70)
+        print("Cancel at %s" % r.timestamp)
+        print("  Verdict : %s — %s" % (r.verdict.code, r.verdict.label))
+        for ev in r.verdict.evidence:
+            print("    - %s" % ev)
+        if r.coincidence_delta is not None:
+            print("  Web app silent for %.1fs before the cancel" % r.coincidence_delta)
+        if r.last_app_line:
+            print("  Last app line before cancel: %s" % r.last_app_line)
+
+    print("=" * 70)
+    tally = Counter(r.verdict.code for r in reports)
+    summary = ", ".join("%dx %s" % (n, code) for code, n in tally.most_common())
+    print("Summary: %d cancel(s): %s" % (len(reports), summary))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/specs/analysis/scan-cancel-logs.md
+++ b/specs/analysis/scan-cancel-logs.md
@@ -1,0 +1,146 @@
+# Analysis Spec: scan_cancel_logs.py — Self-Cancel Log Classifier
+
+**Status:** Draft
+**Author:** Jack
+**Last updated:** 2026-06-16
+**GitHub issue:** #158
+**Type:** Diagnostic tool (stdlib-only, pure logic — no hardware, no network)
+**Source file(s):** `scripts/diagnostics/scan_cancel_logs.py` (new)
+**Parent study:** `specs/analysis/sentri-self-cancel-study.md` §3 (hypotheses), §6.1 (tool)
+
+---
+
+## 1. Purpose
+
+Given the logs pulled off a SENTRI that self-cancelled, **find each self-cancel and classify what most likely caused it** — automatically, so an operator does not have to eyeball thousands of log lines. It is the master discriminator of the study: it separates **Trigger 1** (a real stop flag) from **Trigger 2** (the forced-stop safety net) from the **threading leak (H1)**, and it refuses to name a cause when the evidence does not support one (**H0**).
+
+It also reports the **co-incidence delta** — the seconds between the last thing the web app logged and the moment the controller gave up — which is the single most telling signal for "did the web app go silent exactly when the run died?"
+
+---
+
+## 2. Inputs
+
+| Input | Type | Source | Notes |
+|-------|------|--------|-------|
+| Controller log | `logger.log` (native) / `data/logs/logger.log` (Docker) | `aquila` logger | The decisive file — holds the abort and the safety-net ladder |
+| Web-app log | `app_logger.log` | `aquila_app` logger | Holds `Stop button pressed`, restart markers |
+| Lid heater log (optional) | `lid_heater/lid_heater_logger.log` | `lid_heater` logger | Holds `LID WORKER … live=N` from issue #157 |
+| Window | `int` seconds (default 30) | CLI arg | How far before/after a cancel to slice the other logs |
+
+All inputs are plain text with lines prefixed `YYYY-MM-DD HH:MM:SS,mmm - LEVEL - message`.
+
+---
+
+## 3. Public Interface
+
+```python
+parse_timestamp(line: str) -> datetime | None
+    # Parse the leading "YYYY-MM-DD HH:MM:SS,mmm". None if the line has no timestamp.
+
+find_cancels(logger_lines: list[str]) -> list[int]
+    # Indices of self-cancel events (a "Stop request detected" / "Run stopped by user" line).
+
+classify_window(logger_lines, app_lines, lid_lines=None) -> Verdict
+    # Classify ONE cancel's surrounding window. Pure function over in-memory lines.
+
+coincidence_delta(app_lines: list[str], cancel_ts: datetime) -> float | None
+    # Seconds between the last app-log line at/just before the cancel and the cancel.
+    # None if no timestamped app line precedes the cancel.
+
+scan(logger_path, app_path, lid_path=None, window=30) -> list[CancelReport]
+    # File I/O orchestration: read files, find cancels, slice windows, classify each.
+
+main(argv=None)
+    # argparse CLI entry point; prints a per-cancel report + summary.
+```
+
+`Verdict` = `{code: str, label: str, evidence: list[str]}`.
+`CancelReport` = `{timestamp, verdict, coincidence_delta, last_app_line}`.
+
+---
+
+## 4. Classification Logic
+
+`classify_window` applies the fingerprints from study §3, **most-specific first**. The first match wins.
+
+| Order | Condition (in the window) | Code | Meaning |
+|-------|---------------------------|------|---------|
+| 1 | `Stop button pressed` in app log | **H3** | Trigger 1 — phantom touch / frontend re-fire (a real tap that no human made) |
+| 2 | lid `live=N` peak > 1 | **H1** | Threading — lid-heater thread leak |
+| 3 | `Application startup` / `Started server` / `Uvicorn running` mid-window | **H7** | Web app restarted mid-run (Watchtower / crash / OOM) |
+| 4 | `Backend unreachable … forcing stop` and **no** `Stop button pressed` | **TRIGGER2** | Safety net fired; candidate set H2/H4/H5/H6 — narrow with `snapshot_resources.py` (#160) |
+| 5 | controller comms errors only (`Error in timer request` / `Error in change screen` / `Error updating drawer`) | **TRIGGER2** | Web app unreachable across the board (corroboration) |
+| 6 | a cancel fired but none of the above | **H8** | Stale flag — `stop_requested` true with no fresh press and no safety net |
+| 7 | no diagnostic signal at all | **H0** | Unknown — **never asserts an unproven cause**; bring richer captures (study §9 Outcome D) |
+
+Notes:
+- **TRIGGER2 is deliberately a candidate set**, not a single hypothesis — logs alone cannot distinguish thermal throttle (H4) from FD leak (H5) from memory (H6) from event-loop block (H2). The verdict says so and points at #160.
+- **H8 vs H0:** H8 means a cancel definitely fired but nothing (press, safety net, leak, restart) explains it → the flag must have been stale. H0 means there is no clear signal to reason from.
+
+---
+
+## 5. Outputs
+
+For each detected cancel, printed and returned as a `CancelReport`:
+
+- **Timestamp** of the cancel (from `logger.log`).
+- **Verdict** — code + human label + the evidence lines that drove it.
+- **Co-incidence delta** — seconds the web app was silent before the cancel (large delta ⇒ web app stalled/restarted right as the run died).
+- **Last normal app-log line** before the cancel (for manual cross-check).
+
+A final summary tallies verdicts across all cancels found (e.g. "3 cancels: 2× TRIGGER2, 1× H1").
+
+---
+
+## 6. CLI Usage
+
+```bash
+# native paths
+python scripts/diagnostics/scan_cancel_logs.py \
+    --logger logs/logger.log --app logs/app_logger.log \
+    --lid logs/lid_heater/lid_heater_logger.log --window 30
+
+# Docker host (mounted volume)
+python scripts/diagnostics/scan_cancel_logs.py \
+    --logger data/logs/logger.log --app data/logs/app_logger.log
+```
+
+Exit code 0 always (it is a report, not a gate). Missing optional `--lid` simply disables H1 detection (logs a note).
+
+---
+
+## 7. Edge Cases
+
+- **Non-timestamped lines** (tracebacks, blank lines): `parse_timestamp` returns `None`; windowing skips them.
+- **No cancels found:** prints "no self-cancels detected" and returns `[]`.
+- **Clock skew between logs:** the co-incidence delta is reported but flagged as approximate; both logs use the host clock so skew is normally zero.
+- **Missing app log:** classification still runs on controller-only signals (forced-stop, comms, lid); H3/H7 simply cannot fire.
+- **Encoding:** read with `errors="replace"` (Pi logs are UTF-8; guards against stray bytes).
+
+---
+
+## 8. Test Coverage
+
+`tests/unit/test_scan_cancel_logs.py` (imported via `sys.path`, like `tests/unit/test_wifi_helpers.py`). All pure logic — runs on any machine.
+
+| Test | Verifies |
+|------|----------|
+| `parse_timestamp` valid + non-timestamped | Foundational parse, `None` on no-timestamp |
+| `find_cancels` locates an abort | Cancel-event detection |
+| forced-stop + no stop-pressed → `TRIGGER2` | Safety-net classification |
+| `Stop button pressed` → `H3` | Trigger-1 phantom/re-fire |
+| lid `live>1` → `H1` | Threading-leak classification |
+| cancel + nothing explanatory → `H8` | Stale-flag classification |
+| no signal → `H0` | Refuses to guess |
+| `coincidence_delta` | Correct seconds between last app line and cancel |
+
+Run: `pytest tests/unit/test_scan_cancel_logs.py -v`
+
+---
+
+## 9. Related
+
+- Parent study: `specs/analysis/sentri-self-cancel-study.md` (§3 fingerprints, §8 decision matrix)
+- Consumes: issue #157 instrumentation lines (`LID WORKER … live=N`)
+- Consumed by: #163 `diagnose.py` (orchestrator calls this), #162 runbook
+- Sibling tools: #159 `watch_cancel.py` (live), #160 `snapshot_resources.py` (narrows TRIGGER2)

--- a/tests/unit/test_scan_cancel_logs.py
+++ b/tests/unit/test_scan_cancel_logs.py
@@ -1,0 +1,104 @@
+"""
+Unit tests for scan_cancel_logs.py — the self-cancel log classifier (issue #158).
+
+Pure logic over in-memory log lines; no hardware, no files. Imported via sys.path
+the same way tests/unit/test_wifi_helpers.py imports a script module.
+"""
+import sys
+from datetime import datetime
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(REPO_ROOT / "scripts" / "diagnostics"))
+
+import scan_cancel_logs as scl  # noqa: E402
+
+
+class TestParseTimestamp:
+    def test_parses_a_standard_log_line(self):
+        line = "2026-06-16 14:02:11,304 - INFO - LID WORKER START tid=1 live=1"
+        assert scl.parse_timestamp(line) == datetime(2026, 6, 16, 14, 2, 11, 304000)
+
+    def test_returns_none_for_non_timestamped_line(self):
+        assert scl.parse_timestamp("Traceback (most recent call last):") is None
+        assert scl.parse_timestamp("") is None
+
+
+class TestFindCancels:
+    def test_locates_a_self_cancel_event(self):
+        lines = [
+            "2026-06-16 14:02:00,000 - INFO - RUN START index=1",
+            "2026-06-16 14:02:25,500 - INFO - Stop request detected",
+            "2026-06-16 14:02:25,600 - INFO - Run stopped by user",
+        ]
+        assert scl.find_cancels(lines) == [1]
+
+
+class TestClassifyWindow:
+    def test_forced_stop_without_press_is_trigger2(self):
+        logger_lines = [
+            "2026-06-16 14:02:20,000 - WARNING - Error polling stop request (10/10): timeout",
+            "2026-06-16 14:02:20,100 - ERROR - Backend unreachable for 10 consecutive polls — forcing stop",
+            "2026-06-16 14:02:20,200 - INFO - Stop request detected",
+        ]
+        app_lines = [
+            "2026-06-16 14:02:14,000 - INFO - Run button pressed",
+        ]
+        verdict = scl.classify_window(logger_lines, app_lines)
+        assert verdict.code == "TRIGGER2"
+
+    def test_stop_button_pressed_is_h3(self):
+        logger_lines = [
+            "2026-06-16 14:02:25,200 - INFO - Stop request detected",
+        ]
+        app_lines = [
+            "2026-06-16 14:02:25,000 - INFO - Stop button pressed",
+        ]
+        verdict = scl.classify_window(logger_lines, app_lines)
+        assert verdict.code == "H3"
+
+    def test_lid_worker_accumulation_is_h1(self):
+        logger_lines = [
+            "2026-06-16 14:02:20,100 - ERROR - Backend unreachable for 10 consecutive polls — forcing stop",
+            "2026-06-16 14:02:20,200 - INFO - Stop request detected",
+        ]
+        lid_lines = [
+            "2026-06-16 14:00:00,000 - INFO - LID WORKER START tid=1 live=1",
+            "2026-06-16 14:01:00,000 - INFO - LID WORKER START tid=2 live=2",
+            "2026-06-16 14:02:00,000 - INFO - LID WORKER START tid=3 live=3",
+        ]
+        verdict = scl.classify_window(logger_lines, [], lid_lines=lid_lines)
+        assert verdict.code == "H1"
+
+    def test_cancel_with_no_explanation_is_h8(self):
+        logger_lines = [
+            "2026-06-16 14:02:25,000 - INFO - Stop request detected",
+            "2026-06-16 14:02:25,100 - INFO - Run stopped by user",
+        ]
+        verdict = scl.classify_window(logger_lines, [])
+        assert verdict.code == "H8"
+
+    def test_no_signal_is_h0(self):
+        logger_lines = [
+            "2026-06-16 14:02:00,000 - INFO - RUN START index=1",
+            "2026-06-16 14:02:30,000 - INFO - Hold 95 for 30s",
+        ]
+        verdict = scl.classify_window(logger_lines, [])
+        assert verdict.code == "H0"
+
+
+class TestCoincidenceDelta:
+    def test_seconds_between_last_app_line_and_cancel(self):
+        app_lines = [
+            "2026-06-16 14:02:10,000 - INFO - GET /button_status/",
+            "2026-06-16 14:02:15,000 - INFO - GET /button_status/",  # last before cancel
+            "2026-06-16 14:02:40,000 - INFO - GET /button_status/",  # after cancel
+        ]
+        cancel_ts = datetime(2026, 6, 16, 14, 2, 20, 0)
+        # app went silent 5s before the controller gave up at :20
+        assert scl.coincidence_delta(app_lines, cancel_ts) == 5.0
+
+    def test_none_when_no_app_line_precedes_cancel(self):
+        app_lines = ["2026-06-16 14:02:40,000 - INFO - GET /button_status/"]
+        cancel_ts = datetime(2026, 6, 16, 14, 2, 20, 0)
+        assert scl.coincidence_delta(app_lines, cancel_ts) is None


### PR DESCRIPTION
## What Changed

Implemented a script that reads a SENTRI’s log file, finds the run that self-cancelled, and tells you the most likely cause of each one. Returns a one block per self-cancel — the timestamp, the verdict code + plain-English cause, the evidence lines that drove it, and "web app silent for Ns before the cancel" — then a summary tally (e.g. 2x TRIGGER2, 1x H1). If it can't prove a cause it says H0 — unknown rather than guessing.

## Why

https://github.com/AcornGenetics/aquilla-main/issues/158

## Spec

Link to the spec this implements or modifies:
`specs/analysis/scan-cancel-logs.md`

If no spec exists and this is a non-trivial change, explain why.

## Changes Made

- [x] Source code modified
- [x] Spec updated to match implementation
- [x] New tests written
- [x] Existing tests still pass
- [x] No secrets or `.env` files in this diff
- [ ] ADR written (if an irreversible architectural decision was made)
- [ ] `docs/debugging/known-issues.md` updated (if new edge cases were found)

## Hardware Testing

- [ ] Tested on physical device
- [ ] Tested in simulation mode only — reason: [why physical not possible]
- [ ] Hardware not relevant to this change

## Reviewer Notes

Anything the reviewer should know: tricky parts, things to focus on, known limitations.
