### PR TITLE
Implement snapshot analysis

### DIFF
--- a/scripts/diagnostics/snapshot_resources.py
+++ b/scripts/diagnostics/snapshot_resources.py
@@ -187,6 +187,20 @@ def _button_p95(app_url, n=20):
     return "%.3f" % lat[int(0.95 * len(lat)) - 1]
 
 
+# Where the run history file may live, most-specific first. The real device
+# path is logs/history.json (aquila_web.main: BASE_DIR/"logs"/"history.json");
+# data/ and bare are fallbacks for Docker/other layouts.
+HISTORY_CANDIDATES = ("logs/history.json", "data/history.json", "history.json")
+
+
+def first_existing_size(candidates):
+    """Size (as str) of the first existing path in candidates, else ''."""
+    for cand in candidates:
+        if os.path.exists(cand):
+            return str(os.path.getsize(cand))
+    return ""
+
+
 def collect(label, backend_pid=None, app_pid=None, app_url=None):
     """Gather one snapshot from the host. Missing sources yield blank cells."""
     statvfs_free = ""
@@ -195,11 +209,7 @@ def collect(label, backend_pid=None, app_pid=None, app_url=None):
         statvfs_free = str(round(st.f_bavail * st.f_frsize / 1e6))
     except Exception:
         pass
