### PR TITLE
#197 stages contract foundation

### DIFF
--- a/aquila_web/main.py
+++ b/aquila_web/main.py
@@ -236,6 +236,10 @@ class ProfileSave(BaseModel):
     rox_label: Optional[str] = None
     # Optional estimated completion time, in minutes. None clears any existing estimate.
     estimated_minutes: Optional[int] = None
+    # Structured-editor source of truth (issue #197 contract). When present, the
+    # profile is a Structured Profile; assembly/validation of these stages into
+    # `steps` is handled separately (A1/A2/A3). Persisted verbatim here.
+    stages: Optional[dict] = None
 
 class ProfileDelete(BaseModel):
     profiles: list[str]
@@ -914,6 +918,15 @@ async def profiles_edit_form_page():
         headers={"Cache-Control": "no-store"}
     )
 
+@app.get("/profiles/builder")
+async def profiles_builder_page():
+    # Structured profile editor (issue #197). Serves the shell; the Stage UI,
+    # validation, and save wiring are layered on in the frontend route (B1/B2/B3).
+    return FileResponse(
+        static_dir / "profiles/builder.html",
+        headers={"Cache-Control": "no-store"}
+    )
+
 @app.get("/history")
 async def history_page():
     return FileResponse(static_dir / "history.html")
@@ -1369,6 +1382,10 @@ async def save_profile(payload: ProfileSave):
     base_profile["post_in_gui"] = "True"
     if payload.steps is not None:
         base_profile["steps"] = payload.steps
+    # Persist the structured `stages` source of truth verbatim when provided
+    # (issue #197). Its presence marks a Structured Profile.
+    if payload.stages is not None:
+        base_profile["stages"] = payload.stages
     labels = {}
     if isinstance(base_profile.get("labels"), dict):
         labels.update(base_profile.get("labels", {}))
@@ -1503,7 +1520,7 @@ async def profile_details(id: str | None = Query(default=None), name: str | None
             "steps": _convert_run_config_to_steps(data.get("configuration", {}))
         }
 
