### PR TITLE
Implemented auto reboot on device update

### DIFF
--- a/aquila_web/main.py
+++ b/aquila_web/main.py
@@ -1518,6 +1518,58 @@ _startup_image_digest_ui: str | None = os.getenv("RUNNING_IMAGE_DIGEST_UI") or N
 _latest_ghcr_digest: str | None = None
 _latest_ghcr_digest_ui: str | None = None
 
+# --- OTA auto-reboot completion sentinel (issue #183, ADR-016) ----------------
+from aquila_web import update_sentinel as _sentinel
+
+# Lives on the /opt/fleet host volume so it survives the container swap + reboot.
+_UPDATE_SENTINEL_PATH = os.getenv("AQ_UPDATE_SENTINEL_PATH", "/opt/fleet/last_update.json")
+# Short TTL: a sentinel older than this is stale and must not pop a modal.
+_UPDATE_SENTINEL_TTL = int(os.getenv("AQ_UPDATE_SENTINEL_TTL", "600"))
+
+
+def _utcnow_iso() -> str:
+    return datetime.utcnow().isoformat() + "Z"
+
+
+def _trigger_host_reboot() -> bool:
+    """Best-effort: ask the host kiosk-control service to reboot the device.
+
+    Synchronous + swallows errors: the process is about to die anyway, and a
+    failure must not crash startup (it degrades to 'modal on next manual reset').
+    """
+    try:
+        headers = {"Authorization": f"Bearer {WATCHTOWER_TOKEN}"} if WATCHTOWER_TOKEN else {}
+        with httpx.Client(timeout=10.0) as client:
+            client.post(f"{KIOSK_CONTROL_URL}/reboot", json={}, headers=headers)
+        return True
+    except Exception as e:  # noqa: BLE001 - never let a reboot failure crash boot
+        logger.warning("host reboot request failed: %s", e)
+        return False
+
+
+def _resolve_startup_update_state() -> None:
+    """On boot, advance the update sentinel state machine.
+
+    reboot_pending -> persist show_complete, then reboot the host (once).
+    show_complete  -> surface the completion modal (_update_status = 'complete').
+    none/stale     -> clear the sentinel.
+    """
+    global _update_status
+    record = _sentinel.read_sentinel(_UPDATE_SENTINEL_PATH)
+    action = _sentinel.next_startup_action(record, datetime.utcnow(), _UPDATE_SENTINEL_TTL)
+    if action == "reboot":
+        # Don't reboot mid-run; a fresh post-update boot has no active run anyway.
+        if current_item.screen == "running":
+            return
+        _sentinel.write_sentinel(_UPDATE_SENTINEL_PATH, "show_complete", _utcnow_iso())
+        _update_status = "updating"
+        _trigger_host_reboot()
+    elif action == "show_complete":
+        _update_status = "complete"
+    else:
+        _sentinel.clear_sentinel(_UPDATE_SENTINEL_PATH)
+# ------------------------------------------------------------------------------
+
 
 async def _ghcr_bearer_token(user: str, token: str, repo: str) -> str | None:
     """Exchange Basic credentials for a short-lived GHCR Bearer token."""
@@ -1626,6 +1678,12 @@ async def apply_update():
             status_code=409,
             content={"ok": False, "error": "Cannot update during an active run. Stop the run first."},
         )
+    # Breadcrumb the new container reads on startup to drive the auto-reboot (#183).
+    # Written before triggering Watchtower so a kill mid-swap still leaves it behind.
+    try:
+        _sentinel.write_sentinel(_UPDATE_SENTINEL_PATH, "reboot_pending", _utcnow_iso())
+    except OSError:
+        logger.warning("could not write update sentinel at %s", _UPDATE_SENTINEL_PATH)
     _update_status = "updating"
     headers = {"Authorization": f"Bearer {WATCHTOWER_TOKEN}"} if WATCHTOWER_TOKEN else {}
     try:
@@ -1697,6 +1755,23 @@ async def reset_update_state():
     return {"ok": True}
 
 
+@app.post("/update/ack-complete")
+async def ack_update_complete():
+    """Operator dismissed the 'Update Complete' modal. Fire-once: clear sentinel."""
+    global _update_status
+    _sentinel.clear_sentinel(_UPDATE_SENTINEL_PATH)
+    if _update_status == "complete":
+        _update_status = "idle"
+    return {"ok": True}
+
+
+@app.post("/reboot")
+async def reboot_device():
+    """Proxy a host reboot request to the kiosk-control service."""
+    ok = _trigger_host_reboot()
+    return {"ok": ok}
+
+
 async def _background_update_poller() -> None:
     """Poll GHCR every UPDATE_CHECK_INTERVAL seconds. Never pulls the image."""
     while True:
@@ -1734,6 +1809,16 @@ async def _inject_device_id() -> None:
 @app.on_event("startup")
 async def _inject_device_id() -> None:
     inject_hw_serial_env()
+
+
+@app.on_event("startup")
+async def resolve_update_completion() -> None:
+    """On boot, advance the OTA sentinel: reboot if an update just applied, or
+    surface the 'Update Complete' state if we just came back from that reboot (#183)."""
+    try:
+        _resolve_startup_update_state()
+    except Exception as e:  # noqa: BLE001 - never block startup on this
+        logger.warning("update sentinel resolution failed: %s", e)
 
 
 @app.on_event("startup")

