### PR TITLE
#198 (A1) assemble stages -> steps

### DIFF
--- a/aquila_web/profile_assembly.py
+++ b/aquila_web/profile_assembly.py
@@ -1,0 +1,79 @@
+"""Assemble a structured `stages` object into the runnable `steps` array.
+
+Pure functions only — no HTTP, disk, or hardware imports — so this module is
+unit-testable in isolation. See specs/backend/spec_profile_step_assembly.md
+(#198) and ADR-018 for the fixed Boilerplate constants and ordering.
+"""
+
+# Seconds held at the extension temperature after the optics read fires; the
+# extension-bearing sub-stage is split into (time - tail) -> optics -> tail (ADR-018).
+OPTICS_TAIL_SECONDS = 10
+
+
+def assemble_steps(stages: dict) -> list:
+    """Expand a structured `stages` object into the full `steps` array.
+
+    Weaves the fixed Boilerplate (head/tail, ramps, optics read) together with
+    the user's enabled Stages. Assumes well-formed input (validation is A2/#199).
+    """
+    steps = [
+        {"disable": 0, "duration": 1, "description": "Record equilibration without power."},
+        {"ramp_rate": 1.6},
+        {"pcr_fanon": 1},
+        {"enable": 0, "duration": 1, "description": "Turn on and record temperature for a little bit"},
+        {"optics": ""},
+        {"setpoint": 25, "duration": 1, "description": "Presetting temperature"},
+    ]
+
+    # Incubation (optional): one setpoint between the head and amplification.
+    incubation = stages["incubation"]
+    if incubation["enabled"]:
+        steps.append(
+            {"setpoint": incubation["temp"], "duration": incubation["time"], "description": "Incubation"}
+        )
+
+    # Initial Denaturation (optional): one setpoint before amplification.
+    denaturation = stages["denaturation"]
+    if denaturation["enabled"]:
+        steps.append(
+            {"setpoint": denaturation["temp"], "duration": denaturation["time"], "description": "Initial Denaturation"}
+        )
+
+    # Amplification (always present): mid ramp, then the cycled repeat block.
+    amplification = stages["amplification"]
+    sub_stages = amplification["subStages"]
+    repeat_steps = []
+    for index, sub in enumerate(sub_stages):
+        is_extension = index == len(sub_stages) - 1
+        if is_extension:
+            # The optics read fires mid-hold on the extension-bearing sub-stage:
+            # hold (time - tail) -> read -> hold tail (ADR-018).
+            repeat_steps.append(
+                {"setpoint": sub["temp"], "duration": sub["time"] - OPTICS_TAIL_SECONDS, "description": sub["name"]}
+            )
+            repeat_steps.append({"optics": ""})
+            repeat_steps.append(
+                {"setpoint": sub["temp"], "duration": OPTICS_TAIL_SECONDS, "description": sub["name"]}
+            )
+        else:
+            repeat_steps.append(
+                {"setpoint": sub["temp"], "duration": sub["time"], "description": sub["name"]}
+            )
+    steps.append({"ramp_rate": 1.75})
+    steps.append({"repeat": repeat_steps, "cycles": amplification["cycles"]})
+
+    # Final Temp Hold (optional): one setpoint after amplification, before the tail.
+    final_hold = stages["finalHold"]
+    if final_hold["enabled"]:
+        steps.append(
+            {"setpoint": final_hold["temp"], "duration": final_hold["time"], "description": "Final Temp Hold"}
+        )
+
+    steps += [
+        {"ramp_rate": 1.6},
+        {"setpoint": 40, "duration": 20, "description": "Initial cooling"},
+        {"setpoint": 25, "duration": 10, "description": "Restoring setpoint to RT"},
+        {"disable": 0, "duration": 5, "description": "Turn off and record temperature for a little bit"},
+        {"pcr_fanoff": 0},
+    ]
+    return steps

