### PR TITLE
Suppress run name suggestion and add Custom optics-path dropdown with recent-path history

### DIFF
--- a/aquila_web/main.py
+++ b/aquila_web/main.py
@@ -46,6 +46,8 @@ if str(BASE_DIR) not in sys.path:
 RESULTS_DIR = BASE_DIR / "logs" / "results"
 PLOTS_DIR = BASE_DIR / "logs" / "plots"
 HISTORY_PATH = BASE_DIR / "logs" / "history.json"
+OPTICS_PATHS_PATH = BASE_DIR / "logs" / "optics_paths.json"
+OPTICS_PATHS_LIMIT = 20
 DEFAULT_PROFILE_DIR = BASE_DIR / "profiles"
 LOCAL_PROFILE_DIR = MODULE_BASE_DIR / "profiles"
 BUNDLED_PROFILE_DIR = DEFAULT_PROFILE_DIR / "bundled"
@@ -733,16 +735,45 @@ async def delete_history(payload: dict):
     _save_history(remaining)
     return {"ok": True, "remaining": len(remaining)}
 
+def _load_optics_paths() -> list[str]:
+    if not OPTICS_PATHS_PATH.exists():
+        return []
+    try:
+        with OPTICS_PATHS_PATH.open() as f:
+            data = json.load(f)
+        if isinstance(data, list):
+            return [str(p) for p in data if isinstance(p, str) and p.strip()]
+    except Exception:
+        return []
+    return []
+
+def _save_optics_paths(paths: list[str]) -> None:
+    OPTICS_PATHS_PATH.parent.mkdir(parents=True, exist_ok=True)
+    with OPTICS_PATHS_PATH.open("w") as f:
+        json.dump(paths, f, indent=2)
+
+def _remember_optics_path(path: str) -> list[str]:
+    """Add path to the front of the history (most-recent-first), deduped and capped."""
+    history = _load_optics_paths()
+    history = [p for p in history if p != path]
+    history.insert(0, path)
+    history = history[:OPTICS_PATHS_LIMIT]
+    _save_optics_paths(history)
+    return history
+
 @app.get("/dev/optics_path")
 async def get_dev_optics_path():
-    return {"path": dev_optics_path}
+    return {"path": dev_optics_path, "history": _load_optics_paths()}
 
 @app.post("/dev/optics_path")
 async def set_dev_optics_path(payload: dict):
     global dev_optics_path
     path = payload.get("path") if isinstance(payload, dict) else None
     dev_optics_path = path.strip() if path else None
-    return {"path": dev_optics_path}
+    history = _load_optics_paths()
+    if dev_optics_path:
+        history = _remember_optics_path(dev_optics_path)
+    return {"path": dev_optics_path, "history": history}
 
 @app.get("/run/name")
 async def get_run_name():

--- a/aquila_web/static/run.html
+++ b/aquila_web/static/run.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=768, height=1024, initial-scale=1" />
   <title>Run</title>
-  <link rel="stylesheet" href="static/styles.css?v=218" />
+  <link rel="stylesheet" href="static/styles.css?v=219" />
 </head>
 <body class="app-body">
   <div class="app-shell">
@@ -36,7 +36,15 @@
           <div class="run-meta run-meta--info">
             <div class="run-meta-item">
               <span class="run-meta-label">Profile</span>
-              <select id="mySelect" class="run-profile-select"></select>
+              <div class="profile-combo" id="profile-combo">
+                <select id="mySelect" class="profile-combo__native"></select>
+                <button type="button" class="run-profile-select profile-combo__button"
+                        id="profile-combo-button" aria-haspopup="listbox" aria-expanded="false">
+                  <span class="profile-combo__label" id="profile-combo-label">Select a profile</span>
+                  <span class="profile-combo__chevron" aria-hidden="true">▾</span>
+                </button>
+                <ul class="profile-combo__list is-hidden" id="profile-combo-list" role="listbox"></ul>
+              </div>
             </div>
             <div class="run-meta-item">
               <span class="run-meta-label">Run Name</span>
@@ -153,7 +161,7 @@
     </main>
   </div>
   <script src="static/nav.js?v=1"></script>
-  <script src="static/script.js?v=68"></script>
+  <script src="static/script.js?v=69"></script>
   <script src="static/keyboard.js?v=14"></script>
 </body>
 </html>

--- a/aquila_web/static/run.html
+++ b/aquila_web/static/run.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=768, height=1024, initial-scale=1" />
   <title>Run</title>