--- a/aquila_web/main.py
+++ b/aquila_web/main.py
@@ -1518,7 +1518,7 @@ _startup_image_digest_ui: str | None = os.getenv("RUNNING_IMAGE_DIGEST_UI") or N
 _latest_ghcr_digest: str | None = None
 _latest_ghcr_digest_ui: str | None = None
 
-# --- OTA auto-reboot completion sentinel (issue #183, ADR-016) ----------------
+# --- OTA auto-reboot completion sentinel (issue #183, ADR-018) ----------------
 from aquila_web import update_sentinel as _sentinel
 
 # Lives on the /opt/fleet host volume so it survives the container swap + reboot.

--- a/aquila_web/static/nav.js
+++ b/aquila_web/static/nav.js
@@ -33,3 +33,48 @@ document.addEventListener("click", (event) => {
     })
     .catch(() => {});
 })();
+
+// One-time "Update Complete" modal after an OTA auto-reboot (#183, ADR-016).
+// The backend reports status === "complete" once, driven by the on-disk sentinel.
+(function showUpdateCompleteModal() {
+  if (document.querySelector(".update-complete-modal")) return;
+  fetch("/update/status")
+    .then(r => r.ok ? r.json() : null)
+    .then(data => {
+      if (!data || data.status !== "complete") return;
+
+      const backdrop = document.createElement("div");
+      backdrop.className = "update-complete-modal";
+
+      const card = document.createElement("div");
+      card.className = "update-complete-modal__card";
+      card.setAttribute("role", "alertdialog");
+      card.setAttribute("aria-labelledby", "update-complete-title");
+
+      const title = document.createElement("div");
+      title.id = "update-complete-title";
+      title.className = "update-complete-modal__title";
+      title.textContent = "✓ Update Complete";
+
+      const body = document.createElement("div");
+      body.className = "update-complete-modal__body";
+      body.textContent = "The device updated successfully and is ready to use.";
+
+      const ok = document.createElement("button");
+      ok.type = "button";
+      ok.className = "update-complete-modal__ok";
+      ok.textContent = "OK";
+      ok.addEventListener("click", () => {
+        backdrop.remove();
+        fetch("/update/ack-complete", { method: "POST" }).catch(() => {});
+      });
+
+      card.appendChild(title);
+      card.appendChild(body);
+      card.appendChild(ok);
+      backdrop.appendChild(card);
+      document.body.appendChild(backdrop);
+      ok.focus();
+    })
+    .catch(() => {});
+})();

--- a/aquila_web/static/nav.js
+++ b/aquila_web/static/nav.js
@@ -34,7 +34,7 @@ document.addEventListener("click", (event) => {
     .catch(() => {});
 })();
 
