### PR TITLE
Fix optics path field flashing on Run page in non-dev mode (#193)

### DIFF
--- a/aquila_web/static/run.html
+++ b/aquila_web/static/run.html
@@ -11,7 +11,7 @@
     <main class="main run-main">
       <header class="run-header">
         <h1 class="run-header__title">Run</h1>
-        <div class="run-optics-tab" id="run-optics-tab">
+        <div class="run-optics-tab is-hidden" id="run-optics-tab">
           <span>Optics:</span>
           <div class="optics-combo" id="optics-combo">
             <input id="dev-optics-path" class="keyboard-ignore" type="text" placeholder="/path/to/optics.log" autocomplete="off" role="combobox" aria-autocomplete="list" aria-expanded="false" />

--- a/docs/adr/ADR-017-async-gated-ui-defaults-to-hidden.md
+++ b/docs/adr/ADR-017-async-gated-ui-defaults-to-hidden.md
@@ -1,0 +1,75 @@
+# ADR-017: Async-gated UI elements default to hidden in markup
+
+**Status:** Accepted
+**Date:** 2026-06-23
+**Author:** Rasita Vajapattana
+**Deciders:** Rasita Vajapattana
+
+> Numbering note: this branch is cut from `main` (latest ADR-015). ADR-016 is
+> reserved by the in-flight rebrand branch (#189), so this decision takes 017
+> to avoid a collision regardless of merge order.
+
+---
+
+## Context
+
+The web UI (`aquila_web`) serves its pages as **static HTML files** via FastAPI `FileResponse` — there is no server-side templating. Any element whose presence depends on runtime state (dev vs. non-dev mode, feature flags, fetched config) therefore has its visibility decided **client-side**, after an asynchronous fetch resolves.
+
+The Run page has a dev-only "Optics path" field (`#run-optics-tab`). It was authored visible in the static markup, and JS hid it after `fetch("/button_status")` resolved with `dev_simulate=false`. Because the fetch is async, the field painted visible on first frame and was only hidden once the callback ran — a flash-of-unhidden-content (FOUC) that end users saw on every navigation to `/run` in non-dev mode (see issue #193).
+
+The constraints that make this a recurring trap:
+
+- Static markup paints **before** any JS runs; the initial class list is what the user sees first.
+- Fetch-gated visibility means there is always a gap between first paint and the state-resolving callback.
+- Defaulting to *shown* means the failure mode leaks privileged/dev-only UI to users; defaulting to *hidden* means the worst case is a correct-but-slightly-late reveal.
+
+Doing nothing leaves every current and future async-gated control exposed to the same flash.
+
+## Decision
+
+**We will author every UI element whose visibility depends on async/runtime state as hidden by default in static markup (`is-hidden`), and reveal it from JS only once the state is known.**
+
+Concretely:
+
+- New dev-only, flag-gated, or fetch-gated elements ship with `class="... is-hidden"` in the `.html` file.
+- The JS that resolves the state uses a **forced** toggle, e.g. `el.classList.toggle("is-hidden", !shouldShow)`, so it reveals when the condition holds and is a harmless no-op when it does not.
+- The reference fix: `#run-optics-tab` in `aquila_web/static/run.html` now ships `is-hidden`; `setOpticsVisibility(isDev)` reveals it only in dev mode.
+
+This is reversible per-element (it's a CSS class on markup) but is adopted as the standing convention for the static-file web UI.
+
+## Consequences
+
+### Positive
+- No FOUC: dev-only / gated UI never flashes in front of users.
+- Fail-safe default — a missing or failed state fetch leaves gated UI hidden rather than exposed.
+- Cheap and uniform: one utility class (`.is-hidden { display: none }`) plus a forced toggle.
+
+### Negative
+- Gated elements that *should* show appear a frame late (after the fetch) instead of immediately. Acceptable: a slightly-late correct reveal beats an early wrong one.
+- Relies on JS running; if JS fails entirely, gated elements stay hidden (acceptable, and correct for dev-only controls).
+
+### Neutral / Tradeoffs
+- Slightly more discipline at authoring time — the default class must be remembered. The regression test on the Run page guards the one known case; new cases rely on this ADR plus review.
+
+## Alternatives Considered
+
+### Option A: Keep visible-by-default, hide via JS
+**Why rejected:** This is the exact bug — guarantees a flash and leaks dev-only UI to users on every load.
+
+### Option B: Server-side render visibility (template the HTML per request)
+**Why rejected:** The web UI is intentionally static `FileResponse`; introducing templating for one class toggle is disproportionate and changes the serving architecture.
+
+### Option C: Inline `<style>`/blocking script in `<head>` to set visibility pre-paint
+**Why rejected:** More complex, still needs the state which is fetched async; the default-hidden class achieves the same fail-safe with one attribute.
+
+## Revisit Conditions
+
+- If the web UI moves to server-side templating or a SPA framework that resolves state before first paint, this convention can be relaxed.
+- If a future element genuinely must be visible-by-default and only conditionally *hidden* (inverse case), document the exception and ensure the hidden-state default still cannot leak privileged UI.
+
+## References
+
+- Issue: #193
+- Related ADRs: ADR-012 (custom dropdowns as cosmetic overlays — UI-convention precedent)
+- Code: `aquila_web/static/run.html`, `aquila_web/static/script.js` (`setOpticsVisibility`)
+- Test: `tests/contract/test_optics_path_endpoints.py::test_run_page_hides_optics_tab_by_default`

--- a/tests/contract/test_optics_path_endpoints.py
+++ b/tests/contract/test_optics_path_endpoints.py
@@ -35,3 +35,22 @@ def test_blank_path_clears_selection_but_keeps_history(client):
 
     assert resp["path"] is None
     assert "/tmp/scope.log" in resp["history"]
+
+
+def test_run_page_hides_optics_tab_by_default(client):
+    """
+    The optics path field is dev-only and is revealed by JS after the async
+    /button_status fetch resolves. If the served markup ships it visible, the
+    field flashes on every non-dev load before JS hides it. Guard against that
+    regression: the optics tab must be hidden in the static HTML by default.
+    """
+    import re
+
+    html = client.get("/run").text
+
+    match = re.search(r'<div class="([^"]*)" id="run-optics-tab"', html)
+    assert match is not None, "run-optics-tab div not found in served /run HTML"
+    assert "is-hidden" in match.group(1).split(), (
+        "optics tab must ship hidden by default to avoid a non-dev flash; "
+        f'got class="{match.group(1)}"'
+    )


### PR DESCRIPTION
Closes #193.

## Problem
The dev-only Optics path field (`#run-optics-tab`) shipped **visible** in the static `run.html` and was only hidden after the async `fetch("/button_status")` callback resolved. In non-dev mode (`AQ_DEV_SIMULATE=0` — what users see) this caused a flash-of-unhidden-content on every navigation to `/run`.

## Fix
Ship the field hidden by default (`is-hidden`). `setOpticsVisibility(isDev)` uses a forced `classList.toggle("is-hidden", !isDev)`, so it reveals the field in dev mode and is a no-op in non-dev — no flash, and a fail-safe default (gated UI stays hidden if the fetch fails).

## Changes
- `aquila_web/static/run.html` — add `is-hidden` to `#run-optics-tab`
- `tests/contract/test_optics_path_endpoints.py` — regression test asserting the served `/run` markup hides the optics tab by default (red before fix, green after)
- `docs/adr/ADR-017-async-gated-ui-defaults-to-hidden.md` — records the convention: async-gated UI defaults to hidden in markup

## Verification
- Reproduced in non-dev mode; served HTML now ships `is-hidden`
- Dev mode still shows the field (forced toggle)
- `tests/contract` + `tests/e2e/test_run_dropdowns.py` + `unit_tests/test_optics_history.py`: 120 passed, 3 skipped

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)