-  <link rel="stylesheet" href="static/styles.css?v=217" />
+  <link rel="stylesheet" href="static/styles.css?v=218" />
 </head>
 <body class="app-body">
   <div class="app-shell">
@@ -13,7 +13,12 @@
         <h1 class="run-header__title">Run</h1>
         <div class="run-optics-tab" id="run-optics-tab">
           <span>Optics:</span>
-          <input id="dev-optics-path" type="text" placeholder="/path/to/optics.log" />
+          <div class="optics-combo" id="optics-combo">
+            <input id="dev-optics-path" type="text" placeholder="/path/to/optics.log"
+                   autocomplete="off" role="combobox" aria-expanded="false"
+                   aria-controls="optics-suggestions" aria-autocomplete="list" />
+            <ul class="optics-suggestions is-hidden" id="optics-suggestions" role="listbox"></ul>
+          </div>
         </div>
         <nav class="run-header__nav">
           <a class="run-nav-link" href="/run">Run</a>
@@ -35,7 +40,7 @@
             </div>
             <div class="run-meta-item">
               <span class="run-meta-label">Run Name</span>
-              <input id="run-name-input" class="run-name-input" type="text" />
+              <input id="run-name-input" class="run-name-input" type="text" autocomplete="off" />
             </div>
             <div class="run-secondary-actions" id="drawer-actions">
               <button class="run-secondary-btn" onclick="notifyDrawerOpen()" type="button">Open Drawer</button>
@@ -148,7 +153,7 @@
     </main>
   </div>
   <script src="static/nav.js?v=1"></script>
-  <script src="static/script.js?v=67"></script>
+  <script src="static/script.js?v=68"></script>
   <script src="static/keyboard.js?v=14"></script>
 </body>
 </html>

--- a/aquila_web/static/script.js
+++ b/aquila_web/static/script.js
@@ -1075,9 +1075,116 @@ async function loadProfiles(){
             }
         });
 
+        renderProfileCombo();
+        syncProfileComboLabel();
+
     } catch (err) {
         console.error("Error loading profiles:" , err);
     }
+}
+
+// Custom profile dropdown: a styled, app-controlled list (consistent across
+// browsers/machines) layered over the hidden native <select id="mySelect">,
+// which stays the source of truth for the rest of the run logic.
+function renderProfileCombo() {
+    const select = document.getElementById("mySelect");
+    const list = document.getElementById("profile-combo-list");
+    if (!select || !list) {
+        return;
+    }
+    list.innerHTML = "";
+    Array.from(select.options).forEach((opt) => {
+        if (opt.disabled || opt.value === "") {
+            return; // skip the "Select a profile" placeholder
+        }
+        const li = document.createElement("li");
+        li.className = "profile-combo__option";
+        li.setAttribute("role", "option");
+        li.textContent = opt.textContent;
+        li.dataset.value = opt.value;
+        if (opt.selected) {
+            li.classList.add("is-selected");
+        }
+        li.addEventListener("click", () => {
+            Array.from(select.options).forEach((o) => { o.selected = (o === opt); });
+            select.value = opt.value;
+            closeProfileCombo();
+            syncProfileComboLabel();
+            // Drive the existing native-select change handler (POST + labels)
+            select.dispatchEvent(new Event("change"));
+        });
+        list.appendChild(li);
+    });
+}
+
+function syncProfileComboLabel() {
+    const select = document.getElementById("mySelect");
+    const label = document.getElementById("profile-combo-label");
+    const list = document.getElementById("profile-combo-list");
+    if (!select || !label) {
+        return;
+    }
+    const selected = select.selectedOptions && select.selectedOptions[0];
+    const hasRealSelection = selected && selected.value !== "";
+    label.textContent = hasRealSelection ? selected.textContent : "Select a profile";
+    if (list) {
+        Array.from(list.children).forEach((li) => {
+            li.classList.toggle("is-selected", hasRealSelection && li.dataset.value === select.value);
+        });
+    }
+}
+
+function closeProfileCombo() {
+    const combo = document.getElementById("profile-combo");
+    const list = document.getElementById("profile-combo-list");
+    const button = document.getElementById("profile-combo-button");
+    if (!combo || !list || !button) {
+        return;
+    }
+    combo.classList.remove("is-open");
+    list.classList.add("is-hidden");
+    button.setAttribute("aria-expanded", "false");
+}
+
+function openProfileCombo() {
+    const combo = document.getElementById("profile-combo");
+    const list = document.getElementById("profile-combo-list");
+    const button = document.getElementById("profile-combo-button");
+    if (!combo || !list || !button) {
+        return;
+    }
+    combo.classList.add("is-open");
+    list.classList.remove("is-hidden");
+    button.setAttribute("aria-expanded", "true");
+}
+
+function setupProfileCombo() {
+    const combo = document.getElementById("profile-combo");
+    const button = document.getElementById("profile-combo-button");
+    const list = document.getElementById("profile-combo-list");
+    if (!combo || !button || !list) {
+        return;
+    }
+    button.addEventListener("click", () => {
+        if (list.classList.contains("is-hidden")) {
+            openProfileCombo();
+        } else {
+            closeProfileCombo();
+        }
+    });
+    button.addEventListener("keydown", (event) => {
+        if (event.key === "Escape") {
+            closeProfileCombo();
+        } else if (event.key === "ArrowDown" && list.classList.contains("is-hidden")) {
+            event.preventDefault();
+            openProfileCombo();
+        }
+    });
+    document.addEventListener("click", (event) => {
+        if (!combo.contains(event.target)) {
+            closeProfileCombo();
+        }
+    });
 }
 
 // Custom optics-path combobox: a styled, app-controlled dropdown (consistent