-    return {
+    details = {
         "id": profile_path.name,
         "title": data.get("title", profile_path.stem),
         "labels": data.get("labels", {}),
@@ -1512,6 +1529,11 @@ async def profile_details(id: str | None = Query(default=None), name: str | None
         "estimated_completion_seconds": data.get("estimated_completion_seconds"),
         "steps": data.get("steps", [])
     }
+    # Structured Profiles carry the `stages` source of truth; Legacy Profiles
+    # omit it entirely so the editor can branch on its presence (issue #197).
+    if data.get("stages") is not None:
+        details["stages"] = data["stages"]
+    return details
 
 @app.websocket("/ws")
 async def websocket_endpoint(websocket: WebSocket):

--- a/aquila_web/static/profiles/builder.html
+++ b/aquila_web/static/profiles/builder.html
@@ -1,0 +1,36 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=768, height=1024, initial-scale=1" />
+  <title>Create Profile</title>
+  <link rel="stylesheet" href="/static/styles.css?v=219" />
+</head>
+<body class="app-body">
+  <div class="app-shell">
+    <main class="main run-main">
+      <header class="run-header">
+        <h1 class="run-header__title" id="builder-page-title">
+          <a class="back-icon back-icon--inline" href="/profiles-page" aria-label="Back">&#x2039;</a>
+          Create Profile
+        </h1>
+        <nav class="run-header__nav">
+          <a class="run-nav-link" href="/run">Run</a>
+          <a class="run-nav-link" href="/history">History</a>
+          <a class="run-nav-link" href="/profiles-page">Profiles</a>
+          <a class="run-nav-link settings-link" href="/settings">Settings</a>
+          <a class="help-link" href="/help">
+            <span>?</span>
+            <span class="help-tooltip">How to run a test</span>
+          </a>
+        </nav>
+      </header>
+      <div class="run-divider"></div>
+      <!-- Structured profile editor shell (issue #197). The Stage/Sub-stage UI,
+           validation, and save wiring are built in B1/B2/B3. -->
+      <div class="profile-form" id="profile-builder-root"></div>
+    </main>
+  </div>
+  <script src="/static/nav.js?v=1"></script>
+</body>
+</html>

--- a/specs/backend/spec_stages_contract_foundation.md
+++ b/specs/backend/spec_stages_contract_foundation.md
@@ -1,0 +1,115 @@
+# Backend / API Spec: `stages` Contract Foundation (issue #197)
+
+**Status:** Active
+**Author:** Aquila Engineering Team
+**Last updated:** 2026-06-25
+**GitHub issue:** #197
+**Source file(s):** `aquila_web/main.py`, `aquila_web/static/profiles/builder.html`, `tests/fixtures/sample_stages.json`
+**Umbrella PRD:** `specs/prd/structured-profile-editor-prd.md` · **Decision:** `docs/adr/ADR-018-structured-profile-editor-backend-assembled-steps.md`
+
+---
+
+## 1. Overview
+
+The shared prerequisite for the Structured Profile Editor: make the backend accept, persist, and return a structured `stages` object, and serve the editor's HTML shell. This establishes the `stages` contract both routes build against. It deliberately does **not** assemble `steps`, validate ranges, add the list `structured` flag, or build any UI — those are separate issues (A1 #198, A2 #199, A3 #201, B1–B3) with their own specs.
+
+---
+
+## 2. Endpoints
+
+### `POST /profiles` (extended)
+
+**Purpose:** Accept an optional structured `stages` object and persist it verbatim alongside the existing fields.
+
+**Request body (relevant addition):**
+```json
+{
+  "name": "My Assay",     // required (unchanged)
+  "stages": { ... }       // optional; persisted verbatim (see §4)
+}
+```
+
+**Response (200 OK):** `{ "ok": true, "id": "local/my_assay.json" }` (unchanged).
+
+**Behavior for #197:**
+- When `stages` is present, it is written into the saved JSON unchanged.
+- When `stages` is absent, behavior is exactly as before (Legacy/`steps`-based saves unaffected).
+- No validation of `stages` contents in #197 (deferred to A2/A3). No `steps` regeneration (deferred to A1/A3).
+
+**Error responses:** unchanged from current `POST /profiles` (e.g. 403 on bundled, 500 on write failure).
+
+### `GET /profiles/details` (extended)
+
+Returns the `stages` object **only when the file contains it**; Legacy Profiles omit the key entirely so the presence of `stages` is the Structured-Profile marker. All other returned fields unchanged.
+
+### `GET /profiles/builder` (new)
+
+Serves `static/profiles/builder.html` with `Cache-Control: no-store`. A static shell only — Stage UI, validation, and save wiring are the frontend issues (B1/B2/B3).
+
+---
+
+## 4. Data Models
+
+### `ProfileSave.stages` (request field) — the contract
+
+Optional `dict`. Canonical fixture committed at `tests/fixtures/sample_stages.json`:
+
+```json
+{
+  "incubation":   { "enabled": true,  "temp": 37, "time": 600 },
+  "denaturation": { "enabled": true,  "temp": 95, "time": 120 },
+  "amplification": {
+    "cycles": 40,
+    "subStages": [
+      { "name": "Denaturation",          "temp": 95,   "time": 11 },
+      { "name": "Annealing & Extension", "temp": 60.5, "time": 38 }
+    ]
+  },
+  "finalHold":    { "enabled": false, "temp": 25, "time": 60 }
+}
+```
+
+- `incubation` / `denaturation` / `finalHold`: `{enabled: bool, temp: °C, time: seconds}` — optional Stages.
+- `amplification`: always present (no `enabled`); `cycles` integer; `subStages` length 2–3, each `{name, temp, time}`.
+
+#197 treats this object as opaque — it stores and returns it without interpreting it.
+
+---
+
+## 5. Persistence
+
+- The `stages` object is written verbatim into the Profile JSON (under `profiles/local/` for new profiles).
+- A file containing `stages` is a Structured Profile; its presence is the only marker (ADR-018).
+- `steps` remains the only artifact the hardware runner/analytics read. In #197 a structured-only save does not yet regenerate `steps` (that is A1/A3); the field is carried for the contract.
+
+---
+
+## 7. Validation Rules
+
+None in #197. Range/shape validation of `stages` is specified separately for A2 (#199) and enforced on `POST` in A3 (#201).
+
+---
+
+## 8. Contract Tests
+
+`tests/contract/test_profile_endpoints.py` (marked `contract`):
+- `test_post_profile_persists_and_returns_stages` — a `stages` payload round-trips through `POST` → `GET /profiles/details`.
+- `test_profiles_builder_route_serves_html` — `GET /profiles/builder` returns 200 + HTML.
+- `test_sample_stages_fixture_matches_contract` — the committed fixture matches the canonical shape.
+
+Run: `pytest tests/contract/test_profile_endpoints.py -v`
+
+---
+
+## Out of Scope (other issues, other specs)
+
+- Assembling `stages → steps` and the Boilerplate constants — A1 (#198).
+- Validating `stages` ranges/shape — A2 (#199).
+- Enforcing validation on `POST` and adding the `structured` flag to `GET /profiles` — A3 (#201).
+- The builder UI, validation display, and list routing — B1/B2/B3 (#200/#202/#203).
+
+---
+
+## 9. Open Questions
+
+- [ ] None — contract decisions resolved in ADR-018 and the PRD.

--- a/tests/contract/test_profile_endpoints.py
+++ b/tests/contract/test_profile_endpoints.py
@@ -365,3 +365,74 @@ def test_saved_file_always_carries_both_fields_after_anchor(client):
         assert keys[keys.index("time_unavailable") + 1] == "estimated_completion_seconds"
     finally:
         _delete_profile(client, pid)
+
+
+# ---------------------------------------------------------------------------
+# Structured profiles — `stages` contract foundation (issue #197)
+# ---------------------------------------------------------------------------
+
+# The canonical structured-profile payload both routes build and test against.
+SAMPLE_STAGES = {
+    "incubation": {"enabled": True, "temp": 37, "time": 600},
+    "denaturation": {"enabled": True, "temp": 95, "time": 120},
+    "amplification": {
+        "cycles": 40,
+        "subStages": [
+            {"name": "Denaturation", "temp": 95, "time": 11},
+            {"name": "Annealing & Extension", "temp": 60.5, "time": 38},
+        ],
+    },
+    "finalHold": {"enabled": False, "temp": 25, "time": 60},
+}
+
+
+@pytest.mark.contract
+def test_post_profile_persists_and_returns_stages(client):
+    """A `stages` payload is accepted, persisted, and read back unchanged.
+
+    #197 only carries the contract surface — it does not assemble steps or
+    validate ranges (those are A1/A2/A3). It must, however, round-trip the
+    structured object so both routes can build against a real contract.
+    """
+    resp = client.post(
+        "/profiles",
+        json={"name": "Contract Stages Profile", "stages": SAMPLE_STAGES},
+    )
+    assert resp.status_code == 200, resp.text
+    pid = resp.json()["id"]
+    try:
+        details = client.get(f"/profiles/details?id={pid}")
+        assert details.status_code == 200
+        assert details.json()["stages"] == SAMPLE_STAGES
+    finally:
+        _delete_profile(client, pid)
+
+
+@pytest.mark.contract
+def test_profiles_builder_route_serves_html(client):
+    """GET /profiles/builder serves the structured-editor HTML shell (issue #197)."""
+    resp = client.get("/profiles/builder")
+    assert resp.status_code == 200
+    assert "text/html" in resp.headers.get("content-type", "")
+
+
+@pytest.mark.contract
+def test_sample_stages_fixture_matches_contract():
+    """The committed sample fixture is the canonical `stages` shape (issue #197).
+
+    Both routes build against this file, so it must match the agreed contract:
+    incubation/denaturation/finalHold carry enabled+temp+time; amplification is
+    always present (no `enabled`) with cycles and 2-3 sub-stages.
+    """
+    fixture = Path(__file__).parent.parent / "fixtures" / "sample_stages.json"
+    data = json.loads(fixture.read_text())
+    assert data == SAMPLE_STAGES
+
+    for key in ("incubation", "denaturation", "finalHold"):
+        assert set(data[key]) == {"enabled", "temp", "time"}, key
+    amp = data["amplification"]
+    assert "enabled" not in amp
+    assert "cycles" in amp
+    assert 2 <= len(amp["subStages"]) <= 3
+    for sub in amp["subStages"]:
+        assert set(sub) == {"name", "temp", "time"}

--- a/tests/fixtures/sample_stages.json
+++ b/tests/fixtures/sample_stages.json
@@ -1,0 +1,12 @@
+{
+  "incubation": { "enabled": true, "temp": 37, "time": 600 },
+  "denaturation": { "enabled": true, "temp": 95, "time": 120 },
+  "amplification": {
+    "cycles": 40,
+    "subStages": [
+      { "name": "Denaturation", "temp": 95, "time": 11 },
+      { "name": "Annealing & Extension", "temp": 60.5, "time": 38 }
+    ]
+  },
+  "finalHold": { "enabled": false, "temp": 25, "time": 60 }
+}


### PR DESCRIPTION
Closes #197 — the `stages` contract foundation for the Structured Profile Editor.

## What this does
Establishes the structured `stages` contract both routes build against. Scoped to the contract surface only — **no** assembly, validation, list `structured` flag, or UI (those are A1 #198 / A2 #199 / A3 #201 / B1–B3).

- `ProfileSave.stages` (optional) — accepted and **persisted verbatim** in `save_profile`.
- `GET /profiles/details` returns `stages` **only when present** (Legacy Profiles omit it — presence is the Structured-Profile marker).
- `GET /profiles/builder` serves the editor HTML shell (`static/profiles/builder.html`).
- `tests/fixtures/sample_stages.json` — canonical contract fixture.

## Spec / docs
- Spec: `specs/backend/spec_stages_contract_foundation.md`
- PRD: `specs/prd/structured-profile-editor-prd.md` · ADR-018

## SPEC_WORKFLOW checklist
- [x] Spec file linked
- [x] Spec accurate to what was built
- [x] New tests written (3 contract tests)
- [x] Profile contract + unit suites pass; pre-existing unrelated failures unchanged (verified by stashing)
- [x] No secrets in diff
- [x] ADR written (ADR-018)

## Tests
`tests/contract/test_profile_endpoints.py`: `test_post_profile_persists_and_returns_stages`, `test_profiles_builder_route_serves_html`, `test_sample_stages_fixture_matches_contract`.

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)