-    history = ""
-    for cand in ("data/history.json", "history.json"):
-        if os.path.exists(cand):
-            history = str(os.path.getsize(cand))
-            break
+    history = first_existing_size(HISTORY_CANDIDATES)
     return {
         "label": label,
         "soc_temp": _soc_temp(),

--- a/scripts/diagnostics/snapshot_resources.py
+++ b/scripts/diagnostics/snapshot_resources.py
@@ -1,0 +1,244 @@
+#!/usr/bin/env python3
+"""Per-run host/process resource snapshots for the SENTRI self-cancel study.
+
+Snapshot mode captures metrics to a CSV; --report mode prints the run-over-run
+diff and flags metrics that worsen monotonically (disambiguates Trigger 2).
+Stdlib-only, self-contained. See specs/analysis/snapshot-resources.md.
+"""
+
+
+import csv
+import os
+from collections import namedtuple
+
+# metric -> (bad direction, hypothesis it points to, description)
+METRICS = {
+    "soc_temp": ("up", "H4", "SoC thermal throttle"),
+    "ctrl_fds": ("up", "H5", "controller FD/socket leak"),
+    "app_fds": ("up", "H5", "web-app FD/socket leak"),
+    "time_wait": ("up", "H5", "TIME_WAIT socket buildup"),
+    "ctrl_rss": ("up", "H6", "controller memory growth"),
+    "app_rss": ("up", "H6", "web-app memory growth"),
+    "button_p95": ("up", "H2", "/button_status latency climbing"),
+    "ctrl_threads": ("up", "H1", "controller thread leak"),
+    "history_bytes": ("up", "H2", "history.json growing (blocking work)"),
+    "disk_free_mb": ("down", "DISK", "disk filling up"),
+}
+
+Flag = namedtuple("Flag", ["metric", "hypothesis", "direction", "series"])
+
+
+def _numeric_series(rows, metric):
+    """Float values for a metric across rows, skipping blank/non-numeric cells."""
+    series = []
+    for row in rows:
+        raw = row.get(metric, "")
+        if raw is None or str(raw).strip() == "":
+            continue
+        try:
+            series.append(float(raw))
+        except (TypeError, ValueError):
+            continue
+    return series
+
+
+def analyze(rows):
+    """Flag metrics that worsen monotonically across the given snapshot rows."""
+    flags = []
+    for metric, (direction, hypothesis, _desc) in METRICS.items():
+        series = _numeric_series(rows, metric)
+        if monotonic_trend(series, direction=direction):
+            flags.append(Flag(metric, hypothesis, direction, series))
+    return flags
+
+
+# Ordered CSV columns. "label" first; metrics follow in a stable order.
+SNAPSHOT_FIELDS = [
+    "label", "soc_temp", "throttled", "ctrl_fds", "app_fds", "time_wait",
+    "ctrl_rss", "app_rss", "button_p95", "ctrl_threads", "disk_free_mb",
+    "history_bytes", "oom",
+]
+
+
+def write_snapshot(path, row):
+    """Append one labeled snapshot row to the CSV, writing the header once."""
+    path = os.fspath(path)
+    new_file = not os.path.exists(path) or os.path.getsize(path) == 0
+    with open(path, "a", newline="") as fh:
+        writer = csv.DictWriter(fh, fieldnames=SNAPSHOT_FIELDS, extrasaction="ignore")
+        if new_file:
+            writer.writeheader()
+        writer.writerow(row)
+
+
+def read_snapshots(path):
+    """Read snapshot rows back as a list of dicts (empty if file absent)."""
+    path = os.fspath(path)
+    if not os.path.exists(path):
+        return []
+    with open(path, newline="") as fh:
+        return list(csv.DictReader(fh))
+
+
+def monotonic_trend(values, direction="up"):
+    """True iff values strictly trend the 'bad' way every step (>=2 points)."""
+    if len(values) < 2:
+        return False
+    if direction == "up":
+        return all(b > a for a, b in zip(values, values[1:]))
+    return all(b < a for a, b in zip(values, values[1:]))
+
+
+def report(rows):
+    """Format a run-over-run diff table; FLAG metrics trending the bad way."""
+    if not rows:
+        return "No snapshots recorded."
+    labels = [r.get("label", "?") for r in rows]
+    flagged = {f.metric: f for f in analyze(rows)}
+
+    lines = ["Run-over-run snapshot diff:", ""]
+    header = "%-16s | %s" % ("metric", " | ".join("%10s" % lbl[:10] for lbl in labels))
+    lines.append(header)
+    lines.append("-" * len(header))
+    for metric in SNAPSHOT_FIELDS:
+        if metric == "label":
+            continue
+        cells = " | ".join("%10s" % (r.get(metric, "") or "") for r in rows)
+        mark = ""
+        if metric in flagged:
+            mark = "  <== FLAG: %s (%s)" % (
+                flagged[metric].hypothesis, METRICS[metric][2])
+        lines.append("%-16s | %s%s" % (metric, cells, mark))
+
+    lines.append("")
+    if flagged:
+        summary = ", ".join(
+            "%s %s -> %s" % (f.metric, "up" if f.direction == "up" else "down", f.hypothesis)
+            for f in flagged.values()
+        )
+        lines.append("Flagged: " + summary)
+    else:
+        lines.append("No metric trends monotonically yet (need more runs or no leak).")
+    return "\n".join(lines)
+
+
+# --- host metric collection: not unit-tested (on-device) --------------------
+
+import subprocess  # noqa: E402
+import sys         # noqa: E402
+import time        # noqa: E402
+import argparse    # noqa: E402
+import urllib.request  # noqa: E402
+
+_DEFAULT_CSV = os.path.join("diagnostics_out", "snapshots.csv")
+
+
+def _sh(cmd):
+    try:
+        out = subprocess.run(cmd, shell=True, capture_output=True, text=True, timeout=10)
+        return out.stdout.strip()
+    except Exception:
+        return ""
+
+
+def _proc_field(pid, field):
+    if not pid:
+        return ""
+    try:
+        with open("/proc/%s/status" % pid) as fh:
+            for line in fh:
+                if line.startswith(field):
+                    # e.g. "VmRSS:\t  12345 kB" -> "12345"
+                    return line.split(":", 1)[1].strip().split()[0]
+    except Exception:
+        return ""
+    return ""
+
+
+def _fd_count(pid):
+    if not pid:
+        return ""
+    try:
+        return str(len(os.listdir("/proc/%s/fd" % pid)))
+    except Exception:
+        return ""
+
+
+def _soc_temp():
+    raw = _sh("vcgencmd measure_temp")  # temp=56.3'C
+    if "=" in raw:
+        return raw.split("=", 1)[1].rstrip("'C").rstrip("C")
+    return ""
+
+
+def _button_p95(app_url, n=20):
+    if not app_url:
+        return ""
+    lat = []
+    for _ in range(n):
+        t0 = time.monotonic()
+        try:
+            urllib.request.urlopen("%s/button_status/" % app_url, timeout=6).read()
+            lat.append(time.monotonic() - t0)
+        except Exception:
+            lat.append(6.0)  # treat timeout as the ceiling
+        time.sleep(0.1)
+    lat.sort()
+    return "%.3f" % lat[int(0.95 * len(lat)) - 1]
+
+
+def collect(label, backend_pid=None, app_pid=None, app_url=None):
+    """Gather one snapshot from the host. Missing sources yield blank cells."""
+    statvfs_free = ""
+    try:
+        st = os.statvfs("logs") if os.path.exists("logs") else os.statvfs(".")
+        statvfs_free = str(round(st.f_bavail * st.f_frsize / 1e6))
+    except Exception:
+        pass
+    history = ""
+    for cand in ("data/history.json", "history.json"):
+        if os.path.exists(cand):
+            history = str(os.path.getsize(cand))
+            break
+    return {
+        "label": label,
+        "soc_temp": _soc_temp(),
+        "throttled": _sh("vcgencmd get_throttled"),
+        "ctrl_fds": _fd_count(backend_pid),
+        "app_fds": _fd_count(app_pid),
+        "time_wait": _sh("ss -tan state time-wait | wc -l"),
+        "ctrl_rss": _proc_field(backend_pid, "VmRSS"),
+        "app_rss": _proc_field(app_pid, "VmRSS"),
+        "button_p95": _button_p95(app_url),
+        "ctrl_threads": _proc_field(backend_pid, "Threads"),
+        "disk_free_mb": statvfs_free,
+        "history_bytes": history,
+        "oom": _sh("dmesg 2>/dev/null | grep -i 'killed process' | tail -1"),
+    }
+
+
+def main(argv=None):
+    parser = argparse.ArgumentParser(description="Per-run resource snapshot for the self-cancel study.")
+    parser.add_argument("--label", help="label for this snapshot row (e.g. after-run-2)")
+    parser.add_argument("--backend-pid", default=None, help="controller PID")
+    parser.add_argument("--app-pid", default=None, help="web-app PID")
+    parser.add_argument("--app-url", default="http://127.0.0.1:8090", help="web-app base URL")
+    parser.add_argument("--csv", default=_DEFAULT_CSV, help="snapshot CSV path")
+    parser.add_argument("--report", action="store_true", help="print the run-over-run diff and exit")
+    args = parser.parse_args(argv)
+
+    if args.report:
+        print(report(read_snapshots(args.csv)))
+        return 0
+
+    if not args.label:
+        parser.error("--label is required when taking a snapshot")
+    os.makedirs(os.path.dirname(args.csv) or ".", exist_ok=True)
+    row = collect(args.label, args.backend_pid, args.app_pid, args.app_url)
+    write_snapshot(args.csv, row)
+    print("Snapshot '%s' written to %s" % (args.label, args.csv))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/specs/analysis/snapshot-resources.md
+++ b/specs/analysis/snapshot-resources.md
@@ -1,0 +1,124 @@
+# Analysis Spec: snapshot_resources.py — Per-Run Resource Snapshot
+
+**Status:** Draft
+**Author:** Jack
+**Last updated:** 2026-06-16
+**GitHub issue:** #160
+**Type:** Diagnostic tool (stdlib-only; host metric collection + trend analysis). Self-contained.
+**Source file(s):** `scripts/diagnostics/snapshot_resources.py` (new)
+**Parent study:** `specs/analysis/sentri-self-cancel-study.md` §6.3
+
+---
+
+## 1. Purpose
+
+When the safety net fires (Trigger 2 — the web app went unreachable), the logs alone cannot say *why*. This tool captures a labeled snapshot of host/process metrics **once per run**, and in `--report` mode prints the **run-over-run diff**: the metric that worsens monotonically across runs points at the cause. It is the only tool that **disambiguates within Trigger 2**.
+
+---
+
+## 2. Metrics & Hypothesis Map
+
+Each metric has a "bad direction" — the way it moves when the corresponding fault is present.
+
+| Metric (CSV column) | Source (glue) | Bad direction | Points to |
+|---------------------|---------------|---------------|-----------|
+| `soc_temp` | `vcgencmd measure_temp` (host) | up | **H4** SoC thermal throttle |
+| `throttled` | `vcgencmd get_throttled` (host) | non-zero | **H4** (corroboration) |
+| `ctrl_fds` | `/proc/<pid>/fd` count | up | **H5** FD/socket leak |
+| `app_fds` | `/proc/<pid>/fd` count | up | **H5** |
+| `time_wait` | `ss -tan state time-wait` | up | **H5** |
+| `ctrl_rss` | `/proc/<pid>/status` VmRSS | up | **H6** memory/OOM |
+| `app_rss` | `/proc/<pid>/status` VmRSS | up | **H6** |
+| `button_p95` | 20 timed `/button_status/` GETs | up | **H2** event-loop block (also H4) |
+| `ctrl_threads` | `/proc/<pid>/status` Threads | up | **H1** thread leak (controller) |
+| `disk_free_mb` | `os.statvfs` | **down** | disk-full stall |
+| `history_bytes` | `os.path.getsize` | up | **H2** (growing blocking work) |
+| `oom` | `dmesg \| grep -i oom` | present | **H6** |
+
+---
+
+## 3. Public Interface
+
+```python
+METRICS: dict[str, (direction, hypothesis, description)]   # "up" | "down"
+
+monotonic_trend(values, direction="up") -> bool
+    # True iff values STRICTLY trend the bad way every step (>=2 numeric points).
+
+write_snapshot(path, row: dict) -> None    # append one labeled row to CSV (header once)
+read_snapshots(path) -> list[dict]         # read rows back
+
+analyze(rows) -> list[Flag]                # flags metrics trending the bad way
+    # Flag = (metric, hypothesis, direction, series)
+
+collect(label, backend_pid, app_pid, app_url) -> dict   # host glue — NOT unit-tested
+report(rows) -> str                        # formatted run-over-run diff table
+main(argv=None)                            # snapshot mode (default) + --report mode
+```
+
+---
+
+## 4. Trend Rules
+
+- **Strict monotonic.** A metric is flagged only if it moves the bad way on **every** consecutive run (e.g. `soc_temp` 56 → 61 → 68 → 74). One plateau or dip means no flag — keeps false positives low.
+- **Minimum 2 points.** Fewer runs ⇒ no trend ⇒ no flag.
+- **Numeric coercion.** Values are read from CSV as strings; `analyze` coerces with `float()` and **skips blank / non-numeric** entries (a snapshot whose source was unavailable does not break the analysis).
+- **Direction per metric.** Most metrics flag on increase; `disk_free_mb` flags on decrease.
+
+---
+
+## 5. Outputs
+
+- **Snapshot mode** (default): append one row labeled `--label "after-run-2"` to `diagnostics_out/snapshots.csv`.
+- **`--report` mode**: print a column-aligned table of each metric across runs, with a **FLAG** marker and the pointed-to hypothesis on any metric that trends the bad way monotonically. A summary lists the flagged culprits (e.g. "soc_temp ↑ → H4, ctrl_fds ↑ → H5").
+
+---
+
+## 6. CLI Usage
+
+```bash
+# take a snapshot (run before run 1, then after each run)
+python scripts/diagnostics/snapshot_resources.py --label before-run-1 \
+    --backend-pid 1234 --app-pid 1235 --app-url http://127.0.0.1:8090
+
+# after several runs, see what climbed
+python scripts/diagnostics/snapshot_resources.py --report
+```
+
+Runs on the Pi host (for `vcgencmd`). Missing sources degrade gracefully (blank cell, never a crash).
+
+---
+
+## 7. Edge Cases
+
+- **Missing source** (no `vcgencmd`, PID gone, no docker): that cell is blank; analysis skips it.
+- **First snapshot / single row:** `--report` prints values but flags nothing (no trend yet).
+- **CSV header drift:** header written once on file creation; later rows align to it.
+- **Non-numeric metrics** (`throttled` flags, `oom` text): excluded from `monotonic_trend`; surfaced in the report as-is.
+
+---
+
+## 8. Test Coverage
+
+`tests/unit/test_snapshot_resources.py` (imported via `sys.path`, like `test_wifi_helpers`). Pure logic — host collection is on-device.
+
+| Test | Verifies |
+|------|----------|
+| `monotonic_trend` up → True | strictly increasing flagged |
+| `monotonic_trend` down → True | strictly decreasing (disk) flagged |
+| `monotonic_trend` non-monotonic / <2 → False | no false trend |
+| `write_snapshot` + `read_snapshots` round-trip | CSV model, header once |
+| `analyze` climbing `soc_temp` → H4 | up-metric → hypothesis |
+| `analyze` falling `disk_free_mb` → disk-full | down-metric direction |
+| `analyze` flat metric → no flag | no false positives |
+| `analyze` blank/non-numeric skipped | graceful degradation |
+
+Run: `pytest tests/unit/test_snapshot_resources.py -v`
+
+---
+
+## 9. Related
+
+- Parent study: `specs/analysis/sentri-self-cancel-study.md` §6.3, §8 (narrows TRIGGER2 from #158)
+- Sibling tools: #158 `scan_cancel_logs.py`, #159 `watch_cancel.py`
+- Consumed by: #163 `diagnose.py` (orchestrator runs this + `--report`), #162 runbook

--- a/tests/unit/test_snapshot_resources.py
+++ b/tests/unit/test_snapshot_resources.py
@@ -1,0 +1,79 @@
+"""
+Unit tests for snapshot_resources.py — per-run resource snapshot tool (issue #160).
+
+Pure logic (trend analysis + CSV model); host metric collection is on-device.
+Imported via sys.path like tests/unit/test_wifi_helpers.py.
+"""
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(REPO_ROOT / "scripts" / "diagnostics"))
+
+import snapshot_resources as sr  # noqa: E402
+
+
+class TestMonotonicTrend:
+    def test_strictly_increasing_up_is_true(self):
+        assert sr.monotonic_trend([56.0, 61.0, 68.0, 74.0], direction="up") is True
+
+    def test_strictly_decreasing_down_is_true(self):
+        # disk_free_mb falling every run = disk filling up
+        assert sr.monotonic_trend([900.0, 700.0, 400.0, 120.0], direction="down") is True
+
+    def test_non_monotonic_or_too_few_points_is_false(self):
+        assert sr.monotonic_trend([56.0, 61.0, 60.0, 74.0], direction="up") is False
+        assert sr.monotonic_trend([56.0, 56.0], direction="up") is False  # plateau
+        assert sr.monotonic_trend([56.0], direction="up") is False        # one point
+        assert sr.monotonic_trend([], direction="up") is False
+
+
+class TestCsvModel:
+    def test_write_then_read_round_trip(self, tmp_path):
+        csv_path = tmp_path / "snapshots.csv"
+        sr.write_snapshot(csv_path, {"label": "before-run-1", "soc_temp": "56.0"})
+        sr.write_snapshot(csv_path, {"label": "after-run-1", "soc_temp": "61.0"})
+        rows = sr.read_snapshots(csv_path)
+        assert [r["label"] for r in rows] == ["before-run-1", "after-run-1"]
+        assert rows[1]["soc_temp"] == "61.0"
+
+
+class TestAnalyze:
+    def test_climbing_soc_temp_flags_h4(self):
+        rows = [
+            {"label": "r1", "soc_temp": "56.0"},
+            {"label": "r2", "soc_temp": "63.0"},
+            {"label": "r3", "soc_temp": "71.0"},
+        ]
+        flags = sr.analyze(rows)
+        flagged = {f.metric: f.hypothesis for f in flags}
+        assert flagged.get("soc_temp") == "H4"
+
+    def test_falling_disk_free_flags_disk(self):
+        rows = [
+            {"label": "r1", "disk_free_mb": "900"},
+            {"label": "r2", "disk_free_mb": "500"},
+            {"label": "r3", "disk_free_mb": "120"},
+        ]
+        flagged = {f.metric: f.hypothesis for f in sr.analyze(rows)}
+        assert flagged.get("disk_free_mb") == "DISK"
+
+    def test_flat_or_noisy_metric_is_not_flagged(self):
+        rows = [
+            {"label": "r1", "ctrl_rss": "100000"},
+            {"label": "r2", "ctrl_rss": "100000"},  # flat
+            {"label": "r3", "ctrl_rss": "99000"},   # dips
+        ]
+        assert "ctrl_rss" not in {f.metric for f in sr.analyze(rows)}
+
+    def test_blank_and_non_numeric_values_are_skipped(self):
+        # Missing sources leave blank cells; analysis must not crash, and a
+        # series reduced below 2 numeric points must not be flagged.
+        rows = [
+            {"label": "r1", "app_fds": "", "soc_temp": "not-a-number"},
+            {"label": "r2", "app_fds": "50", "soc_temp": ""},
+            {"label": "r3", "app_fds": "", "soc_temp": "60.0"},
+        ]
+        flags = sr.analyze(rows)  # must not raise
+        assert "app_fds" not in {f.metric for f in flags}
+        assert "soc_temp" not in {f.metric for f in flags}

--- a/tests/unit/test_snapshot_resources.py
+++ b/tests/unit/test_snapshot_resources.py
@@ -77,3 +77,23 @@ class TestAnalyze:
         flags = sr.analyze(rows)  # must not raise
         assert "app_fds" not in {f.metric for f in flags}
         assert "soc_temp" not in {f.metric for f in flags}
+
+
+class TestHistoryBytes:
+    def test_finds_logs_history_json(self, tmp_path):
+        # The real device path is logs/history.json (BASE_DIR/logs/history.json).
+        logs = tmp_path / "logs"
+        logs.mkdir()
+        (logs / "history.json").write_text("x" * 123)
+        size = sr.first_existing_size([
+            str(tmp_path / "data" / "history.json"),   # absent
+            str(logs / "history.json"),                # present
+        ])
+        assert size == "123"
+
+    def test_returns_blank_when_none_exist(self, tmp_path):
+        assert sr.first_existing_size([str(tmp_path / "nope.json")]) == ""
+
+    def test_default_candidates_include_logs_path_first(self):
+        # Regression guard for the reported bug: logs/ must be checked.
+        assert "logs/history.json" in sr.HISTORY_CANDIDATES


### PR DESCRIPTION
## What Changed

Snapshot_resources.py: a script that captures a labeled snapshot of host/process metrics (thread count, etc.) once per run and prints a run-over-run difference table. Helps us identify why a safety net is fired if Trigger 2 is the culprit. 

## Why

https://github.com/AcornGenetics/aquilla-main/issues/160

## Spec

Link to the spec this implements or modifies:
`specs/analysis/snapshot-resources.md`

If no spec exists and this is a non-trivial change, explain why.

## Changes Made

- [x] Source code modified
- [x] Spec updated to match implementation
- [x] New tests written
- [x] Existing tests still pass
- [x] No secrets or `.env` files in this diff
- [ ] ADR written (if an irreversible architectural decision was made)
- [ ] `docs/debugging/known-issues.md` updated (if new edge cases were found)

## Hardware Testing

- [ ] Tested on physical device
- [ ] Tested in simulation mode only — reason: [why physical not possible]
- [ ] Hardware not relevant to this change

## Reviewer Notes

Anything the reviewer should know: tricky parts, things to focus on, known limitations.
