### PR TITLE
Implemented watch cancel

### DIFF
--- a/scripts/diagnostics/watch_cancel.py
+++ b/scripts/diagnostics/watch_cancel.py
@@ -1,0 +1,171 @@
+#!/usr/bin/env python3
+"""Live terminal monitor for SENTRI self-cancellation.
+
+Tails the controller, web-app, and lid logs while you reproduce the bug,
+colorizing the diagnostic fingerprints and showing a live status header.
+Stdlib-only, self-contained. See specs/analysis/watch-cancel.md.
+"""
+import re
+from datetime import datetime
+
+
+_TS = re.compile(r"^(\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2},\d{3})")
+_LIVE = re.compile(r"live=(\d+)")
+_POLL = re.compile(r"Error polling stop request \((\d+)/\d+\)")
+
+
+def _parse_ts(line):
+    m = _TS.match(line)
+    if not m:
+        return None
+    return datetime.strptime(m.group(1), "%Y-%m-%d %H:%M:%S,%f")
+
+_CANCEL_MARKERS = ("Stop request detected", "Run stopped by user", "Stop button pressed")
+
+
+def classify_color(line):
+    """Return the highlight color for a log line, or None for plain."""
+    if "Backend unreachable" in line or "forcing stop" in line:
+        return "red"
+    if "Error polling stop request" in line:
+        return "yellow"
+    if any(marker in line for marker in _CANCEL_MARKERS):
+        return "magenta"
+    if "LID WORKER" in line or "LID JOIN DONE" in line or "live=" in line:
+        return "cyan"
+    return None
+
+
+class Monitor:
+    """Tracks live header state as log lines are fed in."""
+
+    def __init__(self):
+        self.live_workers = 0
+        self.poll_failures = 0
+        self.cancel_fired = False
+        self._last_app_ts = None
+
+    def feed(self, source, line):
+        m = _LIVE.search(line)
+        if m:
+            self.live_workers = int(m.group(1))
+
+        if "RUN START" in line:
+            self.poll_failures = 0
+        poll = _POLL.search(line)
+        if poll:
+            self.poll_failures = int(poll.group(1))
+
+        if "Stop request detected" in line:
+            self.cancel_fired = True
+
+        if source == "app":
+            ts = _parse_ts(line)
+            if ts is not None:
+                self._last_app_ts = ts
+
+    def seconds_since_app(self, now):
+        """Seconds since the web app last logged; None if it never has."""
+        if self._last_app_ts is None:
+            return None
+        return (now - self._last_app_ts).total_seconds()
+
+    def header(self, now, have_lid=True):
+        """One-line status string for the live header."""
+        parts = []
+        if have_lid:
+            parts.append("lid live=%d" % self.live_workers)
+        parts.append("polls %d/10" % self.poll_failures)
+        silent = self.seconds_since_app(now)
+        parts.append("app silent %s" % ("--" if silent is None else "%.1fs" % silent))
+        status = " | ".join(parts)
+        if self.cancel_fired:
+            status += "   *** CANCEL FIRED ***"
+        return status
+
+
+# --- I/O glue below: not unit-tested (manual / on-device) -------------------
+
+import os       # noqa: E402
+import sys      # noqa: E402
+import time     # noqa: E402
+import argparse  # noqa: E402
+
+_ANSI = {
+    "red": "\033[1;31m",
+    "yellow": "\033[33m",
+    "magenta": "\033[1;35m",
+    "cyan": "\033[36m",
+}
+_RESET = "\033[0m"
+
+
+def _wrap(text, color, use_color):
+    if color and use_color:
+        return "%s%s%s" % (_ANSI[color], text, _RESET)
+    return text
+
+
+def _follow(handles):
+    """Yield (source, line) as new lines appear; tail -F style with re-open."""
+    while True:
+        idle = True
+        for entry in handles:
+            source, path = entry["source"], entry["path"]
+            fh = entry["fh"]
+            if fh is None:
+                try:
+                    fh = open(path, errors="replace")
+                    fh.seek(0, os.SEEK_END)
+                    entry["fh"] = fh
+                except FileNotFoundError:
+                    continue
+            # detect truncation/rotation
+            try:
+                if os.stat(path).st_size < fh.tell():
+                    fh.seek(0)
+            except OSError:
+                pass
+            line = fh.readline()
+            if line:
+                idle = False
+                yield source, line.rstrip("\n")
+        if idle:
+            yield None, None  # idle tick → repaint header
+
+
+def main(argv=None):
+    parser = argparse.ArgumentParser(description="Live monitor for SENTRI self-cancellation.")
+    parser.add_argument("--logger", required=True, help="controller logger.log")
+    parser.add_argument("--app", required=True, help="web-app app_logger.log")
+    parser.add_argument("--lid", default=None, help="lid_heater_logger.log (optional)")
+    args = parser.parse_args(argv)
+
+    use_color = sys.stdout.isatty()
+    have_lid = args.lid is not None
+    handles = [
+        {"source": "logger", "path": args.logger, "fh": None},
+        {"source": "app", "path": args.app, "fh": None},
+    ]
+    if have_lid:
+        handles.append({"source": "lid", "path": args.lid, "fh": None})
+
+    monitor = Monitor()
+    print("Watching for self-cancels (Ctrl-C to quit)...\n")
+    try:
+        for source, line in _follow(handles):
+            if line is None:
+                print("\r" + monitor.header(datetime.now(), have_lid), end="\r")
+                time.sleep(0.2)
+                continue
+            monitor.feed(source, line)
+            color = classify_color(line)
+            print(_wrap("[%s] %s" % (source, line), color, use_color))
+            print(monitor.header(datetime.now(), have_lid), end="\r")
+    except KeyboardInterrupt:
+        print("\nStopped.")
+        return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/specs/analysis/watch-cancel.md
+++ b/specs/analysis/watch-cancel.md
@@ -1,0 +1,137 @@
+# Analysis Spec: watch_cancel.py — Live Self-Cancel Monitor
+
+**Status:** Draft
+**Author:** Jack
+**Last updated:** 2026-06-16
+**GitHub issue:** #159
+**Type:** Diagnostic tool (stdlib-only; live terminal UI). Self-contained — no dependency on #158.
+**Source file(s):** `scripts/diagnostics/watch_cancel.py` (new)
+**Parent study:** `specs/analysis/sentri-self-cancel-study.md` §6.2
+
+---
+
+## 1. Purpose
+
+A live terminal monitor you run in a second SSH session **while reproducing** the self-cancel. It tails the controller, web-app, and lid logs in real time, colorizes the diagnostic fingerprints, and keeps a one-line status header so you can *watch the failure build* — rather than classifying logs after the fact (that is #158's job).
+
+It targets, live:
+- **Trigger 2** — the `Error polling stop request (k/10)` ladder climbing, and "seconds since the web app last logged" crossing ~5 s as the safety net fires.
+- **Threading / H1** — the lid-worker `live=N` count rising across runs.
+
+---
+
+## 2. Inputs
+
+| Input | Type | Source | Notes |
+|-------|------|--------|-------|
+| Controller log | `--logger` path | `aquila` logger | abort, poll ladder, comms errors |
+| Web-app log | `--app` path | `aquila_app` logger | `Stop button pressed`, restarts; drives "secs since app" |
+| Lid heater log | `--lid` path (optional) | `lid_heater` logger | `LID WORKER … live=N` (#157) |
+
+Native paths `logs/…`; Docker host paths `data/logs/…`.
+
+---
+
+## 3. Public Interface
+
+```python
+classify_color(line: str) -> str | None
+    # "red" | "yellow" | "magenta" | "cyan" | None  — which highlight a line gets.
+
+class Monitor:
+    live_workers: int        # latest lid live=N seen
+    poll_failures: int       # latest k from "(k/10)"; reset to 0 on a new RUN START
+    cancel_fired: bool       # True once a "Stop request detected" is seen
+    def feed(self, source: str, line: str) -> None   # source: "logger"|"app"|"lid"
+    def seconds_since_app(self, now: datetime) -> float | None
+
+main(argv=None)              # argparse + tail-follow render loop (I/O glue; not unit-tested)
+```
+
+---
+
+## 4. Color Mapping (`classify_color`)
+
+| Fingerprint in line | Color | Why it matters |
+|---------------------|-------|----------------|
+| `Backend unreachable` / `forcing stop` | **red** | the safety net firing (Trigger 2) |
+| `Error polling stop request (k/10)` | **yellow** | the countdown toward a forced stop |
+| `Stop request detected` / `Run stopped by user` / `Stop button pressed` | **magenta** | the abort itself |
+| `LID WORKER` / `LID JOIN DONE` / `live=` | **cyan** | thread lifecycle (H1) |
+| anything else | **None** | printed plain |
+
+---
+
+## 5. Live Header
+
+A single status line repainted as events arrive:
+
+```
+lid live=N | polls k/10 | app silent Ns | <CANCEL banner if fired>
+```
+
+- `live=N` — current lid workers (rising = leak forming).
+- `k/10` — current consecutive poll-failure count (climbing = web app going unreachable).
+- `app silent Ns` — `seconds_since_app(now)`; crossing ~5 s right before a cancel is the smoking gun.
+- A red **CANCEL** banner latches when `cancel_fired` becomes true.
+
+---
+
+## 6. State Rules
+
+- **live_workers:** set to the `N` of the most recent line containing `live=`.
+- **poll_failures:** set to `k` from `Error polling stop request (k/10)`; reset to `0` when a `RUN START` line arrives (new run begins).
+- **seconds_since_app:** `now - (timestamp of last app-log line fed)`; `None` until an app line with a timestamp is seen.
+- **cancel_fired:** latches `True` on `Stop request detected`.
+
+---
+
+## 7. CLI Usage
+
+```bash
+# run in a second SSH session while reproducing
+python scripts/diagnostics/watch_cancel.py \
+    --logger logs/logger.log --app logs/app_logger.log \
+    --lid logs/lid_heater/lid_heater_logger.log
+```
+
+Follows files `tail -F`-style (handles rotation/truncation), Ctrl-C to quit. `--lid` optional (disables the `live=N` field).
+
+---
+
+## 8. Edge Cases
+
+- **Non-timestamped lines** (tracebacks): printed with color if matched, but do not update `seconds_since_app`.
+- **Missing optional `--lid`:** header omits `live=N`.
+- **File not yet created / rotated:** the follow loop retries rather than crashing.
+- **Encoding:** read with `errors="replace"`.
+- **ANSI:** color is applied only when stdout is a TTY; piped output stays plain.
+
+---
+
+## 9. Test Coverage
+
+`tests/unit/test_watch_cancel.py` (imported via `sys.path`, like `test_wifi_helpers`). Pure logic — the follow loop / rendering is manual/on-device.
+
+| Test | Verifies |
+|------|----------|
+| `classify_color` forced-stop → red | safety-net highlight |
+| `classify_color` poll ladder → yellow | countdown highlight |
+| `classify_color` cancel markers → magenta | abort highlight |
+| `classify_color` lid line → cyan | thread-lifecycle highlight |
+| `classify_color` plain → None | no false highlights |
+| `Monitor.feed` lid line → `live_workers` | leak counter |
+| `Monitor.feed` ladder → `poll_failures`; RUN START resets | Trigger-2 counter |
+| `Monitor.seconds_since_app(now)` | app-silence gauge |
+| `Monitor.feed` cancel → `cancel_fired` | banner latch |
+
+Run: `pytest tests/unit/test_watch_cancel.py -v`
+
+---
+
+## 10. Related
+
+- Parent study: `specs/analysis/sentri-self-cancel-study.md` §6.2
+- Reads: #157 instrumentation (`live=N`)
+- Sibling tools: #158 `scan_cancel_logs.py` (post-hoc classify), #160 `snapshot_resources.py`
+- Consumed by: #162 runbook

--- a/tests/unit/test_watch_cancel.py
+++ b/tests/unit/test_watch_cancel.py
@@ -1,0 +1,64 @@
+"""
+Unit tests for watch_cancel.py — the live self-cancel monitor (issue #159).
+
+Pure logic (color decisions + header state); the tail-follow render loop is
+manual/on-device. Imported via sys.path like tests/unit/test_wifi_helpers.py.
+"""
+import sys
+from datetime import datetime
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(REPO_ROOT / "scripts" / "diagnostics"))
+
+import watch_cancel as wc  # noqa: E402
+
+
+class TestClassifyColor:
+    def test_forced_stop_is_red(self):
+        line = "2026-06-16 14:02:20,100 - ERROR - Backend unreachable for 10 consecutive polls — forcing stop"
+        assert wc.classify_color(line) == "red"
+
+    def test_poll_ladder_is_yellow(self):
+        line = "2026-06-16 14:02:18,000 - WARNING - Error polling stop request (7/10): timeout"
+        assert wc.classify_color(line) == "yellow"
+
+    def test_cancel_markers_are_magenta(self):
+        assert wc.classify_color("... - INFO - Stop request detected") == "magenta"
+        assert wc.classify_color("... - INFO - Run stopped by user") == "magenta"
+        assert wc.classify_color("... - INFO - Stop button pressed") == "magenta"
+
+    def test_lid_lifecycle_is_cyan(self):
+        assert wc.classify_color("... - INFO - LID WORKER START tid=1 live=1") == "cyan"
+
+    def test_plain_line_is_none(self):
+        assert wc.classify_color("... - INFO - Hold 95 for 30s") is None
+
+
+class TestMonitor:
+    def test_lid_line_updates_live_workers(self):
+        m = wc.Monitor()
+        m.feed("lid", "2026-06-16 14:00:00,000 - INFO - LID WORKER START tid=1 live=1")
+        m.feed("lid", "2026-06-16 14:01:00,000 - INFO - LID WORKER START tid=2 live=3")
+        assert m.live_workers == 3
+
+    def test_poll_ladder_updates_and_run_start_resets(self):
+        m = wc.Monitor()
+        m.feed("logger", "... - WARNING - Error polling stop request (4/10): timeout")
+        assert m.poll_failures == 4
+        m.feed("logger", "... - WARNING - Error polling stop request (7/10): timeout")
+        assert m.poll_failures == 7
+        m.feed("logger", "2026-06-16 14:05:00,000 - INFO - RUN START index=5")
+        assert m.poll_failures == 0
+
+    def test_seconds_since_app_from_last_app_line(self):
+        m = wc.Monitor()
+        assert m.seconds_since_app(datetime(2026, 6, 16, 14, 2, 20)) is None
+        m.feed("app", "2026-06-16 14:02:15,000 - INFO - GET /button_status/")
+        assert m.seconds_since_app(datetime(2026, 6, 16, 14, 2, 20)) == 5.0
+
+    def test_cancel_marker_latches_cancel_fired(self):
+        m = wc.Monitor()
+        assert m.cancel_fired is False
+        m.feed("logger", "2026-06-16 14:02:25,000 - INFO - Stop request detected")
+        assert m.cancel_fired is True


### PR DESCRIPTION
## What Changed

Implemented a script that reads a SENTRI’s log file, finds the run that self-cancelled, and tells you the most likely cause of each one. Returns a one block per self-cancel — the timestamp, the verdict code + plain-English cause, the evidence lines that drove it, and "web app silent for Ns before the cancel" — then a summary tally (e.g. 2x TRIGGER2, 1x H1). If it can't prove a cause it says H0 — unknown rather than guessing.

## Why

https://github.com/AcornGenetics/aquilla-main/issues/159

## Spec

Link to the spec this implements or modifies:
`specs/analysis/watch-cancel.md`

If no spec exists and this is a non-trivial change, explain why.

## Changes Made

- [x] Source code modified
- [x] Spec updated to match implementation
- [x] New tests written
- [x] Existing tests still pass
- [x] No secrets or `.env` files in this diff
- [ ] ADR written (if an irreversible architectural decision was made)
- [ ] `docs/debugging/known-issues.md` updated (if new edge cases were found)

## Hardware Testing

- [ ] Tested on physical device
- [ ] Tested in simulation mode only — reason: [why physical not possible]
- [ ] Hardware not relevant to this change

## Reviewer Notes

Anything the reviewer should know: tricky parts, things to focus on, known limitations.
