### PR TITLE
Add cosmetic dropdown overlays for run page

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -18,6 +18,9 @@ The Raspberry Pi hardware serial number (from `/proc/cpuinfo`), used as the stab
 **Protocol**
 A named PCR assay profile — a JSON file in `profiles/` that defines thermal steps, cycle count, and optical configuration. The `title` field in the JSON is the canonical protocol name. Protocols are the primary grouping dimension for analytics (e.g., "inconclusive rate by protocol").
 
+**Profile**
+The operator-facing name for a Protocol. The Run screen labels the protocol picker "Profile," and protocols are stored on-disk as `profiles/*.json`. "Profile" is the correct term at the UI and on-disk-artifact layer; "Protocol" is the canonical analytics/domain term for the same thing. There is no case where a Profile is not a Protocol — they are the same concept named for two audiences.
+
 **Run**
 A single execution of a Protocol on a Sentri, producing results for up to 4 Wells. A Run has a start time, end time, and status (completed, aborted). A Run is the unit of event emission — one `run_complete` event per Run.
 

--- a/aquila_web/main.py
+++ b/aquila_web/main.py
@@ -733,16 +733,55 @@ async def delete_history(payload: dict):
     _save_history(remaining)
     return {"ok": True, "remaining": len(remaining)}
 
+OPTICS_PATHS_PATH = BASE_DIR / "logs" / "optics_paths.json"
+OPTICS_PATHS_LIMIT = 20
+
+
+def _merge_optics_history(history, path):
+    """Pure: return new most-recent-first history with ``path`` merged in.
+
+    Blank/whitespace/None ``path`` is a no-op and returns the history unchanged.
+    Otherwise the (stripped) path is deduped and prepended, capped at the limit.
+    """
+    cleaned = (path or "").strip()
+    if not cleaned:
+        return list(history)
+    deduped = [p for p in history if p != cleaned]
+    return [cleaned, *deduped][:OPTICS_PATHS_LIMIT]
+
+
+def _load_optics_history() -> list:
+    if not OPTICS_PATHS_PATH.exists():
+        return []
+    try:
+        with OPTICS_PATHS_PATH.open() as f:
+            data = json.load(f)
+        if isinstance(data, list):
+            return data
+    except Exception:
+        return []
+    return []
+
+
+def _save_optics_history(history) -> None:
+    OPTICS_PATHS_PATH.parent.mkdir(parents=True, exist_ok=True)
+    with OPTICS_PATHS_PATH.open("w") as f:
+        json.dump(history, f, indent=2)
+
+
 @app.get("/dev/optics_path")
 async def get_dev_optics_path():
-    return {"path": dev_optics_path}
+    return {"path": dev_optics_path, "history": _load_optics_history()}
 
 @app.post("/dev/optics_path")
 async def set_dev_optics_path(payload: dict):
     global dev_optics_path
     path = payload.get("path") if isinstance(payload, dict) else None
-    dev_optics_path = path.strip() if path else None
-    return {"path": dev_optics_path}
+    cleaned = path.strip() if path else None
+    dev_optics_path = cleaned or None
+    history = _merge_optics_history(_load_optics_history(), cleaned)
+    _save_optics_history(history)
+    return {"path": dev_optics_path, "history": history}
 
 @app.get("/run/name")
 async def get_run_name():

--- a/aquila_web/static/run.html
+++ b/aquila_web/static/run.html
@@ -13,7 +13,10 @@
         <h1 class="run-header__title">Run</h1>
         <div class="run-optics-tab" id="run-optics-tab">
           <span>Optics:</span>
-          <input id="dev-optics-path" type="text" placeholder="/path/to/optics.log" />
+          <div class="optics-combo" id="optics-combo">
+            <input id="dev-optics-path" class="keyboard-ignore" type="text" placeholder="/path/to/optics.log" autocomplete="off" role="combobox" aria-autocomplete="list" aria-expanded="false" />
+            <ul id="optics-suggestions" class="combo-list optics-suggestions" role="listbox"></ul>
+          </div>
         </div>
         <nav class="run-header__nav">
           <a class="run-nav-link" href="/run">Run</a>
@@ -31,11 +34,18 @@
           <div class="run-meta run-meta--info">
             <div class="run-meta-item">
               <span class="run-meta-label">Profile</span>
-              <select id="mySelect" class="run-profile-select"></select>
+              <div class="profile-combo" id="profile-combo">
+                <select id="mySelect" class="run-profile-select" style="display:none"></select>
+                <button type="button" id="profile-combo-button" class="run-profile-select" aria-haspopup="listbox" aria-expanded="false">
+                  <span id="profile-combo-label">Select a profile</span>
+                  <span class="profile-combo-chevron" aria-hidden="true">▾</span>
+                </button>
+                <ul id="profile-combo-list" class="combo-list" role="listbox"></ul>
+              </div>
             </div>
             <div class="run-meta-item">
               <span class="run-meta-label">Run Name</span>
-              <input id="run-name-input" class="run-name-input" type="text" />
+              <input id="run-name-input" class="run-name-input" type="text" autocomplete="off" />
             </div>
             <div class="run-secondary-actions" id="drawer-actions">
               <button class="run-secondary-btn" onclick="notifyDrawerOpen()" type="button">Open Drawer</button>

--- a/aquila_web/static/script.js
+++ b/aquila_web/static/script.js
@@ -253,6 +253,11 @@ function updateDashboardSections(screen) {
     }
   });
 
