### PR TITLE
docs: ADR-015 ingest -> acorn-analytics Lambda pipeline; reconcile ADR-013/CONTEXT

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -12,15 +12,20 @@ A single physical Aquilla PCR instrument — a Raspberry Pi running the Aquilla 
 **Fleet**
 The collection of all deployed Sentri units. Analytics queries span the fleet; device-level queries scope to a single Sentri. There is one prod fleet; there is no separate physical "dev fleet."
 
-**Sentri Analytics Platform**
-The separate system (repo `Acorn/sentri-analytics`) that owns cloud ingest and the analytics/query surface over Aurora — the mTLS gateway, compute tier, and read APIs. Distinct from a Sentri (the physical instrument). Beware the name collision: AWS resource names such as `SentriVPC` and the `sentri/db` secret belong to this platform/infrastructure, not to an individual Sentri.
-_Avoid_: calling the platform "Sentri" unqualified.
+**Sentri Analytics Platform** _(being split — see ADR-015)_
+Historically "the separate system (repo `Acorn/sentri-analytics`) that owns cloud ingest and the analytics/query surface over Aurora." Under the six-repository split (`sentri-analytics/specs/six-repo-architecture.md`, ADR-015) this single "platform" is **decomposed**, so prefer the specific repo:
+- **`acorn-analytics`** — owns cloud **ingest** (the serverless Lambda pipeline) and the **analytics warehouse**. This is what the device POSTs to.
+- **`acorn-app`** — the user-facing dashboard + its own operational DB (the renamed `sentri-analytics` repo).
+- **`acorn-infra`** — the shared AWS substrate (VPC, API Gateway, SQS, S3, IAM).
+- **`acorn-ca`** — the standalone KMS-backed device CA + S3 truststore (ADR-014's standalone CA).
+Distinct from a Sentri (the physical instrument). The name collision still holds: AWS resource names like `SentriVPC` and the `sentri/db` secret belong to platform infrastructure, not an individual Sentri.
+_Avoid_: calling any of these "Sentri" unqualified; using "Sentri Analytics Platform" as if it were one repo.
 
 **Device ID**
 The Raspberry Pi hardware serial number (from `/proc/cpuinfo`), used as the stable, globally unique identifier for a Sentri in analytics data. Survives reimages. Stored as `AQ_SYNC_DEVICE_ID` env var. Mapped to a human-readable `dock_name` in the AWS device registry. Do not confuse with the hostname-based config key (`sn01`, `sn02`) used for hardware configuration in `host_config.json`. The Device ID is also the canonical transport identity: it is the Subject CN of the Sentri's Device Certificate, so the platform derives Device ID from the cert rather than trusting the request body.
 
 **Device Certificate**
-The per-Sentri mTLS client certificate (and private key) presented on every Sync. Its Subject CN is the Device ID, cryptographically binding the transport identity to the data-model identity. Validated at the Ingest Endpoint against a signing-CA truststore. Replaces the Fleet API Key. Revoked per-device (the stolen-Pi threat model) rather than fleet-wide. Stored `chmod 600` on the Pi.
+The per-Sentri mTLS client certificate (and private key) presented on every Sync. Its Subject CN is the Device ID, cryptographically binding the transport identity to the data-model identity. Validated at the Ingest Endpoint against a signing-CA truststore — the CA private key (KMS, non-extractable) and the S3 truststore are owned by **`acorn-ca`** (ADR-014's standalone CA, now its own service). This device keeps only the client-side keypair + the enrollment/renewal daemons. Replaces the Fleet API Key. Revoked per-device (the stolen-Pi threat model) rather than fleet-wide. Stored `chmod 600` on the Pi.
 
 **Protocol**
 A named PCR assay profile — a JSON file in `profiles/` that defines thermal steps, cycle count, and optical configuration. The `title` field in the JSON is the canonical protocol name. Protocols are the primary grouping dimension for analytics (e.g., "inconclusive rate by protocol").
@@ -50,7 +55,7 @@ A structured JSON record enqueued in the local SQLite database (`data/db/app.db`
 The background process (asyncio task in the FastAPI app, 15-minute interval) that batches pending Events from the local SQLite queue and POSTs them to the AWS Ingest Endpoint. Also triggered on WiFi reconnect. On success, marks events `synced_at` in SQLite. Events accumulate indefinitely if offline.
 
 **Ingest Endpoint**
-The authenticated cloud entry point that receives Event batches from Sentri devices, hosted by the Sentri Analytics Platform. Devices authenticate with their Device Certificate (mTLS) — there is no API key. Reached at a regional custom domain (API Gateway), which forwards through the platform's compute tier to write to Aurora. The device-side URL is stored as `AQ_SYNC_ENDPOINT`. (Superseded the earlier API Gateway + Lambda + RDS + `x-api-key` design; see ADR-013.)
+The authenticated cloud entry point that receives Event batches from Sentri devices, **owned by `acorn-analytics`** (ADR-015). Devices authenticate with their Device Certificate (mTLS) — there is no API key. Reached at a regional custom domain (API Gateway), which feeds a serverless pipeline (ingest Lambda → SQS → archiver Lambda → S3 → loader/ETL Lambda → analytics warehouse). The device-side URL is stored as `AQ_SYNC_ENDPOINT`. (Superseded the earlier API-key design — ADR-013; the hosting is a Lambda pipeline, not an ASG app — ADR-015.) The mTLS truststore/CA is owned by `acorn-ca` (ADR-014).
 
 **Fleet API Key** _(retired)_
 A shared secret (`AQ_SYNC_API_KEY`) formerly sent as `x-api-key` on every Sync. Retired in favor of per-device Device Certificate (mTLS) auth: a shared fleet key is the wrong identity model for a field fleet — a single stolen Pi exposed the whole fleet, and the key could only be rotated fleet-wide. See ADR-013. Listed here only to mark the term obsolete.

--- a/docs/adr/ADR-013-ingest-moves-to-sentri-analytics-platform-mtls.md
+++ b/docs/adr/ADR-013-ingest-moves-to-sentri-analytics-platform-mtls.md
@@ -1,6 +1,6 @@
 # ADR-013: Ingest moves to the sentri-analytics platform; device auth switches to mTLS
 
-**Status:** Accepted — supersedes ADR-009
+**Status:** Accepted — supersedes ADR-009; **amended by ADR-015** (its "ingest served by the ASG application" sub-decision is superseded — ingest now runs as a serverless Lambda pipeline in `acorn-analytics`; the mTLS/cert-CN decisions below remain in force)
 **Date:** 2026-06-17
 **Author:** Nicole Cornell
 **Deciders:** Nicole Cornell

--- a/docs/adr/ADR-015-ingest-moves-to-acorn-analytics-lambda-pipeline.md
+++ b/docs/adr/ADR-015-ingest-moves-to-acorn-analytics-lambda-pipeline.md
@@ -1,0 +1,117 @@
+# ADR-015: Ingest moves to `acorn-analytics` as a serverless Lambda pipeline
+
+**Status:** Accepted — amends ADR-013 (supersedes its "ingest served by the ASG application" sub-decision; ADR-013's mTLS/cert-CN decisions remain in force)
+**Date:** 2026-06-18
+**Author:** Nicole Cornell
+**Deciders:** Nicole Cornell
+
+---
+
+## Context
+
+ADR-013 retired this repo's SAM ingest stack and moved ingest ownership to "the
+sentri-analytics platform," where ingest would be **served by the ASG
+application** — the same operated platform that served the dashboard. Its stated
+justification was convergence: *"Ingest and analytics converge on one operated
+platform (ASG app), removing the SAM Lambda/SQS/S3 pipeline."*
+
+The system has since been re-architected into a six-repository split (see
+`sentri-analytics/specs/six-repo-architecture.md`). Under that split the dashboard
+(`acorn-app`) and the ingest+analytics tier (`acorn-analytics`) are **separate
+repos, stacks, and blast radii** — the convergence premise that justified
+ASG-served ingest is deliberately removed. The ASG belongs to the dashboard; it
+is not where ingest should run.
+
+Facts at decision time:
+- Ingest is **spiky 15-minute batch POSTs from <100 devices** — the canonical
+  scale-to-zero serverless workload. An ASG sized for ingest would idle ~99% of
+  the time.
+- The plan requires a **no-data-loss / buffer-and-retry** ingest path; SQS + an
+  S3 raw archive provide durable buffering and a replayable source of truth for
+  free, which an ASG app would have to reimplement.
+- The security model requires the **public ingest edge and the user dashboard to
+  be separate blast radii**; sharing an ASG re-couples them.
+
+Doing nothing would leave two accepted-but-contradictory positions on ingest
+hosting (ADR-013's ASG-served ingest vs. the six-repo spec's Lambda pipeline).
+
+---
+
+## Decision
+
+**We will host ingest in `acorn-analytics` as a serverless pipeline:
+`API Gateway → ingest Lambda → SQS → archiver Lambda → S3 (raw archive) →
+loader/ETL Lambda → analytics warehouse`.**
+
+Concretely:
+- **Three Lambdas:** *ingest* (validate, derive `device_id` from the mTLS cert
+  CN, enqueue to SQS), *archiver* (SQS consumer → S3 raw archive), *loader/ETL*
+  (S3 → star-schema warehouse).
+- **`acorn-analytics` owns this code and its deploy**; it deploys onto shared
+  substrate (API Gateway, SQS, S3) provisioned by `acorn-infra`.
+- **ADR-013's transport-auth decisions are unchanged:** mTLS terminates at API
+  Gateway against the S3 truststore, and device identity is derived from the
+  cert CN, not the request body.
+- **The CA cloud side moves to `acorn-ca`** (the standalone KMS-backed CA that
+  ADR-014 already called for); this repo keeps only the device-side
+  enrollment/renewal daemons.
+- This is the same direction ADR-013 set (ingest leaves this repo); it changes
+  only *where* ingest runs in the cloud (Lambda pipeline, not ASG app).
+
+Reversible during migration (repoint the fleet endpoint); the hosting shape
+itself is a cloud-side concern with no device impact.
+
+---
+
+## Consequences
+
+### Positive
+- Scale-to-zero ingest matched to a spiky, low-volume batch workload; no idle ASG.
+- Durable buffering (SQS) and a replayable raw archive (S3) satisfy the
+  no-data-loss requirement without custom code.
+- Ingest and dashboard stay separate blast radii, as the security model requires.
+- Removes the API-GW → VPC Link → ALB → ASG chain ADR-013 implied, simplifying
+  the substrate `acorn-infra` must provision.
+
+### Negative
+- Re-introduces the Lambda/SQS/S3 operational surface ADR-013 had folded into the
+  ASG app — three functions to deploy and monitor instead of one app.
+- Ingest contract changes now coordinate across `aquilla-main` ↔ `acorn-analytics`
+  (unchanged from ADR-013's cross-repo coordination cost).
+
+### Neutral / Tradeoffs
+- The `run_complete` payload contract and device-side sync code are unaffected —
+  this is purely a cloud-side hosting decision.
+
+---
+
+## Alternatives Considered
+
+### Keep ingest on the ASG application (ADR-013 as written)
+**Why rejected:** the six-repo split removes the convergence premise; an ASG
+sized for spiky low-volume ingest idles ~99% of the time and re-couples the
+ingest edge with the dashboard blast radius.
+
+### A single ingest Lambda writing straight to the warehouse (no SQS/S3)
+**Why rejected:** drops the durable buffer and replayable raw archive that the
+no-data-loss requirement depends on.
+
+---
+
+## Revisit Conditions
+
+- Fleet/volume grows enough that a streaming path (Kinesis) or always-on compute
+  beats per-invocation Lambda — revisit the pipeline shape (cf. ADR-009's 500+
+  device threshold).
+- If ingest and analytics ever need to re-converge onto one operated platform,
+  re-open the hosting decision.
+
+---
+
+## References
+
+- Amends: ADR-013 (per-device mTLS; ingest leaves this repo) — supersedes only its
+  ASG-ingest hosting sub-decision
+- Related: ADR-014 (KMS-backed standalone CA — its cloud side becomes `acorn-ca`),
+  ADR-009 (original Lambda ingest; superseded by ADR-013)
+- Spec: `sentri-analytics/specs/six-repo-architecture.md` (Repo 3 — `acorn-analytics`)


### PR DESCRIPTION
Records that ingest moves to `acorn-analytics` under the six-repo split, and reconciles this repo's docs.

## What's in here
- **docs/adr/ADR-015** — ingest moves to `acorn-analytics` as a serverless Lambda pipeline (`API GW → ingest → SQS → archiver → S3 → loader/ETL → warehouse`). **Amends ADR-013's "ingest served by the ASG application" sub-decision** — the six-repo split removes the convergence premise that justified ASG-ingest. ADR-013's mTLS / cert-CN identity decisions remain in force.
- **docs/adr/ADR-013** — `amended-by` note pointing to ADR-015.
- **CONTEXT.md** — "Sentri Analytics Platform" decomposed into the `acorn-*` repos; **Ingest Endpoint** owned by `acorn-analytics`; **Device Certificate** truststore/CA owned by `acorn-ca` (ADR-014).

See `acorn-app` PR for the master spec (specs/six-repo-architecture.md).

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)