@@ -1248,6 +1355,9 @@ document.addEventListener("DOMContentLoaded", () => {
     }
     if (stopRunButton) {
         stopRunButton.addEventListener("click", notifyStopRun);
+    }
+    if (typeof setupProfileCombo === "function") {
+        setupProfileCombo();
     }
     if (typeof loadProfiles === "function") {
         loadProfiles();

--- a/aquila_web/static/script.js
+++ b/aquila_web/static/script.js
@@ -20,6 +20,7 @@ const runReadyPill = document.querySelector(".run-ready-pill");
 const drawerActions = document.getElementById("drawer-actions");
 const devOpticsPath = document.getElementById("dev-optics-path");
 const devOpticsWrapper = document.getElementById("run-optics-tab");
+const devOpticsSuggestions = document.getElementById("optics-suggestions");
 const runNameInput = document.getElementById("run-name-input");
 const runWarning = document.getElementById("run-warning");
 const drawerWarning = document.getElementById("drawer-warning");
@@ -1079,6 +1080,116 @@ async function loadProfiles(){
     }
 }
 
+// Custom optics-path combobox: a styled, app-controlled dropdown (consistent
+// across browsers/machines) backed by server-stored path history.
+function setupOpticsCombo(history) {
+    if (!devOpticsPath || !devOpticsSuggestions) {
+        return;
+    }
+    let opticsHistory = Array.isArray(history) ? history.slice() : [];
+    let activeIndex = -1;
+    let visiblePaths = [];
+
+    const closeList = () => {
+        devOpticsSuggestions.classList.add("is-hidden");
+        devOpticsPath.setAttribute("aria-expanded", "false");
+        activeIndex = -1;
+    };
+
+    const renderList = (filterText) => {
+        const query = (filterText || "").trim().toLowerCase();
+        visiblePaths = opticsHistory.filter((p) => p.toLowerCase().includes(query));
+        devOpticsSuggestions.innerHTML = "";
+        if (visiblePaths.length === 0) {
+            closeList();
+            return;
+        }
+        visiblePaths.forEach((path, idx) => {
+            const li = document.createElement("li");
+            li.className = "optics-suggestion";
+            li.setAttribute("role", "option");
+            li.textContent = path;
+            li.dataset.index = String(idx);
+            // mousedown fires before the input's blur, so the click registers
+            li.addEventListener("mousedown", (event) => {
+                event.preventDefault();
+                selectPath(path);
+            });
+            devOpticsSuggestions.appendChild(li);
+        });
+        activeIndex = -1;
+        devOpticsSuggestions.classList.remove("is-hidden");
+        devOpticsPath.setAttribute("aria-expanded", "true");
+    };
+
+    const highlight = () => {
+        Array.from(devOpticsSuggestions.children).forEach((li, idx) => {
+            li.classList.toggle("is-active", idx === activeIndex);
+        });
+    };
+
+    const savePath = async (path) => {
+        try {
+            const resp = await fetch("/dev/optics_path", {
+                method: "POST",
+                headers: { "Content-Type": "application/json" },
+                body: JSON.stringify({ path })
+            });
+            if (resp.ok) {
+                const data = await resp.json();
+                if (Array.isArray(data.history)) {
+                    opticsHistory = data.history;
+                }
+            }
+        } catch (error) {
+            console.error("Failed to save optics path", error);
+        }
+    };
+
+    const selectPath = (path) => {
+        devOpticsPath.value = path;
+        closeList();
+        savePath(path);
+    };
+
+    devOpticsPath.addEventListener("focus", () => renderList(""));
+    devOpticsPath.addEventListener("input", () => renderList(devOpticsPath.value));
+
+    devOpticsPath.addEventListener("keydown", (event) => {
+        const open = !devOpticsSuggestions.classList.contains("is-hidden");
+        if (event.key === "ArrowDown") {
+            event.preventDefault();
+            if (!open) { renderList(devOpticsPath.value); return; }
+            activeIndex = Math.min(activeIndex + 1, visiblePaths.length - 1);
+            highlight();
+        } else if (event.key === "ArrowUp") {
+            event.preventDefault();
+            activeIndex = Math.max(activeIndex - 1, 0);
+            highlight();
+        } else if (event.key === "Enter") {
+            if (open && activeIndex >= 0) {
+                event.preventDefault();
+                selectPath(visiblePaths[activeIndex]);
+            }
+        } else if (event.key === "Escape") {
+            closeList();
+        }
+    });
+
+    devOpticsPath.addEventListener("blur", () => {
+        // Delay so a suggestion mousedown can resolve first
+        setTimeout(closeList, 120);
+        const path = devOpticsPath.value.trim();
+        savePath(path);
+    });
+
+    document.addEventListener("click", (event) => {
+        if (!devOpticsWrapper.contains(event.target)) {
+            closeList();
+        }
+    });
+}
+
 
 document.addEventListener("DOMContentLoaded", () => {
     setupTubeNameInputs();
@@ -1121,20 +1232,9 @@ document.addEventListener("DOMContentLoaded", () => {
                 if (data && data.path) {
                   devOpticsPath.value = data.path;
                 }
+                setupOpticsCombo(Array.isArray(data && data.history) ? data.history : []);
               })
-              .catch(() => null);
-            devOpticsPath.addEventListener("blur", async () => {
-                const path = devOpticsPath.value.trim();
-                try {
-                    await fetch("/dev/optics_path", {
-                        method: "POST",
-                        headers: { "Content-Type": "application/json" },
-                        body: JSON.stringify({ path })
-                    });
-                } catch (error) {
-                    console.error("Failed to save optics path", error);
-                }
-            });
+              .catch(() => setupOpticsCombo([]));
         }
       })
       .catch(() => {

--- a/aquila_web/static/styles.css
+++ b/aquila_web/static/styles.css
@@ -200,6 +200,44 @@ a:active {
   outline: none;
 }
 
+.optics-combo {
+  position: relative;
+  display: inline-block;
+}
+
+.optics-suggestions {
+  position: absolute;
+  top: calc(100% + 8px);
+  left: 0;
+  z-index: 1000;
+  margin: 0;
+  padding: 6px;
+  list-style: none;
+  width: 260px;
+  max-height: 220px;
+  overflow-y: auto;
+  background: #ffffff;
+  border: 1px solid #e2e8f0;
+  border-radius: 16px;
+  box-shadow: 0 6px 14px rgba(15, 23, 42, 0.08);
+}
+
+.optics-suggestion {
+  padding: 10px 14px;
+  font-size: 14px;
+  color: #111827;
+  border-radius: 12px;
+  cursor: pointer;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.optics-suggestion:hover,
+.optics-suggestion.is-active {
+  background: #f8fafc;
+}
+
 .run-header__title {
   margin: 0;
   font-family: "ABC Favorit Mono", "Courier New", monospace;

--- a/aquila_web/static/styles.css
+++ b/aquila_web/static/styles.css
@@ -599,6 +599,79 @@ a:active {
   background: #f8fafc;
 }
 
+.profile-combo {
+  position: relative;
+  width: 100%;
+}
+
+.profile-combo__native {
+  display: none;
+}
+
+.profile-combo__button {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  cursor: pointer;
+  font-family: inherit;
+}
+
+.profile-combo__label {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.profile-combo__chevron {
+  flex-shrink: 0;
+  font-size: 14px;
+  color: #64748b;
+  transition: transform 0.15s ease;
+}
+
+.profile-combo.is-open .profile-combo__chevron {
+  transform: rotate(180deg);
+}
+
+.profile-combo__list {
+  position: absolute;
+  top: calc(100% + 8px);
+  left: 0;
+  right: 0;
+  z-index: 1000;
+  margin: 0;
+  padding: 6px;
+  list-style: none;
+  max-height: 280px;
+  overflow-y: auto;
+  background: #ffffff;
+  border: 1px solid #e2e8f0;
+  border-radius: 16px;
+  box-shadow: 0 6px 14px rgba(15, 23, 42, 0.08);
+}
+
+.profile-combo__option {
+  padding: 12px 16px;
+  font-size: 18px;
+  color: #111827;
+  border-radius: 12px;
+  cursor: pointer;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.profile-combo__option:hover,
+.profile-combo__option.is-active {
+  background: #f8fafc;
+}
+
+.profile-combo__option.is-selected {
+  background: #eef2f7;
+  font-weight: 600;
+}
+
 .run-meta-divider {
   width: 1px;
   height: 40px;

--- a/tests/contract/test_optics_path_endpoints.py
+++ b/tests/contract/test_optics_path_endpoints.py
@@ -1,0 +1,76 @@
+"""
+Contract tests for the dev optics-path endpoints and server-stored history.
+
+GET/POST /dev/optics_path persist a most-recent-first, deduped, capped history
+of optics paths used to back the custom optics-path dropdown on the run page.
+
+Run with:
+
+    pytest tests/contract/ -m contract
+"""
+import pytest
+
+
+@pytest.fixture
+def optics_client(client, tmp_path, monkeypatch):
+    """Client whose optics-path history is isolated to a temp file."""
+    from aquila_web import main as web_main
+
+    monkeypatch.setattr(web_main, "OPTICS_PATHS_PATH", tmp_path / "optics_paths.json")
+    return client
+
+
+@pytest.mark.contract
+def test_get_optics_path_returns_path_and_history(optics_client):
+    """GET /dev/optics_path must return both the current path and a history list."""
+    response = optics_client.get("/dev/optics_path")
+    assert response.status_code == 200
+    body = response.json()
+    assert "path" in body
+    assert isinstance(body["history"], list)
+
+
+@pytest.mark.contract
+def test_post_optics_path_records_history(optics_client):
+    """POST /dev/optics_path stores the path and adds it to the history."""
+    response = optics_client.post("/dev/optics_path", json={"path": "/data/a.log"})
+    assert response.status_code == 200
+    body = response.json()
+    assert body["path"] == "/data/a.log"
+    assert "/data/a.log" in body["history"]
+
+
+@pytest.mark.contract
+def test_post_optics_path_most_recent_first(optics_client):
+    """Newly entered paths appear at the front of the history."""
+    optics_client.post("/dev/optics_path", json={"path": "/data/first.log"})
+    body = optics_client.post("/dev/optics_path", json={"path": "/data/second.log"}).json()
+    assert body["history"][0] == "/data/second.log"
+    assert body["history"][1] == "/data/first.log"
+
+
+@pytest.mark.contract
+def test_post_optics_path_deduplicates(optics_client):
+    """Re-entering a path moves it to the front without duplicating it."""
+    optics_client.post("/dev/optics_path", json={"path": "/data/a.log"})
+    optics_client.post("/dev/optics_path", json={"path": "/data/b.log"})
+    body = optics_client.post("/dev/optics_path", json={"path": "/data/a.log"}).json()
+    assert body["history"].count("/data/a.log") == 1
+    assert body["history"][0] == "/data/a.log"
+
+
+@pytest.mark.contract
+def test_post_blank_path_does_not_record(optics_client):
+    """An empty path clears the current selection and is not added to history."""
+    optics_client.post("/dev/optics_path", json={"path": "/data/a.log"})
+    body = optics_client.post("/dev/optics_path", json={"path": ""}).json()
+    assert body["path"] is None
+    assert "" not in body["history"]
+
+
+@pytest.mark.contract
+def test_history_persists_across_requests(optics_client):
+    """History written by POST is readable by a later GET."""
+    optics_client.post("/dev/optics_path", json={"path": "/data/persist.log"})
+    body = optics_client.get("/dev/optics_path").json()
+    assert "/data/persist.log" in body["history"]


### PR DESCRIPTION
Replaces the browser's native autofill on the optics field with a custom, app-styled dropdown backed by server-stored path history (most-recent-first, deduped, capped at 20). Adds contract tests for the /dev/optics_path history endpoint.