+  if (screen !== "ready") {
+    if (typeof closeProfileCombo === "function") closeProfileCombo();
+    if (typeof closeOpticsCombo === "function") closeOpticsCombo();
+  }
+
   setRunResetVisibility(true);
 
   return true;
@@ -968,6 +973,190 @@ async function loadResults(){
     }
 }
 
+function syncProfileComboLabel() {
+    const select = document.getElementById("mySelect");
+    const label = document.getElementById("profile-combo-label");
+    if (!select || !label) return;
+    const opt = select.selectedOptions && select.selectedOptions[0];
+    label.textContent = (opt && !opt.disabled && opt.value) ? opt.textContent : "Select a profile";
+}
+
+function openProfileCombo() {
+    const btn = document.getElementById("profile-combo-button");
+    const list = document.getElementById("profile-combo-list");
+    if (!btn || !list) return;
+    list.classList.add("is-open");
+    btn.setAttribute("aria-expanded", "true");
+}
+
+function closeProfileCombo() {
+    const btn = document.getElementById("profile-combo-button");
+    const list = document.getElementById("profile-combo-list");
+    if (!btn || !list) return;
+    list.classList.remove("is-open");
+    btn.setAttribute("aria-expanded", "false");
+}
+
+function renderProfileCombo() {
+    const select = document.getElementById("mySelect");
+    const list = document.getElementById("profile-combo-list");
+    if (!select || !list) return;
+    list.innerHTML = "";
+    Array.from(select.options).forEach((opt) => {
+        if (opt.disabled || opt.value === "") return; // skip placeholder
+        const li = document.createElement("li");
+        li.setAttribute("role", "option");
+        li.dataset.value = opt.value;
+        li.textContent = opt.textContent;
+        li.addEventListener("click", () => {
+            select.value = opt.value;
+            select.dispatchEvent(new Event("change", { bubbles: true }));
+            syncProfileComboLabel();
+            closeProfileCombo();
+        });
+        list.appendChild(li);
+    });
+    syncProfileComboLabel();
+}
+
+function setupProfileCombo() {
+    const btn = document.getElementById("profile-combo-button");
+    const list = document.getElementById("profile-combo-list");
+    if (!btn || !list || btn.dataset.comboReady) return;
+    btn.dataset.comboReady = "1";
+    btn.addEventListener("click", (event) => {
+        event.stopPropagation();
+        if (list.classList.contains("is-open")) closeProfileCombo();
+        else openProfileCombo();
+    });
+    btn.addEventListener("keydown", (event) => {
+        if (event.key === "ArrowDown") {
+            event.preventDefault();
+            openProfileCombo();
+        } else if (event.key === "Escape") {
+            closeProfileCombo();
+        }
+    });
+    document.addEventListener("keydown", (event) => {
+        if (event.key === "Escape") closeProfileCombo();
+    });
+    document.addEventListener("click", (event) => {
+        const combo = document.getElementById("profile-combo");
+        if (combo && !combo.contains(event.target)) closeProfileCombo();
+    });
+}
+
+let opticsHistory = [];
+let opticsActiveIndex = -1;
+
+function closeOpticsCombo() {
+    const input = document.getElementById("dev-optics-path");
+    const list = document.getElementById("optics-suggestions");
+    if (!list) return;
+    list.classList.remove("is-open");
+    if (input) input.setAttribute("aria-expanded", "false");
+    opticsActiveIndex = -1;
+}
+
+function renderOpticsSuggestions(filterText) {
+    const input = document.getElementById("dev-optics-path");
+    const list = document.getElementById("optics-suggestions");
+    if (!input || !list) return;
+    const needle = (filterText || "").trim().toLowerCase();
+    const matches = opticsHistory.filter((p) => p.toLowerCase().includes(needle));
+    list.innerHTML = "";
+    if (matches.length === 0) {
+        closeOpticsCombo();
+        return;
+    }
+    matches.forEach((path) => {
+        const li = document.createElement("li");
+        li.setAttribute("role", "option");
+        li.dataset.value = path;
+        li.textContent = path;
+        li.addEventListener("mousedown", (event) => {
+            event.preventDefault();  // fire before input blur
+            input.value = path;
+            saveOpticsPath(path);
+            closeOpticsCombo();
+        });
+        list.appendChild(li);
+    });
+    list.classList.add("is-open");
+    input.setAttribute("aria-expanded", "true");
+    opticsActiveIndex = -1;
+}
+
+function moveOpticsActive(delta) {
+    const list = document.getElementById("optics-suggestions");
+    if (!list) return;
+    const items = Array.from(list.querySelectorAll("[role='option']"));
+    if (items.length === 0) return;
+    opticsActiveIndex = (opticsActiveIndex + delta + items.length) % items.length;
+    items.forEach((el, i) => el.classList.toggle("is-active", i === opticsActiveIndex));
+}
+
+async function saveOpticsPath(path) {
+    try {
+        const resp = await fetch("/dev/optics_path", {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({ path })
+        });
+        if (resp.ok) {
+            const data = await resp.json();
+            if (data && Array.isArray(data.history)) opticsHistory = data.history;
+        }
+    } catch (error) {
+        console.error("Failed to save optics path", error);
+    }
+}
+
+async function setupOpticsCombo() {
+    const input = document.getElementById("dev-optics-path");
+    const list = document.getElementById("optics-suggestions");
+    if (!input || !list || input.dataset.comboReady) return;
+    input.dataset.comboReady = "1";
+    try {
+        const resp = await fetch("/dev/optics_path");
+        if (resp.ok) {
+            const data = await resp.json();
+            if (data && data.path) input.value = data.path;
+            if (data && Array.isArray(data.history)) opticsHistory = data.history;
+        }
+    } catch (error) {
+        console.error("Failed to load optics path", error);
+    }
+    input.addEventListener("focus", () => renderOpticsSuggestions(input.value));
+    input.addEventListener("input", () => renderOpticsSuggestions(input.value));
+    input.addEventListener("keydown", (event) => {
+        const items = Array.from(list.querySelectorAll("[role='option']"));
+        if (event.key === "ArrowDown") {
+            event.preventDefault();
+            moveOpticsActive(1);
+        } else if (event.key === "ArrowUp") {
+            event.preventDefault();
+            moveOpticsActive(-1);
+        } else if (event.key === "Enter") {
+            if (opticsActiveIndex >= 0 && items[opticsActiveIndex]) {
+                input.value = items[opticsActiveIndex].dataset.value;
+            }
+            saveOpticsPath(input.value.trim());
+            closeOpticsCombo();
+        } else if (event.key === "Escape") {
+            closeOpticsCombo();
+        }
+    });
+    input.addEventListener("blur", () => {
+        saveOpticsPath(input.value.trim());
+        closeOpticsCombo();
+    });
+    document.addEventListener("click", (event) => {
+        const combo = document.getElementById("optics-combo");
+        if (combo && !combo.contains(event.target)) closeOpticsCombo();
+    });
+}
+
 async function loadProfiles(){
     const select = document.getElementById("mySelect");
     if (!select){
@@ -1074,6 +1263,8 @@ async function loadProfiles(){
             }
         });
 