--- a/specs/backend/spec_profile_step_assembly.md
+++ b/specs/backend/spec_profile_step_assembly.md
@@ -1,0 +1,83 @@
+# Backend Spec: Profile Step Assembly (`stages → steps`) — issue #198 (A1)
+
+**Status:** Draft
+**Author:** Aquila Engineering Team
+**Last updated:** 2026-06-25
+**GitHub issue:** #198
+**Source file(s):** `aquila_web/profile_assembly.py` (new), `unit_tests/test_profile_assembly.py` (new)
+**Umbrella PRD:** `specs/prd/structured-profile-editor-prd.md` · **Decision:** ADR-018
+**Builds on:** `specs/backend/spec_stages_contract_foundation.md` (#197 — the `stages` contract)
+
+---
+
+## 1. Overview
+
+A pure function that expands a structured `stages` object (the #197 contract) into the complete runnable `steps` array, weaving the fixed Boilerplate together with the user's Stages. No HTTP, no disk, no hardware imports — pure `dict → list`.
+
+```python
+def assemble_steps(stages: dict) -> list[dict]: ...
+```
+
+Lives in a standalone module so it is unit-testable without importing the FastAPI app (no RPi/serial stubbing). Wiring into `POST /profiles` is **A3 (#201)**; range validation is **A2 (#199)**. A1 assumes well-formed input and does not validate.
+
+---
+
+## 2. Input
+
+The `stages` object (canonical fixture `tests/fixtures/sample_stages.json`):
+`incubation`/`denaturation`/`finalHold` = `{enabled, temp, time}` (optional Stages); `amplification` = `{cycles, subStages:[{name,temp,time}]}` (always present, 2–3 sub-stages). `temp` °C, `time` seconds.
+
+---
+
+## 3. Output: assembled `steps`, in order
+
+1. **Head (always):**
+   - `{"disable": 0, "duration": 1, "description": "Record equilibration without power."}`
+   - `{"ramp_rate": 1.6}`
+   - `{"pcr_fanon": 1}`
+   - `{"enable": 0, "duration": 1, "description": "Turn on and record temperature for a little bit"}`
+   - `{"optics": ""}`
+   - `{"setpoint": 25, "duration": 1, "description": "Presetting temperature"}`
+2. **Incubation** (only if `enabled`): `{"setpoint": temp, "duration": time, "description": "Incubation"}`
+3. **Initial Denaturation** (only if `enabled`): `{"setpoint": temp, "duration": time, "description": "Initial Denaturation"}`
+4. **Amplification** (always):
+   - `{"ramp_rate": 1.75}`
+   - `{"repeat": [ <sub-stage steps> ], "cycles": <cycles>}`
+   - Each sub-stage → `{"setpoint": temp, "duration": time, "description": <name>}`.
+   - The **extension-bearing** sub-stage (the 2nd when there are 2, the 3rd when there are 3) is split around the optics read:
+     `{"setpoint": temp, "duration": time-10, "description": <name>}`, `{"optics": ""}`, `{"setpoint": temp, "duration": 10, "description": <name>}`.
+5. **Final Temp Hold** (only if `enabled`): `{"setpoint": temp, "duration": time, "description": "Final Temp Hold"}` — after Amplification, before tail.
+6. **Tail (always):**
+   - `{"ramp_rate": 1.6}`
+   - `{"setpoint": 40, "duration": 20, "description": "Initial cooling"}`
+   - `{"setpoint": 25, "duration": 10, "description": "Restoring setpoint to RT"}`
+   - `{"disable": 0, "duration": 5, "description": "Turn off and record temperature for a little bit"}`
+   - `{"pcr_fanoff": 0}`
+
+Disabled Stages emit nothing. Constants (1.6 / 1.75 / 25 °C / 10 s offset) are fixed per ADR-018.
+
+---
+
+## 7. Validation Rules
+
+None here — A1 assumes valid input. Range/shape validation is A2 (#199), enforced on `POST` in A3 (#201).
+
+---
+
+## 8. Unit Tests
+
+`unit_tests/test_profile_assembly.py` (marked `unit`), importing `aquila_web.profile_assembly` directly. Behaviors: head emitted; tail emitted; amplification ramp 1.75 + repeat with cycles; sub-stage → setpoint with name description; optics split on extension sub-stage (2- and 3-sub-stage cases); incubation/denaturation/final-hold emitted when enabled; disabled stages omitted; full end-to-end ordering.
+
+Run: `pytest unit_tests/test_profile_assembly.py -v`
+
+---
+
+## Out of Scope (other issues)
+
+- Validation — A2 (#199). Wiring into `POST /profiles` + `structured` list flag — A3 (#201). UI — B1/B2/B3.
+
+---
+
+## 9. Open Questions
+
+- [ ] None — assembly rules fixed in ADR-018 / the PRD.

--- a/unit_tests/test_profile_assembly.py
+++ b/unit_tests/test_profile_assembly.py
@@ -1,0 +1,169 @@
+"""
+Unit tests for aquila_web/profile_assembly.py — assemble_steps(stages) -> steps.
+
+Pure logic, no hardware or network (the module has no hardware imports, so unlike
+test_estimated_completion.py this needs no RPi/serial stubbing). Marked ``unit``.
+Spec: specs/backend/spec_profile_step_assembly.md (issue #198).
+"""
+import pytest
+
+from aquila_web.profile_assembly import assemble_steps
+
+pytestmark = pytest.mark.unit
+
+
+def _stages(*, incubation=None, denaturation=None, final_hold=None,
+            cycles=40, sub_stages=None):
+    """Build a valid stages dict. Optional stages default to disabled;
+    amplification defaults to the 2-sub-stage shape."""
+    if sub_stages is None:
+        sub_stages = [
+            {"name": "Denaturation", "temp": 95, "time": 11},
+            {"name": "Annealing & Extension", "temp": 60.5, "time": 38},
+        ]
+    return {
+        "incubation": incubation or {"enabled": False, "temp": 37, "time": 600},
+        "denaturation": denaturation or {"enabled": False, "temp": 95, "time": 120},
+        "amplification": {"cycles": cycles, "subStages": sub_stages},
+        "finalHold": final_hold or {"enabled": False, "temp": 25, "time": 60},
+    }
+
+
+HEAD = [
+    {"disable": 0, "duration": 1, "description": "Record equilibration without power."},
+    {"ramp_rate": 1.6},
+    {"pcr_fanon": 1},
+    {"enable": 0, "duration": 1, "description": "Turn on and record temperature for a little bit"},
+    {"optics": ""},
+    {"setpoint": 25, "duration": 1, "description": "Presetting temperature"},
+]
+
+
+TAIL = [
+    {"ramp_rate": 1.6},
+    {"setpoint": 40, "duration": 20, "description": "Initial cooling"},
+    {"setpoint": 25, "duration": 10, "description": "Restoring setpoint to RT"},
+    {"disable": 0, "duration": 5, "description": "Turn off and record temperature for a little bit"},
+    {"pcr_fanoff": 0},
+]
+
+
+def test_emits_fixed_head_first():
+    """Every assembled profile begins with the fixed equilibration/fan/optics head."""
+    steps = assemble_steps(_stages())
+    assert steps[:len(HEAD)] == HEAD
+
+
+def test_emits_fixed_tail_last():
+    """Every assembled profile ends with the fixed cooldown/fan-off tail."""
+    steps = assemble_steps(_stages())
+    assert steps[-len(TAIL):] == TAIL
+
+
+def test_amplification_emits_ramp_then_repeat_with_cycles():
+    """Amplification is always present: a 1.75 ramp followed by a repeat block
+    carrying the user's cycle count. With no optional stages enabled it sits
+    immediately after the head."""
+    steps = assemble_steps(_stages(cycles=42))
+    assert steps[len(HEAD)] == {"ramp_rate": 1.75}
+    repeat_step = steps[len(HEAD) + 1]
+    assert "repeat" in repeat_step
+    assert repeat_step["cycles"] == 42
+
+
+def _repeat_of(steps):
+    """The repeat block's inner step list (amplification sits after the head when
+    no optional stages are enabled)."""
+    return steps[len(HEAD) + 1]["repeat"]
+
+
+def test_substage_maps_to_setpoint_with_name_description():
+    """A (non-extension) sub-stage becomes one setpoint whose description is its name."""
+    steps = assemble_steps(_stages())
+    repeat = _repeat_of(steps)
+    assert repeat[0] == {"setpoint": 95, "duration": 11, "description": "Denaturation"}
+
+
+def test_optics_split_on_extension_substage_two_substage_case():
+    """With 2 sub-stages, the 2nd (Annealing & Extension) carries the optics read,
+    split as (time-10) -> optics -> 10."""
+    steps = assemble_steps(_stages())  # extension sub-stage time = 38
+    assert _repeat_of(steps) == [
+        {"setpoint": 95, "duration": 11, "description": "Denaturation"},
+        {"setpoint": 60.5, "duration": 28, "description": "Annealing & Extension"},
+        {"optics": ""},
+        {"setpoint": 60.5, "duration": 10, "description": "Annealing & Extension"},
+    ]
+
+
+def test_optics_split_on_extension_substage_three_substage_case():
+    """With 3 sub-stages, the 3rd (Extension) carries the optics read; the 2nd
+    (Annealing) is a plain hold."""
+    three = [
+        {"name": "Denaturation", "temp": 95, "time": 11},
+        {"name": "Annealing", "temp": 60, "time": 20},
+        {"name": "Extension", "temp": 72, "time": 30},
+    ]
+    steps = assemble_steps(_stages(sub_stages=three))
+    assert _repeat_of(steps) == [
+        {"setpoint": 95, "duration": 11, "description": "Denaturation"},
+        {"setpoint": 60, "duration": 20, "description": "Annealing"},
+        {"setpoint": 72, "duration": 20, "description": "Extension"},
+        {"optics": ""},
+        {"setpoint": 72, "duration": 10, "description": "Extension"},
+    ]
+
+
+def test_incubation_emitted_after_head_when_enabled():
+    """An enabled Incubation Stage is one setpoint, right after the head."""
+    steps = assemble_steps(_stages(incubation={"enabled": True, "temp": 37, "time": 600}))
+    assert steps[len(HEAD)] == {"setpoint": 37, "duration": 600, "description": "Incubation"}
+
+
+def test_initial_denaturation_emitted_when_enabled():
+    """An enabled Initial Denaturation Stage is one setpoint with that description."""
+    steps = assemble_steps(_stages(denaturation={"enabled": True, "temp": 95, "time": 120}))
+    assert steps[len(HEAD)] == {"setpoint": 95, "duration": 120, "description": "Initial Denaturation"}
+
+
+def test_final_temp_hold_emitted_before_tail_when_enabled():
+    """An enabled Final Temp Hold is one setpoint placed after amplification,
+    immediately before the cooldown tail."""
+    steps = assemble_steps(_stages(final_hold={"enabled": True, "temp": 25, "time": 60}))
+    assert steps[-len(TAIL) - 1] == {"setpoint": 25, "duration": 60, "description": "Final Temp Hold"}
+
+
+def test_disabled_optional_stages_emit_nothing():
+    """With Incubation/Denaturation/Final Hold all off, only head + amplification + tail remain."""
+    steps = assemble_steps(_stages(cycles=40))
+    assert steps == HEAD + [
+        {"ramp_rate": 1.75},
+        {"repeat": [
+            {"setpoint": 95, "duration": 11, "description": "Denaturation"},
+            {"setpoint": 60.5, "duration": 28, "description": "Annealing & Extension"},
+            {"optics": ""},
+            {"setpoint": 60.5, "duration": 10, "description": "Annealing & Extension"},
+        ], "cycles": 40},
+    ] + TAIL
+
+
+def test_full_profile_ordering_all_stages_enabled():
+    """End-to-end: head -> incubation -> denaturation -> amplification -> final hold -> tail."""
+    steps = assemble_steps(_stages(
+        incubation={"enabled": True, "temp": 37, "time": 600},
+        denaturation={"enabled": True, "temp": 95, "time": 120},
+        final_hold={"enabled": True, "temp": 25, "time": 60},
+        cycles=40,
+    ))
+    assert steps == HEAD + [
+        {"setpoint": 37, "duration": 600, "description": "Incubation"},
+        {"setpoint": 95, "duration": 120, "description": "Initial Denaturation"},
+        {"ramp_rate": 1.75},
+        {"repeat": [
+            {"setpoint": 95, "duration": 11, "description": "Denaturation"},
+            {"setpoint": 60.5, "duration": 28, "description": "Annealing & Extension"},
+            {"optics": ""},
+            {"setpoint": 60.5, "duration": 10, "description": "Annealing & Extension"},
+        ], "cycles": 40},
+        {"setpoint": 25, "duration": 60, "description": "Final Temp Hold"},
+    ] + TAIL


### PR DESCRIPTION
Closes #198 — A1: the pure `stages → steps` assembler.

## What this does
Adds `aquila_web/profile_assembly.py` with `assemble_steps(stages) -> list` — turns the structured `stages` object (from the #197 contract) into the full runnable `steps` array, weaving the fixed Boilerplate together with the user's enabled Stages.

- **Head/tail boilerplate** (equilibration, fan, optics init, entry/exit ramps `1.6`, cooldown).
- **Amplification:** `ramp 1.75` + `repeat{cycles}`; each sub-stage → setpoint; the **extension-bearing** sub-stage (last) is split `(time-10) → optics → 10` (ADR-018).
- **Optional Stages** (Incubation, Initial Denaturation, Final Temp Hold) emitted only when `enabled`; correct ordering head → incubation → denaturation → amplification → final hold → tail.
- Pure module, **no hardware imports** — unit-testable without stubbing.

## Spec / docs
- Spec: `specs/backend/spec_profile_step_assembly.md`
- PRD: `specs/prd/structured-profile-editor-prd.md` · ADR-018

## SPEC_WORKFLOW checklist
- [x] Spec file linked
- [x] Spec accurate to what was built
- [x] New tests written (11 unit tests, built RED→GREEN)
- [x] `pytest unit_tests/test_profile_assembly.py -v` → 11 passed
- [x] No regressions (only new files added; `main.py` untouched). The 3 pre-existing contract failures are environmental and unchanged from baseline.
- [x] No secrets in diff

## Out of scope (other issues)
Wiring into `POST /profiles` + list `structured` flag — A3 (#201). Range/shape validation — A2 (#199).

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)
