### PR TITLE
PCR: anchor shape checks at dip trough to ignore baseline artifact

### DIFF
--- a/aq_curve/evaluator.py
+++ b/aq_curve/evaluator.py
@@ -7,6 +7,7 @@ from aq_curve.pcr_curve_helpers import (
     get_curve_data,
     get_threshold,
     sustained_rise_index,
+    trough_index,
 )
 
 
@@ -87,7 +88,10 @@ def check_log_phase_linearity(curve_data, curve):
     threshold, _ = get_threshold(y_corrected, curve.baseline_slice)
     min_consecutive = config.get_int("PCR_SUSTAINED_CYCLES")
     cq = compute_cq(xdata, y_corrected, threshold, min_consecutive)
-    start = sustained_rise_index(y_corrected, threshold, min_consecutive)
+    # Anchor the rise scan at the dip trough so the leading optical artifact
+    # cannot mis-anchor the log phase at index 0.
+    floor = trough_index(y_corrected)
+    start = sustained_rise_index(y_corrected, threshold, min_consecutive, floor=floor)
     if start is None:
         return False
     end = _find_log_phase_end(y_corrected, start)
@@ -195,10 +199,17 @@ def check_sigmoidal_profile(curve_data, curve):
     amplitude_fraction = (max_val - baseline_mean) / max_val
     if amplitude_fraction < min_peak_fraction:
         return False
-    start = sustained_rise_index(y_corrected, threshold, min_consecutive)
+    # Anchor the rise scan at the dip trough so the leading optical artifact
+    # cannot mis-anchor it at index 0, then measure the slope over the log
+    # phase only ([start:end]). Fitting through the trailing plateau dilutes
+    # the slope for late risers; fitting from the trough adds a long flat
+    # baseline for late risers. The log-phase window avoids both.
+    floor = trough_index(y_corrected)
+    start = sustained_rise_index(y_corrected, threshold, min_consecutive, floor=floor)
     if start is None:
         return False
-    slope = float(np.polyfit(xdata[start:], y_corrected[start:], 1)[0])
+    end = _find_log_phase_end(y_corrected, start)
+    slope = float(np.polyfit(xdata[start:end + 1], y_corrected[start:end + 1], 1)[0])
     signal_range = float(np.max(y_corrected)) - float(np.min(y_corrected))
     post_rise_min = config.get_float("PCR_POST_RISE_SLOPE_MIN")
     return slope >= post_rise_min * signal_range
@@ -411,7 +422,9 @@ def _compute_stable_slope_cv(curve_data, curve):
     xdata, y_corrected, _ = curve_data
     threshold, _ = get_threshold(y_corrected, curve.baseline_slice)
     min_consecutive = config.get_int("PCR_SUSTAINED_CYCLES")
-    start = sustained_rise_index(y_corrected, threshold, min_consecutive)
+    # Skip the leading dip artifact when locating the log phase.
+    floor = trough_index(y_corrected)
+    start = sustained_rise_index(y_corrected, threshold, min_consecutive, floor=floor)
     if start is None:
         return None
     end = _find_log_phase_end(y_corrected, start)

--- a/aq_curve/pcr_curve_helpers.py
+++ b/aq_curve/pcr_curve_helpers.py
@@ -62,10 +62,26 @@ def get_threshold(ydata, baseline_slice):
     return threshold, baseline_mean
 
 
-def sustained_rise_index(ydata, threshold, min_consecutive):
+def trough_index(ydata):
+    """Index where the initial downward dip bottoms out (curve minimum).
+
+    Everything before this is the optical baseline artifact (initial hump /
+    descent); the genuine amplification begins at or after the trough.
+    """
+    if len(ydata) == 0:
+        return 0
+    return int(np.argmin(ydata))
+
+
+def sustained_rise_index(ydata, threshold, min_consecutive, floor=0):
+    """First index of a sustained run of >= min_consecutive points above
+    threshold. ``floor`` skips the leading dip artifact: scanning starts at
+    ``floor`` so a hump before the trough cannot anchor the rise at index 0.
+    """
+    floor = max(0, floor)
     count = 0
-    for idx, val in enumerate(ydata):
-        if val >= threshold:
+    for idx in range(floor, len(ydata)):
+        if ydata[idx] >= threshold:
             count += 1
             if count >= min_consecutive:
                 return idx - min_consecutive + 1


### PR DESCRIPTION
## Problem

Some optics curves begin with an initial **hump** that leaves the baseline-corrected trace above the detection threshold at cycle 1. This mis-anchors `sustained_rise_index` at index 0, pulling the early descending hump→dip into the log-phase window. The shape checks then evaluate the **baseline artifact** instead of the real sigmoid, leaving genuine amplifications stuck as **Inconclusive**.

Diagnosed across several optics logs: the affected wells had clean, real sigmoids whose only failures were `check_log_phase_linearity`, `check_stable_slope`, and `check_sigmoidal_profile` — all driven by `rise_index = 0`.

## Fix

- Add `trough_index(y)` (curve minimum = where the initial dip bottoms out) and an optional `floor=` parameter to `sustained_rise_index()` so the rise scan can start at the dip bottom, skipping the leading artifact.
- `check_log_phase_linearity` and `check_stable_slope` (via `_compute_stable_slope_cv`) now scan for the rise with `floor=trough`, then fit the log phase over `[start:end]`.
- `check_sigmoidal_profile` uses the same trough-floored rise anchor **and** fits the slope over the log-phase window `[start:end]` instead of `[start:]`. This avoids two failure modes: a raw-trough start dilutes late risers with leading baseline, while fitting through the plateau dilutes the slope for late risers.
- `compute_cq` is intentionally left unchanged (`skip_cycles=7`).

## Results (5 optics logs)

| Outcome | Count |
|---|---|
| Wells flipped Inconclusive → Detected | 8 |
| Regressions | 0 |
| True-negatives still Undetected | preserved |

The log-phase-window approach for `check_sigmoidal_profile` was chosen specifically because a naive `start = trough` introduced 5 regressions on late-riser wells (long flat baseline diluting the slope).

## Tests

- `tests/pcr_curve` full suite against a real log: **120 passed**, all 8 wells Detected.
- `tests/unit/analysis` + `tests/pcr_curve`: **57 passed**, no failures.

## Known limitation

Other `sustained_rise_index`-based checks (e.g. `check_monotonic_rise`) were **not** included in this change and remain vulnerable to the same artifact. Intentionally scoped out for now.

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)