+        renderProfileCombo();
+
     } catch (err) {
         console.error("Error loading profiles:" , err);
     }
@@ -1115,26 +1306,7 @@ document.addEventListener("DOMContentLoaded", () => {
         const isDev = Boolean(status && status.dev_simulate);
         setOpticsVisibility(isDev);
         if (isDev && devOpticsPath) {
-            fetch("/dev/optics_path")
-              .then((response) => response.ok ? response.json() : null)
-              .then((data) => {
-                if (data && data.path) {
-                  devOpticsPath.value = data.path;
-                }
-              })
-              .catch(() => null);
-            devOpticsPath.addEventListener("blur", async () => {
-                const path = devOpticsPath.value.trim();
-                try {
-                    await fetch("/dev/optics_path", {
-                        method: "POST",
-                        headers: { "Content-Type": "application/json" },
-                        body: JSON.stringify({ path })
-                    });
-                } catch (error) {
-                    console.error("Failed to save optics path", error);
-                }
-            });
+            setupOpticsCombo();
         }
       })
       .catch(() => {
@@ -1149,6 +1321,7 @@ document.addEventListener("DOMContentLoaded", () => {
     if (stopRunButton) {
         stopRunButton.addEventListener("click", notifyStopRun);
     }
+    setupProfileCombo();
     if (typeof loadProfiles === "function") {
         loadProfiles();
     }

--- a/aquila_web/static/styles.css
+++ b/aquila_web/static/styles.css
@@ -561,6 +561,78 @@ a:active {
   background: #f8fafc;
 }
 
+.profile-combo {
+  position: relative;
+  width: 100%;
+}
+
+#profile-combo-button {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  cursor: pointer;
+}
+
+.profile-combo-chevron {
+  font-size: 16px;
+  color: #6b7280;
+  transition: transform 0.15s ease;
+}
+
+#profile-combo-button[aria-expanded="true"] .profile-combo-chevron {
+  transform: rotate(180deg);
+}
+
+.combo-list {
+  position: absolute;
+  top: calc(100% + 4px);
+  left: 0;
+  right: 0;
+  margin: 0;
+  padding: 4px;
+  list-style: none;
+  background: #ffffff;
+  border: 1px solid #e2e8f0;
+  border-radius: 16px;
+  box-shadow: 0 8px 24px rgba(15, 23, 42, 0.08);
+  z-index: 50;
+  max-height: 320px;
+  overflow-y: auto;
+  display: none;
+}
+
+.combo-list.is-open {
+  display: block;
+}
+
+.combo-list [role="option"] {
+  padding: 12px 14px;
+  font-size: 18px;
+  color: #111827;
+  border-radius: 12px;
+  cursor: pointer;
+}
+
+.combo-list [role="option"]:hover,
+.combo-list [role="option"].is-active {
+  background: #f8fafc;
+}
+
+.optics-combo {
+  position: relative;
+  display: inline-block;
+}
+
+.optics-suggestions {
+  min-width: 220px;
+}
+
+.optics-suggestions [role="option"] {
+  font-size: 14px;
+  padding: 8px 10px;
+}
+
 .run-meta-divider {
   width: 1px;
   height: 40px;

--- a/docs/adr/ADR-012-custom-dropdowns-as-cosmetic-overlays.md
+++ b/docs/adr/ADR-012-custom-dropdowns-as-cosmetic-overlays.md
@@ -1,0 +1,109 @@
+# ADR-012: Custom Dropdowns Are Cosmetic Overlays Over Native Form Controls
+
+**Status:** Accepted
+**Date:** 2026-06-16
+**Author:** Rasita Vajapattana
+**Deciders:** Aquila Engineering Team
+
+---
+
+## Context
+
+The Run screen renders form controls (the Profile picker, the dev-only optics-path
+input) whose appearance is decided by the browser/OS, not the app. On the kiosk fleet
+(ADR-005: Chromium kiosk on Raspberry Pi) this means the native `<select>` option list
+and the native autofill dropdown render with OS styling — dark background, system font,
+no border radius — which is visually inconsistent across machines and clashes with the
+themed UI. Kiosk units must look identical, so app-controlled styling is required
+(issue #166).
+
+The Profile `<select>` is not merely decorative: its value feeds run execution. The
+selected profile is read on run start (`/profile/select`), drives dye-label loading,
+and is preselected from the URL (`?profile=`) and `/button_status`. Existing reads rely
+on the standard `<select>` API (`value`, `selectedOptions`) and the `change` event.
+
+Constraints:
+- ADR-003: plain HTML/CSS/JS, no build step, no framework, manual component reuse.
+- A native `<select>`'s open option list cannot be themed by the app — the OS owns it.
+
+Live options were: (a) replace the native control entirely with a custom widget and
+rewrite every reader, or (b) keep the native control as a hidden source of truth and
+layer a themed widget on top.
+
+Doing nothing leaves the UI visually inconsistent across the fleet.
+
+---
+
+## Decision
+
+**We will build custom dropdowns as cosmetic overlays that leave the native form
+control in the DOM as the hidden source of truth.**
+
+Concretely, for the Profile picker:
+
+- `<select id="mySelect">` remains in the DOM, hidden (`display:none`). It stays the
+  authoritative value holder.
+- A themed `<button>` + `<ul role="listbox">` render the visible UI, mirroring the
+  select's `<option>`s.
+- Selecting a custom option writes the value to the hidden `<select>` and **dispatches
+  a synthetic `change` event**, so all existing readers and the `/profile/select` flow
+  work unmodified.
+
+The same principle applies to other native controls restyled in this codebase: restyle
+on top, never rip out the working control. (The dev-only optics field is an analogous
+custom typeahead over an existing `<input>`; the Run Name field suppresses native
+autofill via `autocomplete="off"` rather than replacing the input.)
+
+This is **reversible with effort** — the overlay can be removed to fall back to the
+native control — but the hidden control must not be deleted while the overlay exists.
+
+---
+
+## Consequences
+
+### Positive
+- Appearance is app-controlled and identical across the fleet (the issue's goal).
+- Run execution is untouched: the cosmetic change carries near-zero regression risk to
+  the run flow, and existing contract tests (`test_ready_screen_run_flow.py`) still
+  characterize real behavior through the unchanged `change`/`value` seam.
+- No framework or build step required — fits ADR-003.
+
+### Negative
+- Two representations of the same state (hidden control + visible overlay) must be kept
+  in sync; a sync bug shows stale labels.
+- A future reader may see the hidden `<select>` as dead code and be tempted to remove
+  it, which would silently break run execution. (This ADR exists to prevent that.)
+
+### Neutral / Tradeoffs
+- The overlay duplicates listbox/keyboard/dismissal behavior the browser gives for free
+  on a native control. On a touch kiosk this is acceptable; keyboard navigation is built
+  but only meaningfully exercised on the dev-only optics field.
+
+---
+
+## Alternatives Considered
+
+### Option A: Replace the native `<select>` entirely with a custom widget
+**Why rejected:** Forces rewriting every reader of the profile value and re-testing the
+whole run flow for a purely cosmetic change — high risk, no behavioral benefit.
+
+### Option B: Restyle the native control's option list with CSS
+**Why rejected:** Not possible — the OS owns the rendering of an open `<select>` list;
+CSS cannot theme it consistently across machines.
+
+---
+
+## Revisit Conditions
+
+- If the project ever adopts a frontend framework (reversing ADR-003), prefer a real
+  component over the hidden-control overlay pattern.
+- If keeping the hidden control and overlay in sync becomes a recurring source of bugs,
+  revisit Option A (full replacement) with proper test coverage.
+
+---
+
+## References
+
+- Related ADRs: ADR-003 (plain HTML/no build), ADR-005 (kiosk host)
+- Issue: #166
+- Spec: `specs/frontend/run-dropdowns-spec.md` (PR #170)

--- a/specs/frontend/run-dropdowns-spec.md
+++ b/specs/frontend/run-dropdowns-spec.md
@@ -1,0 +1,175 @@
+# Frontend / UI Spec: Run Page Dropdowns — Custom Themed Pickers & Run-Name Autofill Suppression
+
+**Status:** Active
+**Author:** Rasita Vajapattana
+**Last updated:** 2026-06-16
+**GitHub PR:** #170
+**Affected screens:** `run` (ready section)
+**Source file(s):** `aquila_web/static/run.html`, `aquila_web/static/script.js`, `aquila_web/static/styles.css`, `aquila_web/main.py`
+
+---
+
+## 1. Overview
+
+Replaces the browser-native form controls in the Run card with app-controlled UI so appearance is **consistent across browsers and machines** (kiosk requirement). Three related changes:
+
+1. **Profile dropdown** — the native `<select>` profile picker is replaced by a custom, themed dropdown (button + listbox). The open option list is styled by the app instead of the OS, matching the rest of the page.
+2. **Optics-path dropdown** (dev mode only) — the plain text input gains a custom autocomplete dropdown backed by **server-stored** recent-path history, replacing the browser's per-machine autofill.
+3. **Run-name autofill suppression** — the Run Name input no longer shows the browser's native "recent values" dropdown.
+
+No change to run execution logic; the native `<select>` is retained (hidden) as the source of truth so all existing reads (`value`, `selectedOptions`) keep working. This cosmetic-overlay-over-native-control approach is recorded in **ADR-012**.
+
+> **Scope note:** Items 1 and 3 (Profile dropdown + Run-name autofill suppression) satisfy issue **#166**. Item 2 (the Optics-path dropdown) is **beyond #166's stated acceptance criteria** but ships in the same PR (#170) because it is the same screen and the same theming pass; it is documented here rather than split into a separate issue.
+
+**Implementation shape:** the two controls are built as **two bespoke functions** (`setupProfileCombo`, `setupOpticsCombo`) sharing only CSS theme tokens and minimal-to-no JS — not a generic widget (there is no pre-existing custom dropdown component to reuse; `keyboard.js` is the only custom widget and is unrelated). Both combos are **force-closed when the screen leaves `ready`** (hooked into the screen-render path in `script.js`, alongside the `#ready-section` `is-hidden` toggle) so they never re-enter `ready` in a stale-open state with a dangling outside-click listener.
+
+---
+
+## 2. Screen Inventory
+
+| Screen ID | Name | Entry condition | Exit conditions |
+|-----------|------|----------------|-----------------|
+| `run` (ready) | Ready to Run | Hardware ready, idle | Operator taps **Run** → `running` |
+
+> All three controls live in the `#ready-section` of the Run page. The optics field (`#run-optics-tab`) is only visible when `dev_simulate` is true.
+
+---
+
+## 3. State Machine Transitions
+
+```
+Profile dropdown:
+[closed] --click button-->        [open]    (custom listbox shown)
+[open]   --pick option-->         [closed]  (label updates; native <select> change dispatched → /profile/select)
+[open]   --click outside / Esc--> [closed]  (no change)
+
+Optics dropdown (dev only):
+[closed] --focus / type-->        [open]    (history filtered as you type)
+[open]   --pick / Enter-->        [closed]  (input set; POST /dev/optics_path; history updated)
+[open]   --blur / Esc / outside-->[closed]  (blur also saves current value)
+```
+
+Driven by `setupProfileCombo` / `renderProfileCombo` / `syncProfileComboLabel` and `setupOpticsCombo` in `aquila_web/static/script.js`.
+
+---
+
+## 4. Screen Designs
+
+### Region: Profile picker (`.profile-combo`)
+
+**Layout:**
+- Hidden native `<select id="mySelect">` (source of truth, `display:none`).
+- `<button id="profile-combo-button">` styled with `.run-profile-select` (same box as before) — shows selected profile label + rotating chevron.
+- `<ul id="profile-combo-list" role="listbox">` — themed option list, absolutely positioned below the button.
+
+**Dynamic content:**
+- Options mirror the native select's `<option>`s (placeholder skipped).
+- Button label = selected option text, or "Select a profile" when none chosen.
+
+**User interactions:** Click button to open/close; click option to select; `ArrowDown` opens; `Esc` closes; outside click closes.
+
+**Error states:** Empty profile list → native select shows "No profiles found"; custom list renders empty.
+
+### Region: Optics path picker (`.optics-combo`, dev only)
+
+**Layout:**
+- `<input id="dev-optics-path" autocomplete="off" role="combobox" class="keyboard-ignore">` inside `.optics-combo`. The `keyboard-ignore` class excludes it from the on-screen keyboard (`keyboard.js`), since Optics is dev-only and used with a physical keyboard — the on-screen keyboard would otherwise cover the suggestion list.
+- `<ul id="optics-suggestions" role="listbox">` — themed suggestion list.
+
+**Dynamic content:**
+- Suggestions = server history filtered (case-insensitive substring) by current input text.
+
+**User interactions:** Focus shows full history; typing filters; `ArrowUp/Down` navigate; `Enter` selects active; `Esc`/outside-click/blur close; blur saves current text.
+
+**Error states:** No matching history → list hidden; free-typed new paths are allowed and saved.
+
+### Region: Run Name input (`#run-name-input`)
+
+**Layout:** Unchanged text input; adds `autocomplete="off"`.
+
+**User interactions:** No suggestion dropdown is offered by the browser.
+
+---
+
+## 5. Data Binding
+
+| UI Element | Data Source | Update Trigger |
+|------------|-------------|----------------|
+| `#profile-combo-label` | `#mySelect` selected option text (DOM) | On select / preselection (`syncProfileComboLabel`) |
+| `#profile-combo-list` options | `#mySelect` `<option>`s (DOM) | After `loadProfiles` populates select |
+| Profile selection | `POST /profile/select` | Custom option click → dispatched native `change` |
+| `#dev-optics-path` value | `GET /dev/optics_path` → `path` | On dev-mode init |
+| `#optics-suggestions` items | `GET /dev/optics_path` → `history[]` | On init + after each `POST /dev/optics_path` |
+| Optics path persistence | `POST /dev/optics_path` | On suggestion select / input blur |
+
+---
+
+## 6. Backend Contract
+
+`GET /dev/optics_path` → `{ "path": str|null, "history": string[] }`
+`POST /dev/optics_path` body `{ "path": str }` → `{ "path": str|null, "history": string[] }`
+
+History rules — the transformation is a **pure function** (`_merge_optics_history(history, path) -> history` in `aquila_web/main.py`), with persistence and selection layered separately so the rules are testable without a backend, a file, or HTTP:
+- Most-recent-first ordering.
+- De-duplicated (re-entering a path moves it to the front).
+- Capped at `OPTICS_PATHS_LIMIT = 20`; older entries dropped.
+- Blank/whitespace path returns history **unchanged** (the pure function never models "clear").
+
+Layered around the pure function:
+- **Persistence**: thin load/save wrappers read/write `logs/optics_paths.json` (gitignored, per-server). Not part of the pure function.
+- **Selection**: blank/whitespace path clears the current selection (`dev_optics_path = None`) at the endpoint level — a separate concern from history, which it never touches.
+
+The endpoint is therefore `history = _merge_optics_history(load().history, path); save(...)`.
+
+---
+
+## 7. Accessibility / Kiosk Constraints
+
+- Consistent appearance across browsers/machines is the primary driver (kiosk units must look identical).
+- Profile button reuses `.run-profile-select` sizing (20px). Option list 18px; optics suggestions 14px (matches optics input).
+- ARIA: profile button `aria-haspopup="listbox"` / `aria-expanded`; lists use `role="listbox"` / `role="option"`; optics input `role="combobox"` / `aria-autocomplete="list"`.
+- Themed via existing tokens: `#e2e8f0` border, 16px radius, `rgba(15,23,42,0.08)` shadow, `#f8fafc` hover.
+
+---
+
+## 8. Assets
+
+| Asset | Path | Format | Notes |
+|-------|------|--------|-------|
+| — | — | — | No new assets; CSS/markup/JS + one backend endpoint change |
+
+---
+
+## 9. Acceptance Criteria
+
+- [ ] Profile picker open list is app-styled and identical across browsers/machines.
+- [ ] Selecting a profile from the custom list still POSTs to `/profile/select` and loads dye labels (no regression).
+- [ ] Profile preselection (URL `?profile=` and `/button_status`) updates the custom button label.
+- [ ] Optics field (dev mode) shows a themed dropdown of recent paths, filtering as you type.
+- [ ] Optics history is server-stored, most-recent-first, deduped, capped at 20, and survives reload.
+- [ ] Run Name input no longer shows the browser's native autofill dropdown.
+- [ ] All three controls visually match the rest of the application theme.
+
+---
+
+## 10. Testing
+
+Coverage maps onto the three existing layers (no JS unit harness — ADR-003 keeps Node out of the project):
+
+| What | Layer | Location |
+|------|-------|----------|
+| Profile listbox: open / select / Esc / outside-click, label sync, native `change` still fires | Playwright e2e | `tests/e2e/test_run_dropdowns.py` |
+| Profile + Optics combos force-closed after leaving `ready` (open → run start → complete → assert closed) | Playwright e2e | same file |
+| Optics typeahead: filter-as-you-type, Arrow/Enter/Esc, blur-saves, outside-click | Playwright e2e | same file |
+| Run Name input has `autocomplete="off"` | Playwright e2e (attribute assertion) | same file |
+| `GET`/`POST /dev/optics_path` wiring (POST path → appears in GET `history`; POST blank → `path` null, history intact) | contract (httpx) | `tests/contract/test_optics_path_endpoints.py` |
+| History rules (most-recent-first, dedupe-moves-to-front, cap-at-20, blank/whitespace returns input unchanged) | pure unit | `unit_tests/test_optics_history.py` (calls `_merge_optics_history` directly) |
+
+> DOM-behavior (e2e) coverage **skip-gates on a live backend**, matching the existing `tests/e2e/test_keyboard.py` convention. In bare CI, `pytest tests unit_tests -v` exercises the contract + pure-unit tests for real; the e2e tests skip unless a backend is reachable at `AQUILA_TEST_URL`.
+
+---
+
+## 11. Open Questions
+
+- "Consistent across all machines" currently means consistent **appearance**; the optics history is stored per server instance (`logs/optics_paths.json`). If the same history must be shared across physically separate devices, a shared/synced store is required.
+- Some browsers ignore `autocomplete="off"` on name-like fields; if native suggestions reappear, switch the Run Name input to `autocomplete="new-password"`.

--- a/tests/contract/test_optics_path_endpoints.py
+++ b/tests/contract/test_optics_path_endpoints.py
@@ -1,0 +1,37 @@
+"""
+Contract tests for the /dev/optics_path endpoints.
+
+GET  /dev/optics_path -> {"path": str|null, "history": string[]}
+POST /dev/optics_path  {"path": str} -> same shape
+
+History is server-stored, most-recent-first, deduped, capped. A blank path
+clears the current selection but leaves history intact.
+"""
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def isolated_optics_storage(monkeypatch, tmp_path):
+    """Point optics-history persistence at a throwaway file per test."""
+    from aquila_web import main as web_main
+    monkeypatch.setattr(
+        web_main, "OPTICS_PATHS_PATH", tmp_path / "optics_paths.json", raising=False
+    )
+    monkeypatch.setattr(web_main, "dev_optics_path", None, raising=False)
+
+
+def test_posted_path_appears_in_get_history(client):
+    client.post("/dev/optics_path", json={"path": "/tmp/scope.log"})
+
+    data = client.get("/dev/optics_path").json()
+
+    assert "/tmp/scope.log" in data["history"]
+
+
+def test_blank_path_clears_selection_but_keeps_history(client):
+    client.post("/dev/optics_path", json={"path": "/tmp/scope.log"})
+
+    resp = client.post("/dev/optics_path", json={"path": ""}).json()
+
+    assert resp["path"] is None
+    assert "/tmp/scope.log" in resp["history"]

--- a/tests/e2e/test_run_dropdowns.py
+++ b/tests/e2e/test_run_dropdowns.py
@@ -1,0 +1,151 @@
+"""
+E2E tests for the custom-styled Run-screen dropdowns (issue #166).
+
+Profile picker (custom listbox over a hidden native <select>), Run Name autofill
+suppression, and the dev-only optics-path typeahead.
+
+Requires a running backend at base_url (default http://localhost:8090; override
+with AQUILA_TEST_URL). Run with: pytest -m e2e tests/e2e/test_run_dropdowns.py
+"""
+import pytest
+
+pytestmark = pytest.mark.e2e
+
+PROFILE_BUTTON = "#profile-combo-button"
+PROFILE_LIST = "#profile-combo-list"
+PROFILE_OPTION = "#profile-combo-list [role='option']"
+RUN_NAME_INPUT = "#run-name-input"
+OPTICS_INPUT = "#dev-optics-path"
+OPTICS_LIST = "#optics-suggestions"
+OPTICS_OPTION = "#optics-suggestions [role='option']"
+
+
+def _goto_run(page, base_url):
+    try:
+        page.goto(f"{base_url}/run", timeout=10_000)
+    except Exception as exc:
+        pytest.skip(f"Backend not reachable at {base_url}: {exc}")
+    page.wait_for_load_state("domcontentloaded")
+
+
+def test_clicking_profile_button_opens_listbox_with_options(page, base_url):
+    _goto_run(page, base_url)
+    # Profiles load asynchronously; wait for at least one custom option to exist.
+    page.wait_for_selector(PROFILE_OPTION, state="attached", timeout=5_000)
+
+    page.locator(PROFILE_BUTTON).click()
+
+    assert page.locator(PROFILE_LIST).is_visible()
+    assert page.locator(PROFILE_OPTION).count() >= 1
+
+
+def test_selecting_option_updates_label_and_fires_native_change(page, base_url):
+    _goto_run(page, base_url)
+    page.wait_for_selector(PROFILE_OPTION, state="attached", timeout=5_000)
+    page.locator(PROFILE_BUTTON).click()
+
+    option = page.locator(PROFILE_OPTION).first
+    value = option.get_attribute("data-value")
+    text = option.inner_text()
+    option.click()
+
+    # Button label reflects the selection.
+    assert page.locator("#profile-combo-label").inner_text() == text
+    # Hidden native <select> (source of truth) is updated.
+    assert page.locator("#mySelect").input_value() == value
+    # Native `change` propagated to the backend (/profile/select via change handler).
+    page.wait_for_function(
+        "(v) => fetch('/button_status').then(r => r.json()).then(s => s.profile === v)",
+        arg=value,
+        timeout=3_000,
+    )
+
+
+def test_escape_and_outside_click_dismiss_the_list(page, base_url):
+    _goto_run(page, base_url)
+    page.wait_for_selector(PROFILE_OPTION, state="attached", timeout=5_000)
+
+    # Escape closes.
+    page.locator(PROFILE_BUTTON).click()
+    assert page.locator(PROFILE_LIST).is_visible()
+    page.keyboard.press("Escape")
+    assert not page.locator(PROFILE_LIST).is_visible()
+
+    # Outside click closes.
+    page.locator(PROFILE_BUTTON).click()
+    assert page.locator(PROFILE_LIST).is_visible()
+    page.locator("body").click(position={"x": 5, "y": 5})
+    assert not page.locator(PROFILE_LIST).is_visible()
+
+
+def test_run_name_input_suppresses_native_autofill(page, base_url):
+    _goto_run(page, base_url)
+    assert page.locator(RUN_NAME_INPUT).get_attribute("autocomplete") == "off"
+
+
+def test_profile_combo_force_closes_when_leaving_ready(page, base_url):
+    _goto_run(page, base_url)
+    page.wait_for_selector(PROFILE_OPTION, state="attached", timeout=5_000)
+
+    page.locator(PROFILE_BUTTON).click()
+    assert page.locator(PROFILE_LIST).is_visible()
+
+    # Screen leaves ready (a run starts) then returns (run completes). Without a
+    # force-close, the list would re-appear stale-open when ready is shown again.
+    page.evaluate("updateDashboardSections('running')")
+    page.evaluate("updateDashboardSections('ready')")
+
+    assert "is-open" not in (page.locator(PROFILE_LIST).get_attribute("class") or "")
+    assert not page.locator(PROFILE_LIST).is_visible()
+
+
+def _require_optics(page):
+    optics = page.locator(OPTICS_INPUT)
+    if optics.count() == 0 or not optics.is_visible():
+        pytest.skip("Optics field is only present in dev/simulation mode")
+    return optics
+
+
+def test_optics_typeahead_filters_server_history(page, base_url):
+    _goto_run(page, base_url)
+    optics = _require_optics(page)
+
+    page.request.post(f"{base_url}/dev/optics_path", data={"path": "/data/alpha.log"})
+    page.request.post(f"{base_url}/dev/optics_path", data={"path": "/data/beta.log"})
+    page.reload()
+    page.wait_for_load_state("domcontentloaded")
+
+    optics = _require_optics(page)
+    optics.click()
+    optics.fill("alpha")
+
+    page.wait_for_selector(OPTICS_OPTION, timeout=3_000)
+    texts = page.locator(OPTICS_OPTION).all_inner_texts()
+    assert any("alpha" in t for t in texts)
+    assert all("beta" not in t for t in texts)
+
+
+def test_selecting_optics_suggestion_sets_input(page, base_url):
+    _goto_run(page, base_url)
+    optics = _require_optics(page)
+
+    page.request.post(f"{base_url}/dev/optics_path", data={"path": "/data/gamma.log"})
+    page.reload()
+    page.wait_for_load_state("domcontentloaded")
+
+    optics = _require_optics(page)
+    optics.click()
+    optics.fill("gamma")
+    page.wait_for_selector(OPTICS_OPTION, timeout=3_000)
+    page.locator(OPTICS_OPTION, has_text="gamma").first.click()
+
+    assert page.locator(OPTICS_INPUT).input_value() == "/data/gamma.log"
+    assert not page.locator(OPTICS_LIST).is_visible()
+
+
+def test_optics_input_is_excluded_from_onscreen_keyboard(page, base_url):
+    _goto_run(page, base_url)
+    optics = _require_optics(page)
+    classes = optics.get_attribute("class") or ""
+    assert "keyboard-ignore" in classes
+    assert optics.get_attribute("autocomplete") == "off"

--- a/unit_tests/test_optics_history.py
+++ b/unit_tests/test_optics_history.py
@@ -1,0 +1,56 @@
+"""
+Unit tests for _merge_optics_history() in aquila_web/main.py.
+
+Pure function: given the current recent-optics-path history and a candidate
+path, return the new history (most-recent-first, deduped, capped). No file IO.
+"""
+import sys
+import types
+
+import pytest
+
+# Stub heavy hardware dependencies before importing main.
+for _mod in ("RPi", "RPi.GPIO"):
+    if _mod not in sys.modules:
+        sys.modules[_mod] = types.ModuleType(_mod)
+
+if "serial" not in sys.modules:
+    _s = types.ModuleType("serial")
+    _st = types.ModuleType("serial.tools")
+    _lp = types.ModuleType("serial.tools.list_ports")
+    _lp.comports = lambda: []
+    _s.tools = _st
+    _st.list_ports = _lp
+    sys.modules.update({"serial": _s, "serial.tools": _st, "serial.tools.list_ports": _lp})
+
+from aquila_web.main import _merge_optics_history, OPTICS_PATHS_LIMIT
+
+
+def test_new_path_is_prepended_to_history():
+    result = _merge_optics_history(["/old/path.log"], "/new/path.log")
+    assert result == ["/new/path.log", "/old/path.log"]
+
+
+def test_reentering_existing_path_moves_it_to_front_without_duplicate():
+    result = _merge_optics_history(["/a.log", "/b.log", "/c.log"], "/c.log")
+    assert result == ["/c.log", "/a.log", "/b.log"]
+
+
+def test_history_is_capped_dropping_the_oldest_entry():
+    full = [f"/path{i}.log" for i in range(OPTICS_PATHS_LIMIT)]
+    result = _merge_optics_history(full, "/newest.log")
+    assert len(result) == OPTICS_PATHS_LIMIT
+    assert result[0] == "/newest.log"
+    assert "/path19.log" not in result  # oldest dropped
+
+
+@pytest.mark.parametrize("blank", [None, "", "   ", "\t\n"])
+def test_blank_path_returns_history_unchanged(blank):
+    history = ["/a.log", "/b.log"]
+    result = _merge_optics_history(history, blank)
+    assert result == ["/a.log", "/b.log"]
+
+
+def test_surrounding_whitespace_is_trimmed_before_storing():
+    result = _merge_optics_history([], "  /padded.log\n")
+    assert result == ["/padded.log"]


### PR DESCRIPTION
Closes: [ #166](https://github.com/AcornGenetics/aquilla-main/issues/166)

## Summary

Replaces the Run screen's native form controls with themed **cosmetic dropdown overlays**, keeping the native controls in the DOM as the hidden source of truth (per ADR-012). This fixes the visual inconsistency on the Chromium kiosk fleet, where native `<select>` option lists and autofill dropdowns render with OS styling that clashes with the themed UI (#166).

The key design choice: the native `<select>` is *not* removed — it stays as the hidden source of truth so every existing reader (`value`, `selectedOptions`, the `change` event, and `?profile=` preselect) keeps working unchanged. The custom widget only layers themed presentation on top.

## What changed

**Backend — `aquila_web/main.py`** (optics-path history)
- New `logs/optics_paths.json` store, capped at 20 entries (most-recent-first, deduped).
- Pure helper `_merge_optics_history()` (blank/whitespace path is a no-op) plus `_load_/_save_optics_history()`.
- `GET /dev/optics_path` now also returns `history`; `POST` merges the submitted path into history and returns it. This powers the optics-path input's suggestion dropdown.

**Frontend**
- `run.html` — optics input wrapped in an `.optics-combo` with a suggestions `<ul>` (combobox a11y roles); profile picker keeps the native `<select id="mySelect">` hidden as source of truth behind a themed button + `<ul>` overlay.
- `script.js` (+213) — overlay behavior: rendering option lists, syncing the custom widget ↔ hidden native control, and optics-path suggestion wiring.
- `styles.css` (+72) — themed dropdown styling (`.combo-list`, `.profile-combo`, `.optics-suggestions`, chevron).

**Docs**
- `docs/adr/ADR-012-custom-dropdowns-as-cosmetic-overlays.md` — the decision record.
- `specs/frontend/run-dropdowns-spec.md` — the frontend spec.
- `CONTEXT.md` — adds a **Profile** glossary entry (operator-facing name for Protocol).

**Tests**
- `tests/contract/test_optics_path_endpoints.py` — endpoint contract.
- `tests/e2e/test_run_dropdowns.py` — dropdown behavior end-to-end.
- `unit_tests/test_optics_history.py` — the pure history-merge logic.
