### PR TITLE
Analytics ingest → Sentri platform with per-device mTLS (ADR-013/014 + PRDs)

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -10,10 +10,17 @@ This glossary defines canonical terms for the analytics domain. Terms here take 
 A single physical Aquilla PCR instrument — a Raspberry Pi running the Aquilla software stack in Docker. "Device" and "Sentri" are synonymous; prefer "Sentri" in analytics contexts to avoid ambiguity with AWS/cloud "devices."
 
 **Fleet**
-The collection of all deployed Sentri units. Analytics queries span the fleet; device-level queries scope to a single Sentri.
+The collection of all deployed Sentri units. Analytics queries span the fleet; device-level queries scope to a single Sentri. There is one prod fleet; there is no separate physical "dev fleet."
+
+**Sentri Analytics Platform**
+The separate system (repo `Acorn/sentri-analytics`) that owns cloud ingest and the analytics/query surface over Aurora — the mTLS gateway, compute tier, and read APIs. Distinct from a Sentri (the physical instrument). Beware the name collision: AWS resource names such as `SentriVPC` and the `sentri/db` secret belong to this platform/infrastructure, not to an individual Sentri.
+_Avoid_: calling the platform "Sentri" unqualified.
 
 **Device ID**
-The Raspberry Pi hardware serial number (from `/proc/cpuinfo`), used as the stable, globally unique identifier for a Sentri in analytics data. Survives reimages. Stored as `AQ_SYNC_DEVICE_ID` env var. Mapped to a human-readable `dock_name` in the AWS device registry. Do not confuse with the hostname-based config key (`sn01`, `sn02`) used for hardware configuration in `host_config.json`.
+The Raspberry Pi hardware serial number (from `/proc/cpuinfo`), used as the stable, globally unique identifier for a Sentri in analytics data. Survives reimages. Stored as `AQ_SYNC_DEVICE_ID` env var. Mapped to a human-readable `dock_name` in the AWS device registry. Do not confuse with the hostname-based config key (`sn01`, `sn02`) used for hardware configuration in `host_config.json`. The Device ID is also the canonical transport identity: it is the Subject CN of the Sentri's Device Certificate, so the platform derives Device ID from the cert rather than trusting the request body.
+
+**Device Certificate**
+The per-Sentri mTLS client certificate (and private key) presented on every Sync. Its Subject CN is the Device ID, cryptographically binding the transport identity to the data-model identity. Validated at the Ingest Endpoint against a signing-CA truststore. Replaces the Fleet API Key. Revoked per-device (the stolen-Pi threat model) rather than fleet-wide. Stored `chmod 600` on the Pi.
 
 **Protocol**
 A named PCR assay profile — a JSON file in `profiles/` that defines thermal steps, cycle count, and optical configuration. The `title` field in the JSON is the canonical protocol name. Protocols are the primary grouping dimension for analytics (e.g., "inconclusive rate by protocol").
