### PR TITLE
Rebrand (part 2 ): Cutover tooling for #188: mid-run guard + flip-fleet orchestrator

### DIFF
--- a/scripts/deploy/fleet-update.sh
+++ b/scripts/deploy/fleet-update.sh
@@ -3,6 +3,11 @@ set -euo pipefail
 
 FLEET_ENV="/opt/fleet/.env"
 DEVICE_ENV="/opt/aquila/config/device.env"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# Refuse to recreate containers while a PCR run is in progress (#188, ADR-002) —
+# the `up -d` below would kill the run. Forwards operator flags (e.g. --force).
+"${SCRIPT_DIR}/run_guard.sh" "$@" || exit $?
 
 GHCR_TOKEN=$(grep ^GHCR_TOKEN= "${DEVICE_ENV}" | cut -d= -f2)
 GHCR_TOKEN_2=$(grep ^GHCR_TOKEN_2= "${DEVICE_ENV}" 2>/dev/null | cut -d= -f2 || echo "")

--- a/scripts/deploy/flip-fleet.sh
+++ b/scripts/deploy/flip-fleet.sh
@@ -1,0 +1,78 @@
+#!/usr/bin/env bash
+# Fleet cutover orchestrator (#188, ADR-016).
+#
+# Flips devices from the old image namespace to acorngenetics/sentri over
+# (Tailscale) SSH. Per device it points GHCR_REPO at the new repo and runs
+# fleet-update.sh — whose mid-run guard defers any device with a live PCR run.
+#
+# SAFE BY DEFAULT: dry-run unless --execute is given. Dry-run prints the plan
+# and touches nothing, so this can be reviewed and even run without risk.
+#
+#   flip-fleet.sh --devices hosts.txt            # dry-run: show the plan
+#   flip-fleet.sh --devices hosts.txt --execute  # actually flip the fleet
+#
+# hosts.txt: one device hostname per line (# comments and blanks ignored).
+set -uo pipefail
+
+NEW_GHCR_REPO="${NEW_GHCR_REPO:-acorngenetics/sentri}"
+SSH_CMD="${SSH_CMD:-ssh}"
+
+DEVICES_FILE=""
+EXECUTE=0
+for ((i = 1; i <= $#; i++)); do
+    case "${!i}" in
+        --devices) j=$((i + 1)); DEVICES_FILE="${!j}" ;;
+        --execute) EXECUTE=1 ;;
+    esac
+done
+
+if [[ -z "$DEVICES_FILE" || ! -f "$DEVICES_FILE" ]]; then
+    echo "flip-fleet: --devices FILE is required (one hostname per line)" >&2
+    exit 64
+fi
+
+# portable read (no mapfile — devices run modern bash, but dev machines may be 3.2)
+DEVICES=()
+while IFS= read -r line; do
+    [[ -z "$line" || "$line" =~ ^[[:space:]]*# ]] && continue
+    DEVICES+=("$line")
+done < "$DEVICES_FILE"
+
+if [[ "$EXECUTE" -ne 1 ]]; then
+    echo "DRY RUN — would flip ${#DEVICES[@]} device(s) to ${NEW_GHCR_REPO}:"
+    for d in "${DEVICES[@]}"; do
+        echo "  - ${d}"
+    done
+    echo "(pass --execute to perform the cutover)"
+    exit 0
+fi
+
+# --- execute: flip each device over SSH ---
+FLEET_ENV_PATH="${FLEET_ENV_PATH:-/opt/fleet/.env}"
+FLEET_UPDATE="${FLEET_UPDATE:-/opt/fleet/fleet-update.sh}"
+GUARD_DEFER_CODE=3  # run_guard.sh exit code for "a run is in progress"
+
+flipped=(); deferred=(); failed=()
+for d in "${DEVICES[@]}"; do
+    # point GHCR_REPO at the new repo, then trigger the (guarded) update
+    remote="sudo sed -i 's|^GHCR_REPO=.*|GHCR_REPO=${NEW_GHCR_REPO}|' ${FLEET_ENV_PATH} && sudo ${FLEET_UPDATE}"
+    if "$SSH_CMD" "$d" "$remote"; then
+        flipped+=("$d"); echo "  [ok] ${d}"
+    else
+        rc=$?
+        if [[ "$rc" -eq "$GUARD_DEFER_CODE" ]]; then
+            deferred+=("$d"); echo "  [deferred — run in progress] ${d}"
+        else
+            failed+=("$d"); echo "  [FAILED rc=${rc}] ${d}"
+        fi
+    fi
+done
+
+echo "---"
+echo "flipped: ${#flipped[@]}  deferred: ${#deferred[@]}  failed: ${#failed[@]}"
+[[ ${#deferred[@]} -gt 0 ]] && echo "deferred (re-run later): ${deferred[*]}"
+[[ ${#failed[@]} -gt 0 ]] && echo "failed: ${failed[*]}"
+
+# non-zero if any device still needs attention, so the operator follows up
+[[ ${#deferred[@]} -eq 0 && ${#failed[@]} -eq 0 ]] || exit 1
+exit 0

--- a/scripts/deploy/run_guard.sh
+++ b/scripts/deploy/run_guard.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+# Mid-run update guard for the fleet cutover (#188, ADR-002).
+#
+# Refuses to let the fleet updater recreate containers while a PCR run is in
+# progress (which would kill the run). Polls the device backend /health and:
+#
+#   exit 0  -> idle, safe to update
+#   exit 3  -> a run is in progress, defer this device
+#   exit 2  -> backend unreachable; run state can't be confirmed (fail-closed)
+#
+# Override with --force (e.g. a genuinely dead backend that must be updated).
+#
+# Configurable via HEALTH_URL (default http://localhost:8090/health) so the
+# behavior can be exercised against a stub endpoint.
+set -uo pipefail
+
+HEALTH_URL="${HEALTH_URL:-http://localhost:8090/health}"
+
+FORCE=0
+for arg in "$@"; do
+    case "$arg" in
+        --force) FORCE=1 ;;
+    esac
+done
+
+if [[ "$FORCE" -eq 1 ]]; then
+    echo "run_guard: --force given, skipping mid-run check"
+    exit 0
+fi
+
+body=$(curl -fsS --max-time 5 "$HEALTH_URL" 2>/dev/null)
+if [[ $? -ne 0 || -z "$body" ]]; then
+    echo "run_guard: cannot reach backend at ${HEALTH_URL} to confirm run state" \
+         "— refusing update (use --force to override)" >&2
+    exit 2
+fi
+
+if echo "$body" | grep -qE '"run_in_progress"[[:space:]]*:[[:space:]]*true'; then
+    echo "run_guard: a PCR run is in progress — deferring update" \
+         "(use --force to override)" >&2
+    exit 3
+fi
+
+echo "run_guard: device idle — safe to update"
+exit 0

--- a/sentri_web/main.py
+++ b/sentri_web/main.py
@@ -605,7 +605,8 @@ async def timer(payload: TimerControl):
 
 @app.get("/health")
 async def health_check():
-    return {"status": "ok"}
+    # run_in_progress lets the fleet updater defer a device mid-run (#188, ADR-002).
+    return {"status": "ok", "run_in_progress": run_in_progress}
 
 
 @app.get("/version")

--- a/tests/contract/test_health_run_guard.py
+++ b/tests/contract/test_health_run_guard.py
@@ -1,0 +1,26 @@
+"""
+Contract tests for the mid-run update guard's backend signal (#188, ADR-002).
+
+The fleet updater (`scripts/deploy/fleet-update.sh`) must not recreate
+containers while a PCR run is in progress — doing so kills the run. The
+device exposes that state on GET /health so the host-side updater can poll it
+and defer the device. ADR-002 flagged this as "not currently enforced".
+
+GET /health -> {"status": "ok", "run_in_progress": bool}
+"""
+
+
+def test_health_reports_idle_when_no_run_in_progress(client):
+    body = client.get("/health").json()
+
+    assert body["status"] == "ok"  # existing contract preserved
+    assert body["run_in_progress"] is False
+
+
+def test_health_reports_run_in_progress_while_running(client, monkeypatch):
+    from sentri_web import main as web_main
+    monkeypatch.setattr(web_main, "run_in_progress", True)
+
+    body = client.get("/health").json()
+
+    assert body["run_in_progress"] is True

--- a/tests/fleet_device/test_flip_fleet.py
+++ b/tests/fleet_device/test_flip_fleet.py
@@ -1,0 +1,119 @@
+"""
+Behavior tests for the fleet cutover orchestrator (#188, ADR-016).
+
+`scripts/deploy/flip-fleet.sh` flips devices from the old image namespace to
+`acorngenetics/sentri` over (Tailscale) SSH: per device it points
+GHCR_REPO at the new repo and runs fleet-update.sh. The mid-run guard inside
+fleet-update.sh means a device with a live PCR run is deferred, not interrupted.
+
+Safety contract: the orchestrator is **dry-run by default** — it touches no
+device unless `--execute` is passed. Tests drive it through its real interface
+(stdout + exit code) with a fake SSH command so they never touch a real fleet.
+"""
+import subprocess
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+FLIP = REPO_ROOT / "scripts" / "deploy" / "flip-fleet.sh"
+
+
+@pytest.fixture
+def fake_ssh(tmp_path):
+    """A stub `ssh` that records each invocation; yields (ssh_path, calls_file).
+
+    Per-device exit code can be steered by writing 'HOSTNAME=CODE' lines into
+    an EXIT_MAP file the stub reads."""
+    calls = tmp_path / "ssh_calls.log"
+    exit_map = tmp_path / "exit_map"
+    exit_map.write_text("")
+    ssh = tmp_path / "fake_ssh"
+    ssh.write_text(
+        "#!/usr/bin/env bash\n"
+        f'echo "$@" >> "{calls}"\n'
+        'host="$1"\n'
+        f'code=$(grep "^${{host}}=" "{exit_map}" 2>/dev/null | cut -d= -f2)\n'
+        'exit "${code:-0}"\n'
+    )
+    ssh.chmod(0o755)
+    yield ssh, calls, exit_map
+
+
+def _devices_file(tmp_path, *hosts):
+    f = tmp_path / "devices.txt"
+    f.write_text("\n".join(hosts) + "\n")
+    return f
+
+
+def _run(devfile, fake_ssh_path, *args):
+    return subprocess.run(
+        ["bash", str(FLIP), "--devices", str(devfile), *args],
+        env={"SSH_CMD": str(fake_ssh_path), "PATH": "/usr/bin:/bin"},
+        capture_output=True,
+        text=True,
+    )
+
+
+def test_dry_run_lists_devices_without_touching_them(tmp_path, fake_ssh):
+    ssh, calls, _ = fake_ssh
+    devfile = _devices_file(tmp_path, "sn01", "sn02")
+
+    result = _run(devfile, ssh)  # no --execute
+
+    assert result.returncode == 0
+    assert "sn01" in result.stdout and "sn02" in result.stdout
+    assert not calls.exists(), "dry-run must not invoke ssh"
+
+
+def test_execute_flips_each_device_to_sentri(tmp_path, fake_ssh):
+    ssh, calls, _ = fake_ssh
+    devfile = _devices_file(tmp_path, "sn01", "sn02")
+
+    result = _run(devfile, ssh, "--execute")
+
+    assert result.returncode == 0
+    log = calls.read_text()
+    # one ssh invocation per device, each pointing GHCR_REPO at the new repo
+    assert log.count("sn01") >= 1 and log.count("sn02") >= 1
+    assert "acorngenetics/sentri" in log
+    assert "fleet-update.sh" in log
+
+
+def test_mid_run_device_is_deferred_not_interrupted(tmp_path, fake_ssh):
+    ssh, calls, exit_map = fake_ssh
+    exit_map.write_text("sn01=3\n")  # run_guard.sh exit 3 == run in progress
+    devfile = _devices_file(tmp_path, "sn01", "sn02")
+
+    result = _run(devfile, ssh, "--execute")
+
+    # sn01 deferred; sn02 still attempted (deferral must not abort the run)
+    assert "sn02" in calls.read_text()
+    assert "deferred" in result.stdout.lower()
+    assert "sn01" in result.stdout
+    # a device still needing a follow-up flip -> non-zero so the operator knows
+    assert result.returncode != 0
+
+
+def test_failed_device_is_reported_distinctly(tmp_path, fake_ssh):
+    ssh, _, exit_map = fake_ssh
+    exit_map.write_text("sn02=1\n")  # generic failure, not the mid-run defer code
+    devfile = _devices_file(tmp_path, "sn01", "sn02")
+
+    result = _run(devfile, ssh, "--execute")
+
+    assert "failed" in result.stdout.lower()
+    assert result.returncode != 0
+
+
+def test_missing_devices_file_errors_clearly(tmp_path, fake_ssh):
+    ssh, _, _ = fake_ssh
+
+    result = subprocess.run(
+        ["bash", str(FLIP), "--devices", str(tmp_path / "nope.txt"), "--execute"],
+        env={"SSH_CMD": str(ssh), "PATH": "/usr/bin:/bin"},
+        capture_output=True, text=True,
+    )
+
+    assert result.returncode != 0
+    assert "devices" in result.stderr.lower()

--- a/tests/fleet_device/test_run_guard.py
+++ b/tests/fleet_device/test_run_guard.py
@@ -1,0 +1,124 @@
+"""
+Behavior tests for the mid-run update guard (#188, ADR-002).
+
+`scripts/deploy/run_guard.sh` is the safety check the fleet updater runs before
+recreating containers. It polls the backend /health and decides whether it is
+safe to update this device:
+
+  exit 0  -> idle, safe to update
+  exit !0 -> a run is in progress, OR run state can't be confirmed (fail-closed)
+
+The guard is exercised through its real interface — the shell process and its
+exit code — against a stub /health endpoint, so these tests survive any
+refactor of the script internals.
+"""
+import http.server
+import json
+import subprocess
+import threading
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+GUARD = REPO_ROOT / "scripts" / "deploy" / "run_guard.sh"
+
+
+@pytest.fixture
+def health_stub():
+    """Serve a controllable /health payload; yield (base_url, set_body)."""
+    state = {"body": {"status": "ok", "run_in_progress": False}}
+
+    class Handler(http.server.BaseHTTPRequestHandler):
+        def do_GET(self):
+            payload = json.dumps(state["body"]).encode()
+            self.send_response(200)
+            self.send_header("Content-Type", "application/json")
+            self.send_header("Content-Length", str(len(payload)))
+            self.end_headers()
+            self.wfile.write(payload)
+
+        def log_message(self, *args):
+            pass  # keep test output clean
+
+    server = http.server.HTTPServer(("127.0.0.1", 0), Handler)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    host, port = server.server_address
+
+    def set_body(body):
+        state["body"] = body
+
+    try:
+        yield f"http://{host}:{port}/health", set_body
+    finally:
+        server.shutdown()
+        server.server_close()
+
+
+def _run_guard(health_url, *args):
+    return subprocess.run(
+        ["bash", str(GUARD), *args],
+        env={"HEALTH_URL": health_url, "PATH": "/usr/bin:/bin"},
+        capture_output=True,
+        text=True,
+    )
+
+
+def test_guard_blocks_when_run_in_progress(health_stub):
+    health_url, set_body = health_stub
+    set_body({"status": "ok", "run_in_progress": True})
+
+    result = _run_guard(health_url)
+
+    assert result.returncode != 0
+    # the guard refused *because of the run*, not because the script is missing
+    assert "progress" in result.stderr.lower()
+
+
+def test_guard_proceeds_when_idle(health_stub):
+    health_url, set_body = health_stub
+    set_body({"status": "ok", "run_in_progress": False})
+
+    result = _run_guard(health_url)
+
+    assert result.returncode == 0
+
+
+def test_force_overrides_run_in_progress(health_stub):
+    health_url, set_body = health_stub
+    set_body({"status": "ok", "run_in_progress": True})
+
+    result = _run_guard(health_url, "--force")
+
+    assert result.returncode == 0
+
+
+def test_unreachable_backend_blocks_fail_closed():
+    # No server: an unconfirmable run state must refuse the update (fail-closed).
+    result = _run_guard("http://127.0.0.1:9/health")  # port 9 (discard) — refused
+
+    assert result.returncode != 0
+
+    forced = _run_guard("http://127.0.0.1:9/health", "--force")
+    assert forced.returncode == 0
+
+
+def test_fleet_update_runs_guard_before_recreating_containers():
+    """The guard is only useful if the updater aborts on its non-zero exit
+    *before* the destructive `docker compose ... up -d`."""
+    text = (REPO_ROOT / "scripts" / "deploy" / "fleet-update.sh").read_text()
+    # only executable lines — a comment mentioning `up -d` isn't the command
+    lines = [ln for ln in text.splitlines() if not ln.lstrip().startswith("#")]
+
+    guard_idx = next(i for i, ln in enumerate(lines) if "run_guard.sh" in ln)
+    up_idx = next(i for i, ln in enumerate(lines) if "up -d" in ln)
+
+    assert guard_idx < up_idx, "run_guard.sh must be invoked before `up -d`"
+    # the updater must honor the guard's verdict (abort on non-zero), and pass
+    # through operator flags like --force
+    guard_line = lines[guard_idx]
+    assert "exit" in guard_line or "||" in guard_line, (
+        "fleet-update.sh must abort when run_guard.sh exits non-zero"
+    )
+    assert '"$@"' in guard_line, "fleet-update.sh must forward args (e.g. --force) to the guard"


### PR DESCRIPTION
## Cutover tooling for #188 (stacked on #189)

The **code-shaped** parts of the fleet cutover (#188), split out of the rebrand PR so #189 stays a pure rename. Reviewable now; **runs after #189 merges** (the `sentri` images only publish once the rebrand is on `main`).

### What's here
1. **Mid-run update guard** (`run_guard.sh` + `/health` `run_in_progress`) — `fleet-update.sh` refuses to recreate containers while a PCR run is in progress (`--force` override; fail-closed if the backend is unreachable). Closes ADR-002's "mid-run updates not currently enforced" note.
2. **`flip-fleet.sh`** — one command to flip the fleet to `acorngenetics/sentri` over (Tailscale) SSH instead of eight hand-done sessions. **Dry-run by default** (touches nothing without `--execute`), defers mid-run devices via the guard, buckets failures, exits non-zero if any device still needs a follow-up.

### Safety
- Both are **inert under review** — nothing runs against a device until an operator invokes the scripts.
- `flip-fleet.sh` **dry-runs unless `--execute`**, so you can read *and* run it safely.

### Out of scope (irreducibly manual, per the #188 runbook)
- [ ] Rename the GitHub repo `aquilla-main → sentri`
- [ ] Run `flip-fleet.sh --execute` against the live fleet
- [ ] Verify digests + delete the old `aquilla-main-*` GHCR packages
- [ ] Remove the temporary dual-publish CI step

### Notes
- **Base branch is `sentri-rebrand`** so the diff shows only the cutover tooling; GitHub will retarget this to `main` once #189 merges.
- Blocked by #189. Tests: 12 (2 `/health` contract + 5 guard/wiring + 5 flip-fleet).