-// One-time "Update Complete" modal after an OTA auto-reboot (#183, ADR-016).
+// One-time "Update Complete" modal after an OTA auto-reboot (#183, ADR-018).
 // The backend reports status === "complete" once, driven by the on-disk sentinel.
 (function showUpdateCompleteModal() {
   if (document.querySelector(".update-complete-modal")) return;

--- a/aquila_web/static/styles.css
+++ b/aquila_web/static/styles.css
@@ -309,6 +309,52 @@ a:active {
   border: 1.5px solid #f8fafc;
 }
 
+/* One-time "Update Complete" modal after an OTA auto-reboot (#183) */
+.update-complete-modal {
+  position: fixed;
+  inset: 0;
+  background: rgba(15, 23, 42, 0.55);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 9999;
+}
+
+.update-complete-modal__card {
+  background: #ffffff;
+  border-radius: 16px;
+  padding: 32px 36px;
+  max-width: 420px;
+  text-align: center;
+  box-shadow: 0 20px 50px rgba(0, 0, 0, 0.35);
+  font-family: "Segoe UI", "Helvetica Neue", Arial, sans-serif;
+}
+
+.update-complete-modal__title {
+  font-size: 24px;
+  font-weight: 700;
+  color: #16a34a;
+  margin-bottom: 12px;
+}
+
+.update-complete-modal__body {
+  font-size: 16px;
+  color: #334155;
+  margin-bottom: 24px;
+}
+
+.update-complete-modal__ok {
+  min-width: 120px;
+  padding: 12px 24px;
+  font-size: 16px;
+  font-weight: 600;
+  color: #ffffff;
+  background: #16a34a;
+  border: none;
+  border-radius: 10px;
+  cursor: pointer;
+}
+
 .help-content {
   max-width: 680px;
   font-family: "Segoe UI", "Helvetica Neue", Arial, sans-serif;

--- a/aquila_web/update_sentinel.py
+++ b/aquila_web/update_sentinel.py
@@ -1,4 +1,4 @@
-"""OTA update completion sentinel (issue #183, ADR-016).
+"""OTA update completion sentinel (issue #183, ADR-018).
 
 A tiny on-disk record at /opt/fleet/last_update.json that survives the Watchtower
 container swap and the post-update reboot, letting a freshly-started container know

--- a/aquila_web/update_sentinel.py
+++ b/aquila_web/update_sentinel.py
@@ -1,0 +1,70 @@
+"""OTA update completion sentinel (issue #183, ADR-016).
+
+A tiny on-disk record at /opt/fleet/last_update.json that survives the Watchtower
+container swap and the post-update reboot, letting a freshly-started container know
+an update just finished. Pure logic only — no FastAPI, no hardware imports.
+"""
+from __future__ import annotations
+
+import json
+import os
+from datetime import datetime, timezone
+
+
+def write_sentinel(path: str, state: str, ts: str) -> None:
+    """Persist the sentinel record {state, ts} to ``path``."""
+    with open(path, "w") as f:
+        json.dump({"state": state, "ts": ts}, f)
+
+
+def read_sentinel(path: str) -> dict | None:
+    """Return the sentinel record, or None if missing/unreadable."""
+    try:
+        with open(path) as f:
+            return json.load(f)
+    except (OSError, ValueError):
+        return None
+
+
+def clear_sentinel(path: str) -> None:
+    """Delete the sentinel if present; idempotent."""
+    try:
+        os.remove(path)
+    except OSError:
+        pass
+
+
+def _age_seconds(ts: str, now: datetime) -> float | None:
+    """Seconds between the sentinel timestamp and ``now``; None if ts is unparseable."""
+    try:
+        recorded = datetime.fromisoformat(ts.replace("Z", "+00:00"))
+    except (ValueError, AttributeError):
+        return None
+    if recorded.tzinfo is None:
+        recorded = recorded.replace(tzinfo=timezone.utc)
+    # Tolerate a naive `now` (e.g. datetime.utcnow()) by treating it as UTC.
+    if now.tzinfo is None:
+        now = now.replace(tzinfo=timezone.utc)
+    return (now - recorded).total_seconds()
+
+
+def next_startup_action(record: dict | None, now: datetime, ttl_seconds: int) -> str:
+    """Decide what a freshly-started container should do given the sentinel.
+
+    Returns one of:
+      "reboot"        — an update just applied; trigger the host reboot (caller first
+                        advances the sentinel to ``show_complete`` so it fires once).
+      "show_complete" — we are back up after the reboot; surface the completion modal.
+      "none"          — no sentinel, unparseable, or older than the TTL (ignore/clear).
+    """
+    if not record:
+        return "none"
+    age = _age_seconds(record.get("ts", ""), now)
+    if age is None or age > ttl_seconds:
+        return "none"
+    state = record.get("state")
+    if state == "reboot_pending":
+        return "reboot"
+    if state == "show_complete":
+        return "show_complete"
+    return "none"

--- a/docs/adr/ADR-016-ota-auto-reboot-on-update-complete.md
+++ b/docs/adr/ADR-016-ota-auto-reboot-on-update-complete.md
@@ -1,0 +1,84 @@
+# ADR-016: OTA updates finish with a full device reboot + one-time completion modal
+
+**Status:** Proposed
+**Date:** 2026-06-19
+**Author:** Jack Hu
+**Deciders:** Jack Hu
+
+---
+
+## Context
+
+Manual OTA updates (ADR-002, `spec_manual_ota_updates.md`) apply by triggering Watchtower's HTTP API, which pulls the new image and **replaces the containers**. The completion state (`_update_status`) is an in-memory Python global, so when the old container is destroyed mid-update that state is lost, and the new container boots at `idle` with no memory that an update just finished. Combined with a WebSocket-reconnect `window.location.reload()` in `script.js`, the kiosk is left frozen indefinitely on the update screen. The operator's only recovery is to manually power-cycle the device (issue #120).
+
+An earlier proposal (`spec_ota_update_complete_on_reload.md`) addressed this *without* rebooting: write an on-disk completion sentinel, add a `complete` status, show "✓ Update complete" on the next page load, and remove the WS reload. It was never implemented.
+
+The freeze can have causes at several layers — the Chromium browser, the X session, the Docker containers, or the serial/USB-connected PCR hardware — and we cannot always be certain which. A field-deployed diagnostic device that wedges after an update means a support call.
+
+Two facts constrain the design:
+- **The container cannot reboot its host**, but the host already runs a privileged systemd service (`kiosk_control.py`, ADR-005) that can.
+- **The reboot cannot be triggered while Watchtower is pulling** (it would interrupt the download) nor by the container running `/update/apply` (that container is killed in the swap). The only safe trigger is the *new* container's startup, after the pull has finished.
+
+If we did nothing: operators keep manually power-cycling after every update.
+
+---
+
+## Decision
+
+**We will make a successful OTA update end with a full software reboot of the device (`systemctl reboot`), and surface a one-time, blocking "Update Complete" modal on the first post-login screen after the reboot.**
+
+Concretely:
+- `/update/apply` writes a two-state on-disk sentinel (`/opt/fleet/last_update.json`) that survives the container swap (ADR-002 volume).
+- The new container, on startup, sees `reboot_pending`, flips the sentinel to `show_complete`, and calls a new `kiosk-control /reboot` endpoint. After the reboot, it sees `show_complete`, reports `complete`, and the frontend shows a blocking modal dismissed with **OK**, which clears the sentinel. The two states guarantee reboot-once / modal-once.
+- The reboot is a **full host reboot**, chosen over the lighter alternatives below.
+
+This is **moderately hard to reverse**: it changes fleet-wide post-update behavior operators come to rely on, and it requires a host-side service deploy (kiosk-control is not in the Watchtower-updated image), so the capability rolls out separately from container images. Implementation detail: `spec_ota_auto_reboot_complete.md`.
+
+---
+
+## Consequences
+
+### Positive
+- The operator no longer manually resets after an update — the device recovers itself and positively confirms completion.
+- A full reboot clears *every* layer (containers, X, Chromium, hardware connections), so it is robust even against freeze causes we haven't diagnosed.
+- The on-disk sentinel makes "update just completed" survive the container swap and the reboot, fixing the root cause of the lost completion state.
+
+### Negative
+- **~30–60s of total device downtime** per update while the Pi reboots (vs ~2s for a browser relaunch).
+- **Boot-loop risk** if the sentinel state machine is wrong — mitigated by advancing/clearing the sentinel before rebooting and a short TTL, but it is a real hazard to get right.
+- **Two-stage rollout:** the `kiosk-control /reboot` endpoint ships via the host-service deploy path, not Watchtower, so auto-reboot does not work on a device until its host service is updated. The first deployment of this feature is special-cased.
+- A blocking modal reintroduces one required tap after an otherwise hands-off update (acceptable: positive confirmation on a diagnostic device).
+
+### Neutral / Trade-offs
+- Reuses the sentinel mechanism from the superseded reload spec; the difference is reboot + modal instead of reload + banner.
+- The `script.js` WS-reconnect reload is left in place; the reboot makes the completion flow independent of it.
+
+---
+
+## Alternatives Considered
+
+### Option A: Sentinel + reload only (the existing `spec_ota_update_complete_on_reload.md`)
+**Why rejected:** Makes the completion *message* reliable but does not guarantee the frozen screen recovers — if Chromium is stuck on a dead page, nothing in the page can revive it, so the operator may still have to manually reset. Doesn't meet the "no manual reset" goal.
+
+### Option B: Kiosk relaunch (no full reboot)
+**Why rejected:** Lighter and faster (~seconds, no downtime, no boot-loop risk) and fixes the *known* browser freeze. Rejected in favor of certainty: a full reboot also clears X/Docker/hardware-level wedges we can't always rule out on a field diagnostic device. Recorded as the natural fallback if reboot downtime proves too costly.
+
+### Option C: Literal power-cycle
+**Why rejected:** Software cannot cut its own power without added relay hardware, and a warm `systemctl reboot` is cleaner (orderly shutdown, no FS-corruption risk) while achieving the same offline→online cycle.
+
+---
+
+## Revisit Conditions
+
+- Reboot downtime proves disruptive in the field → switch to Option B (kiosk relaunch), reusing the same sentinel + modal.
+- Auto-reboot ever causes a boot loop in practice → reassess the sentinel state machine or gate the reboot behind an explicit one-shot host flag.
+- The kiosk-control host service is folded into a host-update mechanism → revisit the two-stage rollout caveat.
+
+---
+
+## References
+- Implements: issue #183 (fixes bug #120)
+- Spec: `specs/backend/spec_ota_auto_reboot_complete.md`
+- Supersedes: `specs/frontend/spec_ota_update_complete_on_reload.md`
+- Related ADRs: ADR-002 (Watchtower OTA + `/opt` persistence), ADR-005 (kiosk host X11/Chromium)
+- `aquila_web/main.py` — OTA endpoints + startup; `scripts/kiosk-control/kiosk_control.py` — host control service

--- a/docs/adr/ADR-018-ota-auto-reboot-on-update-complete.md
+++ b/docs/adr/ADR-018-ota-auto-reboot-on-update-complete.md
@@ -1,4 +1,4 @@
-# ADR-016: OTA updates finish with a full device reboot + one-time completion modal
+# ADR-018: OTA updates finish with a full device reboot + one-time completion modal
 
 **Status:** Proposed
 **Date:** 2026-06-19

--- a/scripts/kiosk-control/kiosk_control.py
+++ b/scripts/kiosk-control/kiosk_control.py
@@ -127,7 +127,7 @@ def _start_chromium() -> tuple[bool, str]:
 
 
 def _reboot_host() -> tuple[bool, str]:
-    """Reboot the device. Used by the OTA auto-reboot flow (#183, ADR-016)."""
+    """Reboot the device. Used by the OTA auto-reboot flow (#183, ADR-018)."""
     result = subprocess.run(["systemctl", "reboot"], capture_output=True)
     if result.returncode == 0:
         return True, "rebooting"

--- a/scripts/kiosk-control/kiosk_control.py
+++ b/scripts/kiosk-control/kiosk_control.py
@@ -126,6 +126,18 @@ def _start_chromium() -> tuple[bool, str]:
     return True, "chromium launched"
 
 
+def _reboot_host() -> tuple[bool, str]:
+    """Reboot the device. Used by the OTA auto-reboot flow (#183, ADR-016)."""
+    result = subprocess.run(["systemctl", "reboot"], capture_output=True)
+    if result.returncode == 0:
+        return True, "rebooting"
+    # Fall back to `sudo reboot` if not running as root / systemctl unavailable.
+    fallback = subprocess.run(["sudo", "reboot"], capture_output=True)
+    if fallback.returncode == 0:
+        return True, "rebooting"
+    return False, fallback.stderr.decode(errors="replace").strip() or "reboot failed"
+
+
 # ---------------------------------------------------------------------------
 # WiFi helpers (nmcli)
 # ---------------------------------------------------------------------------
@@ -309,6 +321,11 @@ class KioskHandler(BaseHTTPRequestHandler):
         elif self.path == "/start-kiosk":
             ok, msg = _start_chromium()
             log.info("start-kiosk: %s", msg)
+            self._respond(200 if ok else 500, {"ok": ok, "message": msg})
+
+        elif self.path == "/reboot":
+            ok, msg = _reboot_host()
+            log.info("reboot: %s", msg)
             self._respond(200 if ok else 500, {"ok": ok, "message": msg})
 
         elif self.path == "/wifi/connect":

--- a/specs/backend/spec_ota_auto_reboot_complete.md
+++ b/specs/backend/spec_ota_auto_reboot_complete.md
@@ -1,0 +1,103 @@
+# Spec: OTA Auto-Reboot + One-Time "Update Complete" Modal
+
+**Issue:** #183 (implementation) — fixes bug #120
+**Supersedes:** `specs/frontend/spec_ota_update_complete_on_reload.md` (reuses its on-disk sentinel idea; replaces the reload-based completion with a reboot + acknowledge modal)
+**Related:** `specs/backend/spec_manual_ota_updates.md`, ADR-002 (Watchtower OTA), ADR-005 (kiosk host X11/Chromium)
+
+## Problem
+
+After a manual OTA update, the kiosk freezes indefinitely on the update/loading screen. Root causes: (1) Watchtower replaces the containers, so the old UI/API container — and the in-memory `_update_status` — is destroyed mid-update; (2) the new container boots at `_update_status = "idle"` with no memory that an update just finished; (3) `script.js` does a WebSocket-reconnect `window.location.reload()` that can destroy the polling loop. The operator's only recovery is a manual power-cycle. See #120.
+
+## Goal
+
+After an update completes, the device **reboots itself** (full software reboot) to guarantee a clean state across every layer (containers, X session, Chromium, hardware connections), and on the way back up shows a **one-time, blocking "Update Complete" modal** that the operator dismisses with **OK**. No manual reset required.
+
+Decision rationale (full reboot over the lighter kiosk-relaunch or reload-only options) is recorded in ADR-016.
+
+---
+
+## Flow
+
+```
+1. User clicks "Update Now" (Help → Updates).
+2. /update/apply (existing run-active 409 guard still applies):
+     - write sentinel /opt/fleet/last_update.json  → {"state": "reboot_pending", "ts": <utc>}
+     - POST Watchtower /v1/update   (existing logic)
+3. Watchtower pulls new image, swaps containers.   (NO reboot here — pull in progress,
+                                                     and this container is being killed)
+4. NEW container starts → startup checks sentinel:
+     - state == "reboot_pending":
+         · rewrite sentinel → {"state": "show_complete", "ts": <utc>}   (persist BEFORE reboot)
+         · (guard) only if no run active
+         · POST kiosk-control /reboot   → host runs `systemctl reboot`
+5. Pi reboots (~30–60s offline), Chromium relaunches → login screen.
+6. Operator logs in → first post-login page loads → nav.js GET /update/status:
+     - startup had read sentinel state == "show_complete" → _update_status = "complete"
+     - frontend renders blocking "✓ Update Complete" modal
+7. User taps OK → modal closes → POST /update/ack-complete → delete sentinel,
+   reset _update_status = "idle". Shows exactly once; never loops.
+```
+
+The two-state sentinel (`reboot_pending` → `show_complete` → deleted) guarantees the device reboots **once** and the modal fires **once**. A short TTL (e.g. 10 min) on the sentinel is a belt-and-suspenders guard so a sentinel that somehow survives can't pop a stale modal days later.
+
+---
+
+## Backend changes (`aquila_web/main.py`)
+
+- **Sentinel helpers** — `_write_update_sentinel(state)`, `_read_update_sentinel()`, `_clear_update_sentinel()` against `/opt/fleet/last_update.json` (host-volume path, survives container swap per ADR-002).
+- **`/update/apply`** — before the Watchtower POST, write sentinel `reboot_pending`. (Existing run-active 409 guard unchanged.)
+- **Startup hook** — on app start, read the sentinel:
+  - `reboot_pending` → flip to `show_complete`, then (if `current_item.screen != "running"`) call kiosk-control `/reboot`. If the reboot call fails, leave `show_complete` in place and log — the modal will still show on the next (manual) reset, so behavior degrades to "no worse than today."
+  - `show_complete` → set `_update_status = "complete"` (do **not** reboot again).
+  - older than TTL → clear and ignore.
+- **`/update/status`** — add `"complete"` to the documented states (`idle | checking | available | updating | error | complete`).
+- **`POST /update/ack-complete`** — clears the sentinel and resets `_update_status = "idle"`. Called when the user taps OK.
+- **`POST /reboot` proxy** — `main.py` forwards to kiosk-control `/reboot` (mirrors the existing `/wifi/*` proxy pattern via `_kiosk_post`).
+
+## Host changes (`scripts/kiosk-control/kiosk_control.py`)
+
+- Add **`POST /reboot`** endpoint → runs `systemctl reboot` (or `sudo reboot`). Origin-checked like the other endpoints (loopback / Docker bridge only).
+- **Deployment note:** kiosk-control is a host systemd service, NOT in the Docker image. This endpoint reaches devices only via the host-service deploy path (`scripts/kiosk-control/update_host_service.sh`, `deployment2.sh`) — not via Watchtower. The first rollout must push the updated host service before auto-reboot works on a device.
+
+## Frontend changes
+
+- **`aquila_web/static/nav.js`** (loaded on all post-login pages) — when `/update/status` returns `status === "complete"`, render a blocking, centered "✓ Update Complete" modal with an **OK** button over a dimmed backdrop. No auto-dismiss.
+- **OK handler** — close modal, `POST /update/ack-complete`. The modal does not reappear (sentinel deleted; status back to `idle`).
+- **Login page** — unchanged (no `nav.js`); modal intentionally appears on the first post-login screen.
+- **`aquila_web/static/script.js` WS-reconnect reload** — left as-is. The reboot makes the completion flow independent of it; out of scope unless it visibly interferes pre-reboot.
+
+---
+
+## Edge cases
+
+| Case | Behavior |
+|------|----------|
+| Update fails (Watchtower non-200) | No sentinel state advance; existing `error` status shown; no reboot. |
+| kiosk-control `/reboot` unreachable / host not yet updated | Sentinel stays `show_complete`; modal shows on next manual reset; failure logged. No worse than today. |
+| Run active at reboot-trigger time | Reboot skipped (guard); a fresh post-update boot has no active run, so this is defensive. |
+| Sentinel older than TTL (e.g. unrelated boot) | Ignored and cleared; no modal. |
+| Power lost mid-reboot | Sentinel persists on disk; modal shows once the device next boots and the operator logs in. |
+
+---
+
+## Tests
+
+- **Unit (pytest)** — sentinel state machine: `apply` writes `reboot_pending`; startup transitions `reboot_pending → show_complete` (and attempts reboot) then `show_complete → complete`; `ack-complete` clears it; TTL expiry ignored. Mock the kiosk-control call and filesystem path.
+- **Contract (`tests/contract/`)** — `/update/status` returns `complete` after a simulated update; `POST /update/ack-complete` clears it; `/update/apply` still 409s during an active run.
+- **Host endpoint** — `POST /reboot` on kiosk-control is hardware/host-dependent; cannot run in CI. Mark `@pytest.mark.hardware` with a note; verify the reboot subprocess is invoked via a mock, not actually executed.
+- `pytest tests unit_tests -v` passes.
+
+## Files touched
+
+| File | Change |
+|------|--------|
+| `aquila_web/main.py` | Sentinel helpers; `apply` writes sentinel; startup reads + triggers reboot + sets `complete`; `/update/ack-complete`; `/reboot` proxy; `complete` status |
+| `scripts/kiosk-control/kiosk_control.py` | New `POST /reboot` → `systemctl reboot` |
+| `aquila_web/static/nav.js` | Blocking "Update Complete" modal on `status == complete`; OK → ack |
+| `specs/frontend/spec_ota_update_complete_on_reload.md` | Mark superseded |
+
+## Out of scope
+
+- Lighter recovery (kiosk relaunch / reload-only) — considered and rejected; see ADR-016.
+- Changing the `script.js` WS-reconnect reload.
+- Persisting completion across reboots beyond the short sentinel TTL.

--- a/specs/backend/spec_ota_auto_reboot_complete.md
+++ b/specs/backend/spec_ota_auto_reboot_complete.md
@@ -12,7 +12,7 @@ After a manual OTA update, the kiosk freezes indefinitely on the update/loading 
 
 After an update completes, the device **reboots itself** (full software reboot) to guarantee a clean state across every layer (containers, X session, Chromium, hardware connections), and on the way back up shows a **one-time, blocking "Update Complete" modal** that the operator dismisses with **OK**. No manual reset required.
 
-Decision rationale (full reboot over the lighter kiosk-relaunch or reload-only options) is recorded in ADR-016.
+Decision rationale (full reboot over the lighter kiosk-relaunch or reload-only options) is recorded in ADR-018.
 
 ---
 
@@ -98,6 +98,6 @@ The two-state sentinel (`reboot_pending` → `show_complete` → deleted) guaran
 
 ## Out of scope
 
-- Lighter recovery (kiosk relaunch / reload-only) — considered and rejected; see ADR-016.
+- Lighter recovery (kiosk relaunch / reload-only) — considered and rejected; see ADR-018.
 - Changing the `script.js` WS-reconnect reload.
 - Persisting completion across reboots beyond the short sentinel TTL.

--- a/specs/frontend/spec_ota_update_complete_on_reload.md
+++ b/specs/frontend/spec_ota_update_complete_on_reload.md
@@ -1,10 +1,10 @@
 # Spec: OTA Update Complete State Survives Page Reload
 
-> **Superseded** by `specs/backend/spec_ota_auto_reboot_complete.md` and ADR-016.
+> **Superseded** by `specs/backend/spec_ota_auto_reboot_complete.md` and ADR-018.
 > The on-disk sentinel idea below is reused, but the completion flow is now a full
 > device reboot + a one-time "Update Complete" modal, not a reload + banner. Kept
 > for context (it documents the root cause and the rejected reload-only approach —
-> see ADR-016 Alternative A).
+> see ADR-018 Alternative A).
 
 ## Problem
 

--- a/specs/frontend/spec_ota_update_complete_on_reload.md
+++ b/specs/frontend/spec_ota_update_complete_on_reload.md
@@ -1,5 +1,11 @@
 # Spec: OTA Update Complete State Survives Page Reload
 
+> **Superseded** by `specs/backend/spec_ota_auto_reboot_complete.md` and ADR-016.
+> The on-disk sentinel idea below is reused, but the completion flow is now a full
+> device reboot + a one-time "Update Complete" modal, not a reload + banner. Kept
+> for context (it documents the root cause and the rejected reload-only approach —
+> see ADR-016 Alternative A).
+
 ## Problem
 
 When a device update is applied, the UI shows an overlay ("Applying update…") and polls

--- a/tests/contract/test_update_complete_flow.py
+++ b/tests/contract/test_update_complete_flow.py
@@ -1,0 +1,71 @@
+"""Contract tests for the OTA auto-reboot completion flow (issue #183).
+
+Drives the real endpoints via TestClient; the host reboot call is mocked.
+"""
+
+
+def test_show_complete_sentinel_surfaces_then_ack_clears(client, tmp_path, monkeypatch):
+    from aquila_web import main as web_main
+    from aquila_web import update_sentinel as us
+
+    path = str(tmp_path / "last_update.json")
+    monkeypatch.setattr(web_main, "_UPDATE_SENTINEL_PATH", path)
+
+    # Simulate the post-reboot boot: a "show_complete" sentinel is on disk.
+    us.write_sentinel(path, "show_complete", web_main._utcnow_iso())
+    web_main._resolve_startup_update_state()
+
+    # The completion state is surfaced to the frontend.
+    assert client.get("/update/status").json()["status"] == "complete"
+
+    # Acknowledging clears the sentinel and returns to idle — fires exactly once.
+    assert client.post("/update/ack-complete").json()["ok"] is True
+    assert client.get("/update/status").json()["status"] == "idle"
+    assert us.read_sentinel(path) is None
+
+
+def test_reboot_pending_triggers_reboot_and_advances_sentinel(client, tmp_path, monkeypatch):
+    from aquila_web import main as web_main
+    from aquila_web import update_sentinel as us
+
+    path = str(tmp_path / "last_update.json")
+    monkeypatch.setattr(web_main, "_UPDATE_SENTINEL_PATH", path)
+    monkeypatch.setattr(web_main.current_item, "screen", "ready")  # not mid-run
+    reboots = []
+    monkeypatch.setattr(web_main, "_trigger_host_reboot", lambda: reboots.append(1) or True)
+
+    # Post-update boot: the applying container left a "reboot_pending" sentinel.
+    us.write_sentinel(path, "reboot_pending", web_main._utcnow_iso())
+    web_main._resolve_startup_update_state()
+
+    assert reboots == [1]  # rebooted exactly once
+    # Sentinel advanced BEFORE the reboot, so the next boot shows the modal, not a loop.
+    assert us.read_sentinel(path)["state"] == "show_complete"
+
+
+def test_apply_writes_reboot_pending_sentinel(client, tmp_path, monkeypatch):
+    from aquila_web import main as web_main
+    from aquila_web import update_sentinel as us
+
+    path = str(tmp_path / "last_update.json")
+    monkeypatch.setattr(web_main, "_UPDATE_SENTINEL_PATH", path)
+    monkeypatch.setattr(web_main.current_item, "screen", "ready")  # not mid-run
+
+    # Watchtower is unreachable in tests; the sentinel must be written first regardless.
+    client.post("/update/apply")
+    rec = us.read_sentinel(path)
+    assert rec is not None and rec["state"] == "reboot_pending"
+
+
+def test_apply_during_active_run_is_rejected_and_writes_no_sentinel(client, tmp_path, monkeypatch):
+    from aquila_web import main as web_main
+    from aquila_web import update_sentinel as us
+
+    path = str(tmp_path / "last_update.json")
+    monkeypatch.setattr(web_main, "_UPDATE_SENTINEL_PATH", path)
+    monkeypatch.setattr(web_main.current_item, "screen", "running")
+
+    resp = client.post("/update/apply")
+    assert resp.status_code == 409
+    assert us.read_sentinel(path) is None
+

--- a/tests/unit/test_kiosk_reboot.py
+++ b/tests/unit/test_kiosk_reboot.py
@@ -1,0 +1,38 @@
+"""Unit test for kiosk-control's host-reboot helper (issue #183).
+
+The endpoint itself drives a real `systemctl reboot` on the Pi (hardware), but the
+command-construction logic is testable with subprocess mocked — no real reboot.
+"""
+import importlib.util
+import pathlib
+from unittest import mock
+
+_KC_PATH = (
+    pathlib.Path(__file__).resolve().parents[2]
+    / "scripts" / "kiosk-control" / "kiosk_control.py"
+)
+
+
+def _load_kiosk_control():
+    spec = importlib.util.spec_from_file_location("kiosk_control", _KC_PATH)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def test_reboot_host_invokes_systemctl_reboot():
+    kc = _load_kiosk_control()
+    with mock.patch.object(kc.subprocess, "run") as run:
+        run.return_value = mock.Mock(returncode=0)
+        ok, msg = kc._reboot_host()
+    assert ok is True
+    run.assert_called_once_with(["systemctl", "reboot"], capture_output=True)
+
+
+def test_reboot_host_falls_back_to_sudo_when_systemctl_fails():
+    kc = _load_kiosk_control()
+    with mock.patch.object(kc.subprocess, "run") as run:
+        run.side_effect = [mock.Mock(returncode=1), mock.Mock(returncode=0)]
+        ok, _ = kc._reboot_host()
+    assert ok is True
+    assert run.call_args_list[1][0][0] == ["sudo", "reboot"]

--- a/tests/unit/test_update_sentinel.py
+++ b/tests/unit/test_update_sentinel.py
@@ -1,0 +1,60 @@
+"""Unit tests for the OTA update completion sentinel state machine (issue #183).
+
+The sentinel is a small on-disk record that survives the container swap and the
+reboot, so a freshly-started container knows an update just finished. These tests
+exercise the pure logic only — no FastAPI, no hardware.
+
+Run: pytest tests/unit/test_update_sentinel.py -v
+"""
+from datetime import datetime, timedelta, timezone
+
+from aquila_web import update_sentinel as us
+
+_TS = "2026-06-19T14:00:00Z"
+_BASE = datetime(2026, 6, 19, 14, 0, 0, tzinfo=timezone.utc)
+
+
+def test_write_then_read_round_trips_state(tmp_path):
+    path = tmp_path / "last_update.json"
+    us.write_sentinel(str(path), "reboot_pending", "2026-06-19T14:00:00Z")
+    record = us.read_sentinel(str(path))
+    assert record["state"] == "reboot_pending"
+    assert record["ts"] == "2026-06-19T14:00:00Z"
+
+
+def test_read_returns_none_when_absent_or_corrupt(tmp_path):
+    assert us.read_sentinel(str(tmp_path / "nope.json")) is None
+    corrupt = tmp_path / "corrupt.json"
+    corrupt.write_text("not json {{{")
+    assert us.read_sentinel(str(corrupt)) is None
+
+
+def test_fresh_reboot_pending_resolves_to_reboot():
+    rec = {"state": "reboot_pending", "ts": _TS}
+    now = _BASE + timedelta(seconds=30)
+    assert us.next_startup_action(rec, now, ttl_seconds=600) == "reboot"
+
+
+def test_fresh_show_complete_resolves_to_show_complete():
+    rec = {"state": "show_complete", "ts": _TS}
+    now = _BASE + timedelta(seconds=30)
+    assert us.next_startup_action(rec, now, ttl_seconds=600) == "show_complete"
+
+
+def test_sentinel_past_ttl_is_ignored():
+    rec = {"state": "show_complete", "ts": _TS}
+    now = _BASE + timedelta(seconds=601)
+    assert us.next_startup_action(rec, now, ttl_seconds=600) == "none"
+
+
+def test_no_record_resolves_to_none():
+    now = _BASE + timedelta(seconds=30)
+    assert us.next_startup_action(None, now, ttl_seconds=600) == "none"
+
+
+def test_clear_removes_the_sentinel(tmp_path):
+    path = tmp_path / "last_update.json"
+    us.write_sentinel(str(path), "show_complete", _TS)
+    us.clear_sentinel(str(path))
+    assert us.read_sentinel(str(path)) is None
+    us.clear_sentinel(str(path))  # idempotent — no error when already gone


### PR DESCRIPTION
## What Changed

Implemented a SENTRI auto reboot on device update. When the user updates their machine, once the new image has been successfully downloaded and the old image tossed, the device will automatically reboot. On device startup after the reboot, the user will be prompted with a flag detailing that their device has been updated.

## Why

[Link to the GitHub issue: Closes #[number]](https://github.com/AcornGenetics/aquilla-main/issues/183)

## Spec

Link to the spec this implements or modifies:
`specs/frontend/spec_ota_update_complete_on_reload.md`

If no spec exists and this is a non-trivial change, explain why.

## Changes Made

- [x] Source code modified
- [x] Spec updated to match implementation
- [x] New tests written
- [x] Existing tests still pass
- [x] No secrets or `.env` files in this diff
- [x] ADR written (if an irreversible architectural decision was made)
- [ ] `docs/debugging/known-issues.md` updated (if new edge cases were found)

## Hardware Testing

- [ ] Tested on physical device
- [ ] Tested in simulation mode only — reason: [why physical not possible]
- [ ] Hardware not relevant to this change

## Reviewer Notes

MUST BE TESTED ON A PHYSICAL DEVICE. I.E. FIX HAS NOT BEEN TESTED YET