@@ -43,7 +50,7 @@ A structured JSON record enqueued in the local SQLite database (`data/db/app.db`
 The background process (asyncio task in the FastAPI app, 15-minute interval) that batches pending Events from the local SQLite queue and POSTs them to the AWS Ingest Endpoint. Also triggered on WiFi reconnect. On success, marks events `synced_at` in SQLite. Events accumulate indefinitely if offline.
 
 **Ingest Endpoint**
-The AWS API Gateway URL that receives Event batches from Sentri devices. Authenticates via `x-api-key` header (shared fleet API key stored as `AQ_SYNC_API_KEY` env var). Backed by a Lambda function that writes to RDS PostgreSQL.
+The authenticated cloud entry point that receives Event batches from Sentri devices, hosted by the Sentri Analytics Platform. Devices authenticate with their Device Certificate (mTLS) — there is no API key. Reached at a regional custom domain (API Gateway), which forwards through the platform's compute tier to write to Aurora. The device-side URL is stored as `AQ_SYNC_ENDPOINT`. (Superseded the earlier API Gateway + Lambda + RDS + `x-api-key` design; see ADR-013.)
 
-**Fleet API Key**
-A shared secret (`AQ_SYNC_API_KEY`) stored in each Sentri's environment, sent as `x-api-key` on every Sync request. Rotated via Tailscale SSH fleet script when compromised or on scheduled rotation. A single key covers the entire fleet.
+**Fleet API Key** _(retired)_
+A shared secret (`AQ_SYNC_API_KEY`) formerly sent as `x-api-key` on every Sync. Retired in favor of per-device Device Certificate (mTLS) auth: a shared fleet key is the wrong identity model for a field fleet — a single stolen Pi exposed the whole fleet, and the key could only be rotated fleet-wide. See ADR-013. Listed here only to mark the term obsolete.

--- a/docs/adr/ADR-009-analytics-ingest-api-gateway-lambda.md
+++ b/docs/adr/ADR-009-analytics-ingest-api-gateway-lambda.md
@@ -1,6 +1,6 @@
 # ADR-009: Analytics Ingest via API Gateway + Lambda, not IoT Core
 
-**Status:** Accepted
+**Status:** Superseded by ADR-013 (2026-06-17) — ingest moves to the sentri-analytics platform and device auth switches to mTLS. The shared-API-key model and SAM ingest stack described below are retired; see ADR-013.
 **Date:** 2026-06-08
 **Author:** Nicole Cornell
 **Deciders:** Nicole Cornell
@@ -76,6 +76,112 @@ Sync schedule: 15-minute asyncio background task in the FastAPI app, plus a trig
 - Fleet exceeds 500 Sentri devices → evaluate IoT Core + Kinesis
 - Need for real-time alerting (< 1 minute latency) → add EventBridge or SNS trigger from Lambda
 - Per-device audit trail becomes a compliance requirement → migrate to per-device API keys or mTLS
+
+---
+
+## Addendum (2026-06-16): API key is not enforced as currently deployed
+
+**Status of this addendum:** Known gap — documented, not yet fixed.
+
+### What was found
+
+The decision above specifies a shared fleet API key "validated by API Gateway's
+built-in usage plan." That validation does **not** happen with the stack as
+written. The device sends the key, but nothing on the server checks it:
+
+1. `infra/template.yaml` deploys an **HTTP API** (`AWS::Serverless::HttpApi`,
+   resource `IngestApi`). API keys and usage plans are a **REST API**
+   (`AWS::ApiGateway::RestApi`) feature only — HTTP APIs have no concept of an
+   API key or usage plan, so the manually-created `sentri-fleet-key` and its
+   usage plan (see `docs/aws-deployment-guide.md`) cannot be attached to this
+   endpoint and have no effect.
+2. The template defines **no authorizer** — the auth section is comments only.
+3. The ingest Lambda (`infra/handlers/ingest_handler.py`) never reads the
+   `x-api-key` header; it forwards any body with `device_id` + `events` to SQS.
+
+**Consequence:** the `/ingest` endpoint is effectively open. The "No API key →
+403" smoke test in the deployment guide does not hold as deployed — an
+unauthenticated POST returns `200`. The key is sent by `aquila_web/sync.py` and
+`scripts/backfill_history.py` but discarded by the gateway and Lambda.
+
+### Why the key still exists
+
+`sentri-fleet-key` is a real artifact of this ADR's auth design, not leftover
+scaffolding. The ADR and deployment guide were written to the REST-API
+usage-plan model; the template was implemented as the cheaper/simpler HTTP API,
+and the docs were never reconciled with that change. The device side was wired
+correctly to *send* the key, which masked that the server never *checks* it.
+
+### Remediation options
+
+Pick one. Listed cheapest-to-implement first.
+
+- **Option 1 — Validate in the Lambda (no infra change).** Store the expected
+  key in SSM Parameter Store (SecureString) or Secrets Manager, read it in
+  `ingest_handler.handler`, and compare against `event["headers"]["x-api-key"]`
+  (HTTP API lowercases header names); return `403` on mismatch. Fastest fix,
+  keeps the HTTP API. Downside: auth lives in app code, no usage-plan throttling
+  or per-key metering.
+- **Option 2 — Lambda authorizer on the HTTP API.** Add a request authorizer
+  that checks the header before the ingest function runs. Keeps the HTTP API,
+  centralizes auth, still no usage-plan metering.
+- **Option 3 — Switch to a REST API with a usage plan.** Matches the original
+  ADR wording exactly and makes `sentri-fleet-key` real. Most infra change.
+  Details below.
+
+### Option 3 in detail: migrating to a REST API with usage plans
+
+What changes in `infra/template.yaml`:
+
+1. **Swap the API resource type.** Replace `IngestApi`
+   (`AWS::Serverless::HttpApi`) with `AWS::Serverless::Api` (REST API). On it,
+   set `Auth.ApiKeyRequired: true` (globally or per-method via
+   `DefinitionBody`), which makes API Gateway reject any request missing a valid
+   key with `403` before the Lambda runs.
+2. **Define the API key and usage plan in the template** (so it is no longer a
+   manual console step). Add:
+   - `AWS::ApiGateway::ApiKey` (`sentri-fleet-key`) with `Enabled: true`.
+   - `AWS::ApiGateway::UsagePlan` referencing the API + stage, with optional
+     `Throttle` / `Quota` limits (e.g. rate-limit the fleet).
+   - `AWS::ApiGateway::UsagePlanKey` binding the key to the plan.
+   Output the key id (and retrieve the value via
+   `aws apigateway get-api-key --include-value`) so it can be pushed to devices
+   as `AQ_SYNC_API_KEY`.
+3. **Update the event source on `IngestHandlerFunction`.** Change the
+   `IngestPost` event from `Type: HttpApi` to `Type: Api`, point `RestApiId` at
+   the new resource, keep `Method: POST` / `Path: /ingest`, and set
+   `Auth.ApiKeyRequired: true` on the method.
+4. **Stage name.** REST APIs require an explicit `StageName` (e.g. `!Ref
+   Environment`); keep it consistent so the `IngestEndpoint` output URL still
+   ends in `/prod/ingest`.
+
+What does **not** change:
+
+- **The device.** `aquila_web/sync.py` already sends `x-api-key`; the REST API
+  reads exactly that header. No device-side code change, no re-flash.
+- **The ingest endpoint shape.** Still `POST /ingest` returning
+  `{"queued": N}`. The `IngestEndpoint` stack output keeps the same format
+  (`https://<id>.execute-api.<region>.amazonaws.com/<stage>/ingest`), though the
+  `<id>` changes because it is a new API resource.
+- **The Lambda body handling.** `ingest_handler.py` can stay as-is — API Gateway
+  rejects bad keys before invoking it, so no in-handler key check is needed.
+- **Downstream** SQS → S3 → Aurora is untouched.
+
+Caveats:
+
+- Replacing the API resource type forces a **new API id** (the old HTTP API is
+  deleted, a new REST API created), so `AQ_SYNC_ENDPOINT` must be re-pushed to
+  the fleet after migration.
+- Note the URL difference: REST APIs use
+  `…/execute-api.…/<stage>/<resource>` and the stage is part of the path the
+  same way; confirm the deployed URL from stack outputs before updating devices.
+- After this change the deployment guide's "No API key → 403" smoke test becomes
+  accurate and should be kept as a post-deploy verification step.
+
+This migration is the only option that makes the ADR's stated auth mechanism
+("validated by API Gateway's built-in usage plan") literally true. If the
+simpler Option 1 or 2 is chosen instead, update the Decision section's "Auth:"
+line to match what is actually enforced.
 
 ---
 

--- a/docs/adr/ADR-013-ingest-moves-to-sentri-analytics-platform-mtls.md
+++ b/docs/adr/ADR-013-ingest-moves-to-sentri-analytics-platform-mtls.md
@@ -1,0 +1,166 @@
+# ADR-013: Ingest moves to the sentri-analytics platform; device auth switches to mTLS
+
+**Status:** Accepted — supersedes ADR-009
+**Date:** 2026-06-17
+**Author:** Nicole Cornell
+**Deciders:** Nicole Cornell
+
+---
+
+## Context
+
+ADR-009 placed the analytics ingest endpoint in this repo as a SAM stack —
+API Gateway (HTTP API) + Lambda + SQS + S3 + Aurora — with devices
+authenticating via a shared fleet API key sent as an `x-api-key` header.
+
+Two problems emerged:
+
+1. **The API key is not enforceable as built** (see the 2026-06-16 addendum to
+   ADR-009 and issue #174). HTTP APIs do not support API keys or usage plans,
+   no authorizer was defined, and `ingest_handler.py` never inspects the header
+   — so `/ingest` is effectively open.
+2. **A shared fleet key is the wrong identity model for a field fleet.** A
+   single stolen Raspberry Pi exposes the ingest endpoint for the whole fleet,
+   and the key can only be rotated fleet-wide. ADR-009 itself flagged migrating
+   to per-device credentials as a revisit condition.
+
+In parallel, the analytics read layer (`Acorn/sentri-analytics`) has produced a
+full platform **system design** (`sentri-analytics-system-design.md`) that
+defines a self-healing, mTLS-authenticated ingest + analytics platform:
+API Gateway HTTP API (regional custom domain, **mTLS truststore in S3**) →
+VPC Link → internal ALB → Auto Scaling group running the Node application →
+Aurora over a peered VPC. Under that design the **ingest endpoint is served by
+the ASG application**, device identity comes from an **mTLS client
+certificate**, and per-device rate limiting protects the backend.
+
+That design and this repo's SAM ingest stack are two implementations of the same
+ingest path. They cannot both own it. This ADR records the decision to retire
+this repo's implementation and define what remains aquilla-main's
+responsibility.
+
+If we did nothing: we would keep an open, unauthenticated ingest endpoint and
+two conflicting ingest architectures.
+
+---
+
+## Decision
+
+**We will retire this repo's SAM ingest stack and move ingest ownership to the
+sentri-analytics platform, and we will replace the shared API key with
+per-device mTLS client certificates.**
+
+Concretely, this splits the work as follows.
+
+### What aquilla-main remains responsible for (the device edge)
+
+1. **Device auth → mTLS.** `aquila_web/sync.py` must present a client
+   certificate on the ingest POST (`requests.post(..., cert=(client_cert,
+   client_key), ...)`) and **drop the `x-api-key` header** (currently
+   `aquila_web/sync.py:30-32`). Same change for `scripts/backfill_history.py`.
+2. **Per-device cert provisioning + secure storage on the Pi.** Each device gets
+   its own client cert + private key, stored `chmod 600`, wired into the request.
+   This is deployment / host-config work (`scripts/deploy/deployment2.sh`,
+   `config_files/`, `host_config.json`).
+3. **Cert rotation / revocation on the device.** The device must support
+   re-provisioning a cert, and the fleet script must be able to push a new one.
+   This is the critical-path "device cert rollout" in the platform migration
+   runbook; the threat model is a stolen Pi.
+4. **Repoint `AQ_SYNC_ENDPOINT`** to the new API Gateway regional custom domain
+   at cutover.
+5. **Own the `run_complete` payload contract** — the JSON shape the platform
+   parses. The payload remains keyed on `device_id` (the Pi serial). Note:
+   `dock_name` is **not** a device-side field — it is platform-owned metadata in
+   the AWS device registry (`device_sites`), joined server-side from `device_id`.
+   The device must not emit it; a stolen or reimaged Pi must not be able to
+   mislabel its own location. (This corrects an earlier draft of this ADR that
+   said the device should emit `dock_name`.)
+6. **Decommission the SAM ingest stack.** `aquila-main/infra/template.yaml`
+   (API Gateway + Lambdas + SQS + S3 + Aurora) is superseded by the
+   sentri-analytics platform and is torn down at the runbook's decommission
+   phase. **The Aurora cluster is the exception** — the platform design treats
+   Aurora as pre-existing in its own VPC reached via peering, so the cluster
+   must be preserved (and excluded from the SAM teardown), not deleted with the
+   rest of the stack.
+
+### What moves to sentri-analytics (out of scope for this repo)
+
+The API Gateway edge + mTLS truststore, VPC Link, internal ALB, ASG/launch
+template, VPC endpoints, rate-limit store, the Node `/ingest` endpoint (reading
+cert identity and writing to Aurora), AMI bake, CI/CD, and migrations. See
+`sentri-analytics-system-design.md`.
+
+This is **largely irreversible** once the SAM stack is decommissioned: rollback
+during migration is repointing the fleet endpoint, not redeploying Lambdas.
+
+---
+
+## Consequences
+
+### Positive
+- Strong per-device identity: a compromised Pi is revoked individually via
+  truststore rotation, not a fleet-wide key change.
+- The "open endpoint" gap from ADR-009 / issue #174 is closed at the gateway —
+  unauthenticated requests fail the mTLS handshake before reaching the app.
+- One ingest implementation, not two conflicting stacks.
+- Ingest and analytics converge on one operated platform (ASG app), removing the
+  SAM Lambda/SQS/S3 pipeline this repo had to maintain.
+
+### Negative
+- **PKI is now a hard requirement.** Issuing, distributing, rotating, and
+  revoking per-device certs is real operational work that did not exist with a
+  shared key. Cert provisioning becomes part of device deployment.
+- Device-side change touches every physical Pi (cert rollout is the migration
+  critical path); offline devices get certs on next connection.
+- This repo loses direct control of the ingest endpoint; a contract change now
+  requires cross-repo coordination with sentri-analytics.
+
+### Neutral / Tradeoffs
+- The payload/schema contract is unchanged in shape — only the transport auth
+  and the hosting move. `dock_name` is platform-owned registry metadata, not a
+  device field, so it imposes no payload change on this repo.
+- The `device_id` (RPi hardware serial) remains the stable identity in the data
+  model; the mTLS cert is the transport identity layered on top.
+
+---
+
+## Alternatives Considered
+
+### Option A: Keep the SAM stack, fix the API key (issue #174 as filed)
+**Why rejected:** Migrating the HTTP API to a REST API with usage-plan API keys
+still leaves a shared fleet secret (wrong identity model for a field fleet) and
+maintains a second ingest stack that conflicts with the sentri-analytics
+platform design, which explicitly rejects API keys and REST API.
+
+### Option B: In-Lambda API key validation
+**Why rejected:** Closes the open-endpoint gap but keeps the shared-key model and
+the duplicate stack; superseded by the platform's mTLS edge.
+
+### Option C: AWS IoT Core per-device certificates
+**Why rejected:** Same reasoning as ADR-009 — IoT Core's provisioning and
+streaming overhead isn't justified at <100 devices, and mTLS at the API Gateway
+gives per-device identity without it.
+
+---
+
+## Revisit Conditions
+
+- Per-device cert management proves too heavy operationally → evaluate a managed
+  device-identity service (IoT Core provisioning) or an automated ACM Private CA
+  workflow.
+- The sentri-analytics platform design is abandoned or materially changed →
+  re-open the ingest ownership and auth decision.
+- Fleet exceeds the scale assumptions in `sentri-analytics-system-design.md` →
+  revisit the ASG-app-as-ingest choice vs. a dedicated streaming path.
+
+---
+
+## References
+
+- Supersedes: ADR-009 (analytics ingest via API Gateway + Lambda; shared API key)
+- Related ADRs: ADR-001 (hostname-keyed device config), ADR-002 (Watchtower fleet updates)
+- Issue: #174 (API-key enforcement — to be reframed/closed in light of this ADR)
+- `sentri-analytics-system-design.md` — the target platform design (sentri-analytics)
+- `aquila_web/sync.py` — device sync client (x-api-key → mTLS)
+- `scripts/backfill_history.py` — backfill client (same auth change)
+- `scripts/deploy/deployment2.sh`, `config_files/`, `host_config.json` — cert provisioning
+- `infra/template.yaml` — SAM ingest stack to be decommissioned (preserve Aurora)

--- a/docs/adr/ADR-014-device-pki-self-managed-kms-ca-short-lived-certs.md
+++ b/docs/adr/ADR-014-device-pki-self-managed-kms-ca-short-lived-certs.md
@@ -1,0 +1,126 @@
+# ADR-014: Device PKI — self-managed KMS-backed CA issuing short-lived certs
+
+**Status:** Accepted
+**Date:** 2026-06-17
+**Author:** Nicole Cornell
+**Deciders:** Nicole Cornell
+
+---
+
+## Context
+
+ADR-013 made per-device **mTLS** the device-auth mechanism for ingest and called
+PKI "a hard requirement," but deliberately left the PKI itself unspecified: who
+runs the Certificate Authority, what the cert identity is, how long certs live,
+how devices enroll and renew, how revocation works, and where the CA private key
+lives. The `sentri-analytics-system-design.md` only states that the **truststore
+(signing CA public cert) lives in S3** and is consumed by API Gateway HTTP API
+mTLS validation. This ADR fills that gap.
+
+Relevant facts and constraints at decision time:
+
+- The fleet is **<100 physical Raspberry Pi Sentris**, **one prod fleet** (no
+  physical dev fleet), and each Pi is **online daily**.
+- **API Gateway HTTP API mTLS does not natively perform CRL/OCSP revocation
+  checking.** The truststore is just a CA bundle; per-device revocation must be
+  solved out-of-band (custom deny-list, or CA/truststore rotation).
+- **Cost sensitivity:** ACM Private CA is **~$400/mo** (general-purpose) or
+  **~$50/mo** (short-lived-certificate mode) **per CA**, which dwarfs the
+  architecture's other line items at this scale (design §9).
+- **Effectively greenfield:** only one Pi currently syncs and its data is
+  disposable, so the PKI model can be chosen freely without a migration of live
+  credentials.
+
+## Decision
+
+1. **Cert identity = Device ID.** The certificate Subject CN is the Pi hardware
+   serial (Device ID). The platform derives device identity from the cert; the
+   request body's `device_id` is a **cross-check only** and a mismatch is
+   rejected. This binds the transport identity to the data-model identity. See
+   `CONTEXT.md` → Device Certificate.
+2. **Self-managed CA, private key in AWS KMS — not ACM Private CA.** The CA is a
+   self-signed root whose private key is a non-extractable KMS asymmetric key;
+   CSRs are signed via the KMS `Sign` API. The S3 truststore is this CA's public
+   cert. Cost is **~$1/mo** instead of ~$400/mo, with HSM-grade key custody.
+3. **Short-lived certs (≤7 days), auto-renewed.** Revocation is handled by
+   **non-renewal** — a compromised or stolen Pi self-expires within the cert
+   lifetime — which sidesteps the API Gateway mTLS revocation gap entirely.
+4. **On-device keygen; brokered signing.** Each Pi generates its own keypair and
+   CSR (`CN=Device ID`); the **private key never leaves the device**. Initial
+   **enrollment is operator-authenticated** (`scripts/deploy/deployment2.sh`).
+   **Renewal is automated and authenticated by the device's current valid cert**
+   (mTLS) against a renewal endpoint; a renewal daemon on the Pi swaps certs
+   before expiry. A Pi offline longer than its cert lifetime drops back to manual
+   re-enrollment (rare — the fleet is online daily).
+5. **One CA for the single prod fleet.** No dev-fleet CA. If the dev platform
+   environment needs ingest traffic, it uses simulation mode (ADR-007) or
+   throwaway certs, not physical hardware.
+
+## Consequences
+
+### Positive
+- Eliminates the ~$400/mo ACM PCA cost; the CA is ~$1/mo.
+- Neutralizes revocation — the hardest unsolved operational item on API Gateway
+  mTLS (design §7) — via short cert lifetime instead of CRL/OCSP infrastructure.
+- Device private keys never traverse the network or a provisioning host.
+- A single identity (Device ID) spans transport (cert CN) and data model.
+
+### Negative
+- Adds a **renewal daemon on every Pi** (device-side, this repo) and a
+  **renewal/signing endpoint** (platform-side, sentri-analytics). This is the
+  price of revocation-by-non-renewal.
+- **CA key custody becomes our responsibility** (mitigated by keeping the key in
+  KMS, non-extractable).
+- A Pi offline beyond its cert lifetime cannot self-renew and needs operator
+  re-enrollment.
+- Per-cert issuance volume rises with renewal frequency (cost remains trivial).
+
+### Neutral / Tradeoffs
+- Short-lived certs depend on the **daily-online** assumption; acceptable for
+  this fleet. If that assumption breaks, see Revisit Conditions.
+
+## Alternatives Considered
+
+### ACM Private CA, general-purpose mode
+**Why rejected:** ~$400/mo per CA is unjustified at <100 devices; the managed
+convenience is not worth the cost when a KMS-backed self-managed CA achieves the
+same truststore-in-S3 outcome.
+
+### ACM Private CA, short-lived-certificate mode (~$50/mo)
+**Why rejected:** Still pays for a managed CA where a KMS-backed self-managed CA
+delivers the same short-lived posture at ~$1/mo.
+
+### Long-lived certs (1–3 yr) + revocation deny-list
+**Why rejected:** Requires building revocation infrastructure that API Gateway
+mTLS lacks natively (no CRL/OCSP), e.g. an app-side deny-list checked per
+request. Short-lived certs avoid that work. Retained as the **fallback** if
+auto-renewal proves operationally fragile.
+
+### Central keygen + push to devices
+**Why rejected:** The private key would traverse a provisioning host/network and
+exist in bulk at provisioning time, weakening the per-device identity guarantee
+that justified moving off the shared key.
+
+### CA owned inside aquila-main or sentri-analytics application code
+**Why rejected:** Splitting issuance from the S3 truststore invites a
+CA/truststore mismatch that fails handshakes fleet-wide. A standalone CA (KMS key
++ S3 truststore) consumed by both repos keeps trust single-owned.
+
+## Revisit Conditions
+
+- Auto-renewal proves fragile (Pis frequently offline past cert lifetime) →
+  switch to long-lived certs + a deny-list revocation path, or lengthen the cert
+  lifetime.
+- Fleet grows enough that self-managed CA operations become a burden →
+  reconsider ACM PCA short-lived mode.
+- A compliance trigger requires a managed/audited CA → ACM PCA or external PKI.
+
+## References
+
+- ADR-013 (per-device mTLS device auth — this ADR specifies its PKI)
+- ADR-007 (simulation mode — source of dev-platform test traffic)
+- `sentri-analytics-system-design.md` §3, §7 (truststore in S3; revocation as an
+  open item)
+- `CONTEXT.md` — Device Certificate, Device ID
+- `aquila_web/sync.py`, `scripts/deploy/deployment2.sh`,
+  `scripts/deploy/fleet-update.sh` — device-side enrollment/renewal

--- a/docs/adr/ADR-014-device-pki-self-managed-kms-ca-short-lived-certs.md
+++ b/docs/adr/ADR-014-device-pki-self-managed-kms-ca-short-lived-certs.md
@@ -56,6 +56,83 @@ Relevant facts and constraints at decision time:
    environment needs ingest traffic, it uses simulation mode (ADR-007) or
    throwaway certs, not physical hardware.
 
+## Self-managed CA with key in AWS KMS — what it actually means
+
+A **Certificate Authority** is just two things: a private key, and a public
+certificate signed by that key. Anyone can "be" a CA — what makes a CA
+trustworthy is that other parties agree to trust its public cert. The
+hard/sensitive part is the **private key**: whoever holds it can mint certs that
+your whole fleet will trust. Protecting that key *is* the job of running a CA.
+
+ACM Private CA is AWS's **managed** version: AWS holds the key, runs the issuance
+API, handles the HSM — and charges ~$400/mo (or ~$50/mo short-lived mode) for
+that convenience.
+
+**"Self-managed CA, key in KMS"** means you run the CA yourself, but you don't
+hold the raw private key either — you delegate just the key custody to AWS KMS.
+Here's the split:
+
+### The pieces
+
+1. **The CA private key = a KMS asymmetric key.** You create an asymmetric key
+   pair in KMS (e.g. RSA or ECC, usage = `SIGN_VERIFY`). The private key is
+   **non-extractable** — it physically never leaves the KMS HSM. There is no API
+   to download it. You can only ask KMS to *sign bytes* on your behalf.
+2. **The CA public certificate = a self-signed root.** You generate a self-signed
+   root certificate whose public key is the KMS key's public half, and whose
+   signature was produced by calling KMS `Sign`. This cert is the CA — it's safe
+   to publish.
+3. **The truststore = that public cert in S3.** API Gateway HTTP API mTLS reads
+   this CA bundle from S3 and uses it to validate incoming device certs. (This is
+   the part `sentri-analytics-system-design.md` already specified.)
+
+### How issuing a device cert works
+
+```
+Pi generates keypair locally ──► builds CSR (CN = Device ID)
+                                      │
+                                      ▼
+              signing endpoint receives CSR
+                                      │
+                       hashes the to-be-signed cert
+                                      │
+                                      ▼
+                    KMS Sign API  (private key stays in HSM)
+                                      │
+                       returns signature bytes
+                                      │
+                                      ▼
+        assemble signed X.509 cert ──► hand back to Pi
+```
+
+You never `openssl` with a key file on disk. Wherever a normal CA would do
+`sign(tbsCertificate, caPrivateKey)`, you instead call
+`kms:Sign(tbsCertificate, KeyId)`. KMS returns the signature, and you staple it
+onto the certificate. The device's own private key, meanwhile, never leaves the
+Pi — only its CSR travels.
+
+### Why this was chosen
+
+| Concern | How this approach handles it |
+|---|---|
+| **Cost** | ~$1/mo (a KMS key is ~$1/mo + per-sign calls) vs ~$400/mo for ACM PCA |
+| **Key custody** | Non-extractable HSM-backed key — same security property as the managed offering |
+| **Truststore** | Identical outcome: one CA public cert in S3, consumed by API Gateway mTLS |
+| **Trust ownership** | Single CA owned in one place, so the S3 truststore can never drift out of sync with the issuer |
+
+So you get **HSM-grade key protection** (the expensive, security-critical part)
+from KMS at commodity price, while you own the cheap, easy parts (generating
+CSRs, assembling certs, publishing the truststore). The ~$399/mo you save is
+essentially the fee ACM charges to also run the issuance plumbing — plumbing
+that's trivial at a <100-device scale.
+
+### The catch
+
+You're now responsible for the issuance code and the renewal flow (the renewal
+daemon on each Pi + the signing endpoint). KMS only protects the *key* — it
+doesn't run the CA logic for you. That operational burden is the explicit
+tradeoff this ADR accepted in exchange for dropping the managed-CA cost.
+
 ## Consequences
 
 ### Positive

--- a/docs/aws-deployment-guide.md
+++ b/docs/aws-deployment-guide.md
@@ -72,6 +72,15 @@ aws cloudformation describe-stacks \
 
 ### 2. Create the Fleet API key
 
+> ⚠️ **Not enforced as currently deployed.** The stack deploys an HTTP API
+> (`AWS::Serverless::HttpApi`), which does not support API keys or usage plans —
+> a key created here cannot be attached to the ingest endpoint and is ignored by
+> the Lambda. The steps below describe the *intended* REST-API auth model. Until
+> the gateway is migrated, the `/ingest` endpoint accepts unauthenticated
+> requests and the "No API key → 403" check below will return `200`. See the
+> 2026-06-16 addendum in `docs/adr/ADR-009-analytics-ingest-api-gateway-lambda.md`
+> for the gap and the migration steps to make this real.
+
 SAM deploys the API Gateway but does not auto-create an API key.
 
 1. AWS Console → **API Gateway → API Keys → Create API Key**
@@ -129,7 +138,11 @@ curl -X POST \
   https://<id>.execute-api.us-east-1.amazonaws.com/prod/ingest
 ```
 
-### No API key — should return `403`
+### No API key — should return `403` (intended; currently returns `200`)
+
+> Until the gateway is migrated to a REST API with a usage plan (or in-Lambda
+> key validation is added), this request returns `200`, not `403` — the
+> `x-api-key` header is not checked. See the ADR-009 addendum.
 
 ```bash
 curl -X POST \

--- a/infra/sentri-analytics-integration.md
+++ b/infra/sentri-analytics-integration.md
@@ -1,0 +1,105 @@
+# aquilla-main changes required to support sentri-analytics hosting modernization
+
+Purpose: sentri-analytics is moving from a single hand-built EC2 box (`setup.sh`) to a baked-AMI Auto Scaling Group (see `sentri-analytics/docs/adr/0004-hosting-modernization-scope.md`). sentri-analytics is a **read-only** dashboard on the Aurora cluster this repo owns. This file lists the changes **aquilla-main** must make so the new compute can reach Aurora, plus the coordination items around credentials and decommissioning.
+
+aquilla-main owns: the Aurora VPC, the Aurora cluster, its `DBSecurityGroup`, the Aurora-side route tables, and the DB credentials. sentri-analytics cannot grant itself access to any of these — that is why these changes live here.
+
+## TL;DR — what must change here
+
+1. **Codify the existing (drifted) connectivity** into `template.yaml` before anything else.
+2. **Add an Aurora-side return route** to the sentri-analytics app VPC over the peering connection.
+3. **Add Aurora `DBSecurityGroup` ingress** on 5432 for the sentri-analytics app VPC CIDR.
+4. **Provide a stable read credential** (ideally a dedicated read-only role) and coordinate any rotation.
+
+Nothing about the device ingest pipeline (API Gateway, Lambdas, SQS, S3, mTLS) changes. This is purely the database-access path for an internal reader.
+
+## Verified topology (account 867958227555, us-east-2)
+
+| | Aurora VPC (this repo) | sentri-analytics app VPC |
+|---|---|---|
+| VPC | `vpc-0031b6ad2eac1ae9f` (SAM `SentriVPC`) | new per-env VPC (`SentriVpcStack`) |
+| CIDR | `10.0.0.0/16` | `10.1.0.0/16` |
+| Subnets | `10.0.1.0/24` (2a), `10.0.2.0/24` (2b), isolated | public + private-with-egress |
+| Route table | `rtb-076d091c4bfd764c7` | own |
+| Aurora SG | `DBSecurityGroup` — **allows only `LambdaSecurityGroup`** (`template.yaml:106-115`) | — |
+
+Same account + same region ⇒ the VPC peering connection (created on the sentri-analytics side) **auto-accepts**; no manual acceptance step. The required work is the **return route** and the **SG ingress** on this side.
+
+## Step 0 (do first): resolve the connectivity drift
+
+The deployed Aurora currently accepts connections from the existing sentri-analytics EC2 (`10.1.x`), but `template.yaml` contains **no peering, no route to `10.1.0.0/16`, and no SG rule for it**. Those were added out-of-band in the console. Risk: the next `sam deploy` can revert them and break **both** the current EC2 and the new ASG.
+
+- [ ] Inspect the live Aurora VPC: confirm the peering connection ID (`pcx-…`), the route on `rtb-076d091c4bfd764c7` to `10.1.0.0/16`, and the `DBSecurityGroup` rule that actually admits the current EC2.
+- [ ] Bring those into `template.yaml` (below) so they are managed, not drifted.
+
+## Required changes
+
+### 1. Aurora-side return route to the sentri-analytics VPC
+
+Peering routes are not symmetric — sentri-analytics adds the route on its side; Aurora must add the return route or replies never get back.
+
+```yaml
+# template.yaml — Aurora VPC route table
+SentriAnalyticsPeeringRoute:
+  Type: AWS::EC2::Route
+  Properties:
+    RouteTableId: !Ref PrivateRouteTable        # deployed: rtb-076d091c4bfd764c7
+    DestinationCidrBlock: !Ref SentriAnalyticsVpcCidr   # 10.1.0.0/16 (prod)
+    VpcPeeringConnectionId: !Ref SentriAnalyticsPeeringId
+```
+
+`SentriAnalyticsPeeringId` and the CIDR come from the sentri-analytics CDK output `PeeringConnectionId` (`sentri-vpc-stack.ts:43`). Pass them in as SAM parameters — this is the cross-stack handshake.
+
+### 2. Aurora `DBSecurityGroup` ingress for the dashboard
+
+Currently only the ingest Lambda SG is allowed. Add the reader. Use the **CIDR** form — cross-VPC security-group references over peering are brittle; the CIDR rule is robust and matches the parallel-run requirement.
+
+```yaml
+# template.yaml — DBSecurityGroup.SecurityGroupIngress (add alongside the existing Lambda rule)
+- IpProtocol: tcp
+  FromPort: 5432
+  ToPort: 5432
+  CidrIp: !Ref SentriAnalyticsVpcCidr           # 10.1.0.0/16
+  Description: sentri-analytics dashboard (read-only) over VPC peering
+```
+
+Keep the existing `LambdaSecurityGroup` ingress untouched.
+
+### 3. Per-environment
+
+sentri-analytics intends separate dev and prod app VPCs. Each gets its own non-overlapping CIDR (e.g. prod `10.1.0.0/16`, dev `10.2.0.0/16`) and therefore its own return route + ingress rule + peering. Parameterize so the dev and prod SAM stacks each admit only their matching sentri-analytics VPC.
+
+### 4. Read credential (coordination — see also rotation below)
+
+sentri-analytics fetches `sentri/db` from Secrets Manager and connects with `DATABASE_SSL=true`. Aurora keeps requiring TLS (`require`) — no change. **Recommended:** instead of sharing the Aurora master credential, provision a dedicated least-privilege role via the existing `schema_runner` Lambda:
+
+```sql
+CREATE ROLE sentri_readonly LOGIN PASSWORD '<from secret>';
+GRANT CONNECT ON DATABASE sentri TO sentri_readonly;
+GRANT USAGE ON SCHEMA public TO sentri_readonly;
+GRANT SELECT ON devices, runs, run_results TO sentri_readonly;
+GRANT SELECT, INSERT, UPDATE, DELETE ON device_sites TO sentri_readonly;  -- device_sites is owned by sentri-analytics
+```
+
+This makes credential rotation independent of the pipeline and enforces the read-only contract at the database, not just by convention.
+
+## Coordination items (timeline)
+
+- **Parallel run:** keep BOTH the old EC2 access and the new ASG VPC access on Aurora at the same time. Do not remove the old EC2's route/SG rule until sentri-analytics Phase E.
+- **Credential rotation (sentri-analytics Phase D):** the old `setup.sh` path leaked the DB credential via SSM/CloudTrail, so it will be rotated. **If sentri-analytics and the pipeline share a credential, rotating it will break `aurora_loader` (Lambda 3) unless its secret/`DB_DSN` is updated in the same change.** The dedicated read-only role above avoids this coupling entirely — strongly preferred.
+- **Decommission (sentri-analytics Phase E):** when the old EC2 is torn down, remove its now-stale route/SG ingress rule from the Aurora side too.
+
+## Optional hardening
+
+- [ ] Bump `AuroraCluster.BackupRetentionPeriod` (currently 7 days, `template.yaml`) before gated migrations, so PITR covers a "would we notice a bad migration" window.
+- [ ] Add the read-only role + grants to the `schema_runner` migration set so it is reproducible.
+
+## What aquilla-main does NOT need to do
+
+- No changes to API Gateway, the three ingest Lambdas, SQS, S3, or the device payload.
+- No mTLS / PKI / truststore work (that is a separate ingest-tier decision; see `sentri-analytics/docs/AnalyticsInfrastrucure/ingest-architecture-tradeoff.md`).
+- No schema changes to `devices`/`runs`/`run_results` for the hosting move. (Those are only needed for *new dashboard features* — firmware version, telemetry, etc. — which are out of scope here.)
+
+## Acceptance check
+
+From a new sentri-analytics ASG instance (in `10.1.0.0/16`), `psql "$DATABASE_URL"` connects over TLS and `SELECT count(*) FROM runs;` returns — while the device ingest pipeline continues writing normally, and the rule survives a `sam deploy` (no drift).

--- a/specs/Data-pipline/device-edge-mtls-migration-prd.md
+++ b/specs/Data-pipline/device-edge-mtls-migration-prd.md
@@ -1,0 +1,116 @@
+# PRD: Sentri Analytics Pipeline — Device-Edge mTLS Migration & Aurora Connectivity
+
+> **Revision 1 — 2026-06-17**
+> Successor to `analytics-pipeline-prd.md`. Supersedes its *Authentication and Key Rotation*
+> and *AWS Ingest Architecture* sections: ingest ownership moves to the Sentri Analytics
+> Platform and device auth switches from the shared Fleet API Key to per-device mTLS Device
+> Certificates. See **ADR-013** (ingest moves to platform; auth → mTLS) and **ADR-014**
+> (device PKI: self-managed KMS-backed CA, short-lived certs). Glossary in `CONTEXT.md`.
+
+## Problem Statement
+
+Today every Sentri authenticates to the Ingest Endpoint with a single shared Fleet API Key sent as an `x-api-key` header. As built this key is not even enforced (HTTP APIs have no usage plans, no authorizer is defined, and the handler never inspects the header — see issue #174), so `/ingest` is effectively open. Worse, a shared fleet key is the wrong identity model for a field fleet of physical instruments: a single stolen Pi exposes ingest for the whole fleet, and the key can only be rotated fleet-wide.
+
+In parallel, ingest ownership is moving off this repo's SAM stack and onto the Sentri Analytics Platform, whose system design authenticates devices with per-device mTLS client certificates at a managed gateway. This repo must change the **device edge** to speak mTLS, provision and renew per-device certificates, open the **Aurora** path for the new platform compute, and retire the old SAM ingest stack — without which the fleet cannot move to the new, authenticated platform.
+
+## Solution
+
+From the operator's and fleet's perspective:
+
+- Each Sentri presents its own **Device Certificate** (mTLS) on every Sync instead of a shared key. The certificate's Subject CN is the **Device ID** (the Pi hardware serial), so the platform derives device identity cryptographically and a stolen certificate cannot impersonate a different Sentri.
+- A Sentri generates its own keypair on-device and enrolls during deployment; its private key never leaves the Pi. Certificates are short-lived and the Sentri renews them automatically before expiry, authenticating the renewal with its current still-valid certificate. Revoking a compromised Sentri is simply ceasing to renew it — it self-expires.
+- The shared Fleet API Key and the `x-api-key` header are removed entirely.
+- The Aurora cluster (owned by this repo) admits the new platform's app VPC over peering so the platform's compute can read/write, with a dedicated least-privilege role rather than the master credential.
+- Because nothing is in production yet (one Sentri syncing, disposable data), the fleet cuts over to the new Ingest Endpoint big-bang once the platform edge exists, and the old SAM ingest stack is then deleted — preserving the Aurora cluster.
+
+## User Stories
+
+1. As a fleet operator, I want each Sentri to authenticate with its own Device Certificate, so that a single stolen Pi does not expose ingest for the entire fleet.
+2. As a fleet operator, I want the shared Fleet API Key removed from every Sentri, so that there is no shared secret left to leak or rotate fleet-wide.
+3. As the Sentri Analytics Platform, I want device identity to come from the certificate's CN (the Device ID), so that I can trust the device identity without relying on the request body.
+4. As the Sentri Analytics Platform, I want a request whose body `device_id` disagrees with the certificate CN to be rejectable, so that a device cannot claim to be a different Sentri.
+5. As a Sentri, I want to send my client certificate and key on every Sync POST, so that I pass the mTLS handshake at the new Ingest Endpoint.
+6. As a Sentri, I want to no longer send an `x-api-key` header, so that I stop depending on the retired shared-key model.
+7. As the backfill tool, I want to authenticate with the same Device Certificate as live Sync, so that historical Event uploads use the same identity model.
+8. As a Sentri, I want to generate my own keypair and a CSR with `CN=<Device ID>` during deployment, so that my private key never leaves the device.
+9. As a fleet operator, I want initial enrollment (CSR signing) to be authenticated by my own credentials at provisioning time, so that the Pi never holds a credential that could mint certificates.
+10. As a Sentri, I want my certificate and private key stored `chmod 600`, so that they are not world-readable on the device.
+11. As a Sentri, I want a background task that checks my certificate's expiry, so that I renew before it lapses and never lose the ability to Sync.
+12. As a Sentri, I want to renew by submitting a new CSR authenticated with my current valid certificate, so that renewal needs no operator presence and no stored credential.
+13. As a Sentri, I want the new certificate swapped in atomically, so that a renewal interrupted mid-write never leaves me with a broken certificate.
+14. As a fleet operator, I want a manual renewal trigger endpoint, so that I can force a renewal for diagnostics without waiting for the scheduled task.
+15. As a fleet operator, I want a re-enrollment path for a Sentri whose certificate expired while it was offline beyond the certificate lifetime, so that the rare offline-too-long device can rejoin.
+16. As a fleet operator, I want to repoint a Sentri's Ingest Endpoint to the new platform's regional custom domain, so that the fleet sends to the new platform at cutover.
+17. As a fleet operator, I want to cut the whole fleet over at once (big-bang), so that the old open `x-api-key` endpoint is closed quickly rather than lingering during a phased rollout.
+18. As an analytics consumer, I want `dock_name` to remain platform-owned registry metadata, so that a stolen or reimaged Sentri cannot mislabel its own location.
+19. As a Sentri, I want my Event payload shape unchanged (still keyed on `device_id`), so that the migration is auth-only and introduces no new device-side fields.
+20. As the Sentri Analytics Platform, I want the Aurora cluster to accept connections from my app VPC CIDR over peering, so that my compute can reach the database.
+21. As the owner of the Aurora VPC, I want the return route to the platform app VPC codified in the SAM template, so that replies traverse the peering connection and a redeploy does not revert it.
+22. As the owner of the Aurora cluster, I want the existing console-added connectivity (peering, route, security-group ingress) brought into the template, so that the next deploy does not silently break ingress.
+23. As a security-conscious operator, I want the platform to connect with a dedicated read/least-privilege role rather than the master credential, so that credential rotation is decoupled from the ingest pipeline and the access contract is enforced at the database.
+24. As the owner of this repo, I want the old SAM ingest stack (API Gateway, Lambdas, SQS, S3) decommissioned after cutover, so that there is one ingest implementation, not two.
+25. As the owner of this repo, I want the Aurora cluster explicitly preserved during decommission, so that the new platform's pre-existing-database assumption holds.
+26. As a developer, I want the device auth change covered by the existing Sync test seam, so that "certificate sent, no api-key" is verified automatically.
+27. As a developer, I want the renewal decision logic unit-tested, so that "renew when within N days of expiry" is verified without hardware.
+28. As a developer, I want the atomic certificate swap covered by an integration test, so that an interrupted renewal cannot corrupt the active certificate.
+29. As a fleet operator, I want certificate renewal to rely on daily connectivity, so that short-lived certificates are practical given Sentris are online every day.
+30. As an auditor, I want revocation to be achievable by ceasing renewal, so that revoking a stolen Sentri does not require CRL/OCSP infrastructure the gateway lacks.
+
+## Implementation Decisions
+
+### Identity model (per ADR-013, ADR-014)
+- The Device Certificate Subject CN is the **Device ID** (Pi hardware serial from `/proc/cpuinfo`, already the stable analytics identity). The platform derives device identity from the certificate; the Event body continues to carry `device_id` only as a **cross-check** — a body/CN mismatch is a rejected request.
+- The Event/`run_complete` payload shape is **unchanged**. `dock_name` is **not** a device-emitted field; it is platform-owned registry metadata (`device_sites`) joined server-side by `device_id`. No payload contract change is owed by this repo.
+
+### Device sync auth
+- The Sync client drops the `x-api-key` header and presents the client certificate and key on the POST (a `cert=(client_cert, client_key)` style request). The `AQ_SYNC_API_KEY` env var and Fleet API Key are removed.
+- The backfill tool makes the same auth change at its request-building boundary.
+- New device configuration: certificate path, key path, and renewal endpoint env vars; `AQ_SYNC_ENDPOINT` is repointed to the platform's regional custom domain at cutover.
+
+### Enrollment, renewal, rotation
+- On-device keypair generation + CSR (`CN=Device ID`); the private key never leaves the Pi; certificate and key stored `chmod 600`. Initial enrollment is operator-authenticated at deployment time.
+- Certificates are short-lived; renewal is automatic. Renewal is implemented as a **Python background task in the FastAPI app**, mirroring the existing background Sync task, plus a manual-trigger endpoint **`POST /sync/cert/renew`** mirroring `POST /sync/flush`. Renewal authenticates with the current valid certificate, submits a new CSR, and swaps the certificate **atomically** (write-to-temp + rename).
+- A re-enrollment path in the fleet update tooling covers the rare "offline beyond certificate lifetime" Sentri.
+- Revocation model is **revocation-by-non-renewal**: ceasing to renew a Sentri lets its certificate self-expire, avoiding the gateway's missing CRL/OCSP support. One CA serves the single prod fleet (no dev-fleet CA).
+
+### Aurora connectivity (`infra/template.yaml`)
+- Codify the existing (currently console-added, drifted) peering connection, route to the platform app VPC CIDR, and `DBSecurityGroup` ingress, so a redeploy does not revert them.
+- Add the Aurora-side return route over the peering connection to the platform app VPC CIDR (peering routes are not symmetric).
+- Add `DBSecurityGroup` ingress on 5432 for the platform app VPC **CIDR** (cross-VPC security-group references over peering are brittle); keep the existing Lambda ingress untouched until decommission.
+- Parameterize the app VPC CIDR and peering id so the values come from the platform's CDK outputs (cross-stack handshake).
+- Provision a dedicated `sentri_readonly` role (LOGIN; CONNECT on the database; USAGE on schema; SELECT on `devices`, `runs`, `run_results`; and full CRUD on `device_sites`, which the platform owns) via the existing `schema_runner` migration path, instead of sharing the master credential.
+
+### Cutover and decommission
+- **Big-bang greenfield cutover:** with one Sentri syncing and disposable data, provision certificates fleet-wide, repoint the fleet to the new Ingest Endpoint at once, then delete the old SAM ingest stack (API Gateway + Lambdas + SQS + S3). No parallel-run, no dual-write, no idempotency-as-blocker.
+- The Aurora cluster is **excluded from teardown** and preserved.
+
+## Testing Decisions
+
+Good tests here assert external behavior at the highest available seam — what the device sends on the wire and what configuration resources exist — not internal call sequences. Mock the network boundary (`requests.post`) and the filesystem (`tmp_path`) rather than asserting implementation details.
+
+- **Device sync auth — existing seam (`POST /sync/flush` → `aquila_web.sync`).** Prior art: `tests/unit/test_background_sync.py`, which monkeypatches `aquila_web.sync.requests.post` and captures call kwargs. Replace the existing `TestApiKeyHeader` class (asserts `x-api-key` is sent) with tests asserting the client certificate tuple is passed and **no** `x-api-key` header is present. Keep the existing "no endpoint → synced 0" and "network error swallowed, events stay pending" behaviors green.
+- **Backfill auth.** Unit test at the backfill request-building boundary: mock `requests.post`, assert the certificate is passed and no api-key header is set.
+- **Renewal decision logic.** Pure-logic unit test (in `unit_tests/`): given a certificate expiry and a threshold, the function decides whether to renew. Prior art for pure-logic units: `unit_tests/test_optics_history.py`, `tests/unit/test_device_id.py`.
+- **Renewal swap + endpoint.** Integration test via `POST /sync/cert/renew` with `tmp_path` certificates and the renewal POST mocked: a successful renewal swaps the active certificate atomically; a failed renewal leaves the existing certificate intact. Prior art: `tests/integration/test_seams.py` (TestClient + `tmp_path` seam tests).
+- **Enrollment / provisioning.** Host-dependent (on-device keygen, install, deployment scripts) — mark `@pytest.mark.hardware` with a documented "why not CI" note per the repo testing rules. Extract any pure logic (e.g. CSR subject construction = `CN=Device ID`) into Python and unit-test it.
+- **Aurora connectivity.** Light infra assertion: parse `infra/template.yaml` and assert the return route, the app-VPC-CIDR `DBSecurityGroup` ingress rule, and the `sentri_readonly` provisioning exist. Note the existing `tests/infra/` handler tests (`aurora_loader`, `ingest_handler`, `s3_archiver`) retire with the decommissioned SAM stack. Real validation is `sam deploy` plus the acceptance check: from a platform app-VPC instance, `psql` connects over TLS and a `SELECT` against `runs` returns.
+
+## Out of Scope
+
+These are **Sentri Analytics Platform** (`Acorn/sentri-analytics`) deliverables and **preconditions for cutover**, not work in this repo:
+
+- The mTLS API Gateway (HTTP API), regional custom domain, ACM certificate, and the S3 truststore.
+- The Certificate Authority itself (a self-managed, KMS-backed CA per ADR-014) and the signing/renewal endpoint the device calls.
+- VPC Link, internal ALB, Auto Scaling group / launch template, VPC endpoints, the rate-limit store, and the Node `/ingest` application.
+- AMI bake, CI/CD pipeline, and platform-side migrations.
+- The analytics read/query surface and the `device_sites` / `dock_name` registry.
+
+Also out of scope: data migration of any kind (existing ingest data is disposable); changing the Event payload schema (auth-only migration); any dev-fleet certificate isolation (one prod fleet, one CA — the dev platform environment uses simulation-mode traffic, not hardware).
+
+## Further Notes
+
+- Anchored by **ADR-013** (ingest moves to the Sentri Analytics Platform; device auth → mTLS) and **ADR-014** (device PKI: self-managed KMS-backed CA, short-lived certificates, on-device keygen, revocation-by-non-renewal). Glossary terms (Sentri, Device ID, Device Certificate, Ingest Endpoint, Sentri Analytics Platform, Fleet API Key *(retired)*, Sync, Event) are defined in `CONTEXT.md`.
+- **Sequencing:** every in-scope item except the big-bang cutover can be built and tested now against mocks. Cutover requires the platform-side gateway + truststore + signing/renewal endpoint to exist first; confirm that before repointing the fleet.
+- The short-lived-certificate posture depends on Sentris being **online daily** (assumption confirmed). A Sentri offline beyond its certificate lifetime drops to manual re-enrollment — accepted as rare.
+- ADR-014's chosen PKI eliminates the ~$400/mo ACM Private CA cost and sidesteps the gateway's missing revocation checking; long-lived certificates + a deny-list remain the documented fallback if auto-renewal proves operationally fragile.
+- The Aurora connectivity work is independent of the PKI/auth work and can proceed on a separate track.

--- a/specs/prd/kms-ca-enrollment-mtls-s3-verification-prd.md
+++ b/specs/prd/kms-ca-enrollment-mtls-s3-verification-prd.md
@@ -1,0 +1,112 @@
+# PRD: KMS-backed CA — password-gated device enrollment in deployment + mTLS→S3 verification slice
+
+> **Tracking issue:** [#176](https://github.com/AcornGenetics/aquilla-main/issues/176)
+> **Revision 1 — 2026-06-17**
+>
+> **Tracer-bullet vertical slice** carved from `specs/Data-pipline/device-edge-mtls-migration-prd.md`.
+> Anchored by **ADR-014** (device PKI: self-managed KMS-backed CA, on-device keygen, operator-authenticated enrollment) and **ADR-013** (device auth → mTLS; truststore in S3, consumed by API Gateway mTLS). Glossary in `CONTEXT.md` (Sentri, Device ID, Device Certificate, Ingest Endpoint, Sync, Event).
+>
+> **Goal of this slice:** prove the whole chain end-to-end on real infrastructure — *KMS-backed CA exists → a Sentri enrolls during deployment (gated by an operator password) → the Sentri presents its Device Certificate to an mTLS gateway → the Event lands in S3.* It is the smallest runnable proof that ADR-014's PKI works before the broader renewal/Aurora/decommission work is built.
+
+## Problem Statement
+
+I have ADR-014 (a self-managed, KMS-backed CA issuing per-device Device Certificates) on paper, but nothing that proves it works. Today a Sentri authenticates to the Ingest Endpoint with a shared Fleet API Key (`x-api-key`) that isn't even enforced, and my deployment script (`deployment2.sh`) just prompts for that shared key and writes it to `device.env`. There is:
+
+- no Certificate Authority actually standing (no KMS key, no root cert, no truststore in S3),
+- no way for a Sentri to *get* a certificate when I deploy it — and no gate stopping just anyone from minting one,
+- no demonstration that a certificate, once on a device, actually authenticates a real upload all the way into S3.
+
+Until I can run that chain from nothing and watch an Event land in the bucket because of the certificate, I can't trust the design or build the rest of the migration on top of it.
+
+## Solution
+
+From my (the operator's) and the fleet's perspective:
+
+- **A CA exists, once, with one command.** A one-time bootstrap creates a non-extractable KMS asymmetric key, builds the self-signed root certificate by signing it through the KMS `Sign` API, and publishes the root (the **truststore**) to the S3 location the gateway's mTLS validation reads. The CA private key never exists outside the KMS HSM.
+- **Deploying a Sentri gets it a certificate.** When I run `deployment2.sh`, the Sentri generates its own keypair on-device and a CSR with `CN=<Device ID>`, I am prompted for an **enrollment password**, and the signing path issues a Device Certificate only if that password is valid. The certificate and key land on the Pi `chmod 600`; the device's private key never leaves the Pi and the Pi never holds a credential that could mint *other* certificates.
+- **The shared Fleet API Key is gone.** Deployment stops prompting for / writing `AQ_SYNC_API_KEY`; the Sentri presents its Device Certificate on Sync instead of an `x-api-key` header.
+- **I can verify it works.** A test/verification script run from the device presents the Device Certificate to the **mTLS Ingest Endpoint** and POSTs a sample Event; I can then see that exact Event archived as an object in the raw-events S3 bucket. A bad/absent/wrong-CA certificate fails the handshake and nothing lands. That is the proof.
+
+## User Stories
+
+1. As an operator, I want a one-command CA bootstrap, so that I can stand up the Certificate Authority without hand-assembling keys.
+2. As a security-conscious operator, I want the CA private key created as a non-extractable KMS asymmetric key, so that the root signing key can never be exported or leaked.
+3. As an operator, I want the self-signed root certificate produced by signing through the KMS `Sign` API, so that the root is bound to the KMS key without the private key ever leaving the HSM.
+4. As an operator, I want the root certificate (truststore) published to the S3 location the gateway reads, so that API Gateway mTLS can validate device certificates against it.
+5. As an operator, I want the bootstrap to be idempotent / safe to re-run, so that re-running it does not silently create a second CA or clobber the live truststore.
+6. As a Sentri, I want to generate my own keypair on-device during deployment, so that my private key never leaves the Pi.
+7. As a Sentri, I want to build a CSR with `CN=<Device ID>`, so that my transport identity equals my data-model identity (the Pi hardware serial).
+8. As an operator, I want `deployment2.sh` to prompt me for an enrollment password (masked input), so that obtaining a certificate requires my authorization at provisioning time.
+9. As the signing path, I want to verify the enrollment password before signing a CSR, so that an unauthenticated caller cannot mint a Device Certificate.
+10. As the signing path, I want to sign the device CSR through the KMS `Sign` API, so that issuance uses the same HSM-held CA key as the root.
+11. As the signing path, I want to set the certificate's `CN` from the CSR's `CN` (the Device ID) and a short validity window, so that issued certificates carry the right identity and posture.
+12. As a Sentri, I want my certificate and private key written `chmod 600`, so that they are not world-readable on the device.
+13. As a Sentri, I want the certificate and key paths recorded in `device.env`, so that the Sync client and verification script can find them.
+14. As an operator, I want enrollment to fail loudly (non-zero exit, clear message) on a wrong password or signing error, so that a deployment never silently completes without a valid certificate.
+15. As an operator, I want `deployment2.sh` to stop prompting for and writing `AQ_SYNC_API_KEY`, so that the retired shared-key model is removed from new deployments.
+16. As a Sentri, I want to present my Device Certificate (client cert + key) on the Sync POST instead of an `x-api-key` header, so that I authenticate by mTLS.
+17. As an operator, I want the Ingest Endpoint gateway configured for mTLS with the S3 truststore, so that only certificates signed by my CA complete the handshake.
+18. As an operator, I want a verification script I can run from the device, so that I can confirm the certificate authenticates a real upload end-to-end.
+19. As an operator, I want the verification script to POST a sample Event over mTLS and then confirm the object exists in the raw-events S3 bucket, so that I have proof the chain works into storage, not just at the handshake.
+20. As an operator, I want the verification to fail when no certificate, an expired certificate, or a wrong-CA certificate is presented, so that I know the gateway is actually enforcing mTLS and not accepting anything.
+21. As a developer, I want the CSR-subject construction (`CN=Device ID`) extracted as pure logic, so that it is unit-testable without hardware.
+22. As a developer, I want the signing logic tested against a stubbed KMS, so that "valid password → signs; bad password → refuses" is verified without real AWS calls.
+23. As a developer, I want the device Sync auth change covered by the existing Sync test seam, so that "certificate sent, no `x-api-key`" is verified automatically.
+24. As a developer, I want the gateway mTLS + truststore configuration asserted against the infra template, so that a redeploy can't silently drop mTLS enforcement.
+25. As an operator, I want the existing raw-events S3 bucket and archiver path reused for verification, so that the slice proves the real ingest-to-storage route rather than a throwaway one.
+
+## Implementation Decisions
+
+### CA bootstrap (self-managed, KMS-backed — ADR-014)
+- A one-time bootstrap (a `scripts/` utility) creates a **KMS asymmetric key** (usage `SIGN_VERIFY`, e.g. RSA/ECC), reads its **public key**, and assembles a **self-signed root certificate** whose signature is produced via the KMS `Sign` API (the private key is non-extractable and never leaves the HSM).
+- The root certificate (the **truststore** / CA public cert) is uploaded to the **S3 location the gateway's mTLS validation reads**. The KMS private key is the single root of trust; no raw CA key file ever exists on disk.
+- Bootstrap is **idempotent / guarded**: re-running detects an existing CA key + truststore and refuses to silently replace them.
+
+### Certificate signing path (operator-authenticated — "enrollment password")
+- A signing function takes a **CSR + an enrollment token/password**, **verifies the password first**, and only then signs the CSR via KMS `Sign`, returning a Device Certificate with `CN` carried from the CSR and a short validity window.
+- A wrong/absent password is rejected without signing. (Where the signing path is hosted — small Lambda vs. local invocation during this slice — is an implementation detail; the contract is *password-gated, KMS-signed issuance*. Auto-renewal and a cert-authenticated renewal endpoint are **out of scope** here — see Out of Scope.)
+
+### Device enrollment in `deployment2.sh`
+- During deployment the Sentri **generates its own keypair** and a **CSR with `CN=<Device ID>`** (Device ID = the Pi hardware serial per `CONTEXT.md`; the script already establishes a `DEVICE_ID`).
+- `deployment2.sh` prompts for the **enrollment password using its existing masked-prompt helper** (`prompt_if_unset … true` / `read -rsp`), submits CSR + password to the signing path, and on success writes the **certificate and key `chmod 600`** and records their paths in `device.env`.
+- The script **stops prompting for and writing `AQ_SYNC_API_KEY`**; the Fleet API Key is removed from new deployments. Enrollment failure (bad password / signing error) **exits non-zero with a clear message** — no silent completion.
+- Pure logic (CSR subject construction = `CN=Device ID`) is extracted into Python so it is unit-testable; the on-device keygen/install steps are host-dependent.
+
+### Device Sync auth (`aquila_web/sync.py`)
+- The Sync client **drops the `x-api-key` header** and presents the **client certificate + key** on the POST (`cert=(client_cert, client_key)` style). Certificate/key paths come from `device.env`. The Event payload shape is **unchanged** (still keyed on `device_id`).
+
+### mTLS gateway → S3 (reuse existing SAM ingest path)
+- Enable **mTLS on the existing `AWS::Serverless::HttpApi` Ingest Endpoint** (`infra/template.yaml`) with the **S3 truststore** from bootstrap; disable the default execute-api endpoint so only the mTLS-validated path is reachable. The existing **`S3ArchiverFunction` → `RawEventsBucket` (`sentri-raw-events-${AccountId}`)** route is **reused** as the ingest-to-storage path under test.
+- This is the production-shaped verification path (API Gateway mTLS per ADR-013), not IAM Roles Anywhere.
+
+### Verification script
+- A device-side script loads the Device Certificate from `device.env`, **POSTs a sample Event over mTLS** to the Ingest Endpoint, then **confirms the resulting object exists in `RawEventsBucket`**. Negative cases (no cert / expired / wrong-CA) must fail the handshake and land nothing.
+
+## Testing Decisions
+
+Good tests assert **external behavior at the highest available seam** — what the device puts on the wire, what the signing path returns for good vs. bad input, and what infra resources exist — not internal call order. Mock the network boundary (`requests.post`) and AWS boundaries (botocore `Stubber` / `tmp_path`) rather than reaching for real services in unit tests.
+
+- **Device Sync auth — existing seam (`POST /sync/flush` → `aquila_web.sync`).** Prior art: `tests/unit/test_background_sync.py` (monkeypatches `aquila_web.sync.requests.post`, captures call kwargs). Replace the `x-api-key` assertion with: the client-certificate tuple is passed and **no** `x-api-key` header is present. Keep "no endpoint → synced 0" and "network error swallowed, events stay pending" green.
+- **CSR subject construction.** Pure-logic unit test (`unit_tests/`): given a Device ID, the CSR subject is `CN=<Device ID>`. Prior art: `unit_tests/test_optics_history.py`, `tests/unit/test_device_id.py`.
+- **CA bootstrap + signing.** Unit test the cert-assembly + signing logic against a **stubbed KMS** (botocore `Stubber`): root cert is signed via KMS `Sign`; a device CSR with a valid enrollment password is signed and carries `CN` from the CSR; a **wrong/absent password is refused without a `Sign` call**; re-running bootstrap against an existing CA refuses to clobber. Prior art for handler/infra-style tests: `tests/infra/` (`test_s3_archiver.py`, `test_ingest_handler.py`).
+- **Gateway mTLS + truststore.** Light infra assertion: parse `infra/template.yaml` and assert the HttpApi has mTLS enabled, references the S3 truststore, disables the default execute-api endpoint, and that the `S3ArchiverFunction` → `RawEventsBucket` route is intact. Prior art: `tests/infra/conftest.py` template-parsing pattern.
+- **Enrollment / on-device keygen.** Host-dependent (keygen, install, `deployment2.sh`) — mark `@pytest.mark.hardware` with a documented "why not CI" note per the repo testing rules; cover the extractable pure logic (CSR subject) above.
+- **End-to-end acceptance (the real proof).** After `sam deploy` + bootstrap: from a Sentri with an enrolled certificate, the verification script POSTs a sample Event over mTLS and the matching object appears in `RawEventsBucket`; presenting no / expired / wrong-CA certificate fails the handshake and lands nothing.
+
+## Out of Scope
+
+Owned by the broader migration PRD (`specs/Data-pipline/device-edge-mtls-migration-prd.md`) or the **Sentri Analytics Platform** (`Acorn/sentri-analytics`), **not** this slice:
+
+- **Automatic certificate renewal**, the cert-authenticated renewal endpoint (`POST /sync/cert/renew`), the on-device renewal daemon, atomic mid-renewal swap, and the offline-too-long re-enrollment path. This slice is **enroll-once + verify**; renewal is the next slice.
+- Revocation-by-non-renewal mechanics beyond the short validity window itself.
+- The full production **Sentri Analytics Platform edge** (VPC Link, internal ALB, ASG, the Node `/ingest` app, regional custom domain, rate-limit store). This slice reuses the existing SAM `HttpApi` + `S3ArchiverFunction` + `RawEventsBucket` purely to prove the certificate chain.
+- **Aurora connectivity** (peering, return route, `DBSecurityGroup` ingress, `sentri_readonly` role) — independent track in the broader PRD.
+- **Decommissioning** the old SAM ingest stack and the **big-bang fleet cutover**.
+- Backfill-tool auth change; any Event payload schema change (this slice is auth-only); any dev-fleet certificate isolation (one prod fleet, one CA).
+
+## Further Notes
+
+- This is intentionally the **smallest end-to-end runnable proof** of ADR-014: CA → enrollment (password-gated) → certificate on device → mTLS → S3. Everything in scope can be built and unit-tested now against mocks; the **acceptance test** needs the bootstrapped CA, the mTLS-enabled gateway, and one enrolled Sentri.
+- The short-validity posture is acceptable here because the slice doesn't yet auto-renew — certificates are issued fresh for the verification run. Renewal is deferred to the next slice by design.
+- The KMS-backed CA eliminates the ~$400/mo ACM Private CA cost while keeping HSM-grade key custody (ADR-014); long-lived certs + a deny-list remain the documented fallback if the eventual auto-renewal proves fragile.
+- Device ID note: `deployment2.sh` currently derives `DEVICE_ID` from the hostname; `CONTEXT.md`/ADR-014 define Device ID as the Pi hardware serial. Reconciling the two is a small clarification to settle during implementation (the CSR `CN` must equal whatever the platform treats as the Device ID).


### PR DESCRIPTION
## Summary

Documents the move of analytics ingest off this repo's SAM stack and onto the **Sentri Analytics Platform**, replacing the shared Fleet API Key with **per-device mTLS Device Certificates**, and adds a runnable first slice of the device PKI.

### ADRs
- **ADR-013** — ingest moves to the Sentri Analytics Platform; device auth switches to mTLS.
- **ADR-014** — device PKI: self-managed **KMS-backed CA**, short-lived certs, on-device keygen, revocation-by-non-renewal. Includes a "what it actually means" section explaining the CA mechanics (KMS asymmetric key → self-signed root via KMS `Sign` → S3 truststore → CSR issuance flow).
- ADR-009 / `aws-deployment-guide.md` aligned with the superseding design.

### Specs / PRDs
- `specs/Data-pipline/device-edge-mtls-migration-prd.md` — full device-edge mTLS migration + Aurora connectivity PRD.
- `specs/prd/kms-ca-enrollment-mtls-s3-verification-prd.md` — **tracer-bullet slice** (issue #176): KMS-CA bootstrap, password-gated device enrollment in `deployment2.sh`, and an end-to-end check that a Device Certificate authenticates an Event through the mTLS gateway into S3.

### Context / infra docs
- `CONTEXT.md` — add Device Certificate & Sentri Analytics Platform terms; retire Fleet API Key; update Ingest Endpoint and Device ID.
- `infra/sentri-analytics-integration.md` — Aurora connectivity changes.

## Scope
Docs/specs only — no behavior change. (The earlier cosmetic run-page dropdown commit has been removed from this branch.)

Related: #176

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)