### PR TITLE
#200 Structured Profiles B1 — builder shell: Stages, checkboxes, save

### DIFF
--- a/aquila_web/static/profiles/builder.html
+++ b/aquila_web/static/profiles/builder.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=768, height=1024, initial-scale=1" />
   <title>Create Profile</title>
-  <link rel="stylesheet" href="/static/styles.css?v=219" />
+  <link rel="stylesheet" href="/static/styles.css?v=220" />
 </head>
 <body class="app-body">
   <div class="app-shell">
@@ -26,11 +26,140 @@
         </nav>
       </header>
       <div class="run-divider"></div>
-      <!-- Structured profile editor shell (issue #197). The Stage/Sub-stage UI,
-           validation, and save wiring are built in B1/B2/B3. -->
-      <div class="profile-form" id="profile-builder-root"></div>
+      <!-- Structured profile editor (issues #197 shell, #200 builder). Field
+           validation is B3; Amplification Sub-stage add/remove is B2. -->
+      <div class="profile-form" id="profile-builder-root">
+        <section class="card" id="builder-details">
+          <div class="field-grid">
+            <div class="field">
+              <label for="profile-name">Profile name</label>
+              <input id="profile-name" type="text" value="" />
+            </div>
+          </div>
+          <div class="field-grid">
+            <div class="field">
+              <label for="profile-fam-label">FAM Label</label>
+              <input id="profile-fam-label" type="text" value="FAM" />
+            </div>
+            <div class="field">
+              <label for="profile-rox-label">ROX Label</label>
+              <input id="profile-rox-label" type="text" value="ROX" />
+            </div>
+          </div>
+          <div class="field-grid">
+            <div class="field">
+              <label for="profile-estimated-minutes">Est. Time (Min)</label>
+              <input id="profile-estimated-minutes" type="number" inputmode="numeric" min="1" step="1" value="" placeholder="(Optional)" />
+            </div>
+          </div>
+        </section>
+
+        <section class="card stage" id="stage-incubation">
+          <header class="stage__header">
+            <label class="stage__toggle">
+              <input type="checkbox" id="stage-incubation-enabled" checked />
+              <span class="stage__title">Incubation</span>
+            </label>
+          </header>
+          <div class="field-grid">
+            <div class="field">
+              <label for="stage-incubation-temp">Temp (&deg;C)</label>
+              <input id="stage-incubation-temp" type="number" inputmode="numeric" value="" />
+            </div>
+            <div class="field">
+              <label for="stage-incubation-time">Time (s)</label>
+              <input id="stage-incubation-time" type="number" inputmode="numeric" value="" />
+            </div>
+          </div>
+        </section>
+
+        <section class="card stage" id="stage-denaturation">
+          <header class="stage__header">
+            <label class="stage__toggle">
+              <input type="checkbox" id="stage-denaturation-enabled" checked />
+              <span class="stage__title">Initial Denaturation</span>
+            </label>
+          </header>
+          <div class="field-grid">
+            <div class="field">
+              <label for="stage-denaturation-temp">Temp (&deg;C)</label>
+              <input id="stage-denaturation-temp" type="number" inputmode="numeric" value="" />
+            </div>
+            <div class="field">
+              <label for="stage-denaturation-time">Time (s)</label>
+              <input id="stage-denaturation-time" type="number" inputmode="numeric" value="" />
+            </div>
+          </div>
+        </section>
+
+        <section class="card stage" id="stage-amplification">
+          <header class="stage__header">
+            <span class="stage__title">Amplification</span>
+          </header>
+          <div class="field-grid">
+            <div class="field">
+              <label for="stage-amp-cycles">Cycles</label>
+              <input id="stage-amp-cycles" type="number" inputmode="numeric" value="" />
+            </div>
+          </div>
+          <div class="amp-substages">
+            <div class="amp-substage" data-sub="0">
+              <span class="amp-substage__name" id="stage-amp-sub-0-name">Denaturation</span>
+              <div class="field-grid">
+                <div class="field">
+                  <label for="stage-amp-sub-0-temp">Temp (&deg;C)</label>
+                  <input id="stage-amp-sub-0-temp" type="number" inputmode="numeric" value="" />
+                </div>
+                <div class="field">
+                  <label for="stage-amp-sub-0-time">Time (s)</label>
+                  <input id="stage-amp-sub-0-time" type="number" inputmode="numeric" value="" />
+                </div>
+              </div>
+            </div>
+            <div class="amp-substage" data-sub="1">
+              <span class="amp-substage__name" id="stage-amp-sub-1-name">Annealing &amp; Extension</span>
+              <div class="field-grid">
+                <div class="field">
+                  <label for="stage-amp-sub-1-temp">Temp (&deg;C)</label>
+                  <input id="stage-amp-sub-1-temp" type="number" inputmode="numeric" value="" />
+                </div>
+                <div class="field">
+                  <label for="stage-amp-sub-1-time">Time (s)</label>
+                  <input id="stage-amp-sub-1-time" type="number" inputmode="numeric" value="" />
+                </div>
+              </div>
+            </div>
+          </div>
+        </section>
+
+        <section class="card stage" id="stage-finalhold">
+          <header class="stage__header">
+            <label class="stage__toggle">
+              <input type="checkbox" id="stage-finalhold-enabled" checked />
+              <span class="stage__title">Final Temp Hold</span>
+            </label>
+          </header>
+          <div class="field-grid">
+            <div class="field">
+              <label for="stage-finalhold-temp">Temp (&deg;C)</label>
+              <input id="stage-finalhold-temp" type="number" inputmode="numeric" value="" />
+            </div>
+            <div class="field">
+              <label for="stage-finalhold-time">Time (s)</label>
+              <input id="stage-finalhold-time" type="number" inputmode="numeric" value="" />
+            </div>
+          </div>
+        </section>
+
+        <div class="button-row" id="builder-actions">
+          <button id="save-profile-button" class="form-action-btn form-action-btn--primary" type="button">Save profile</button>
+          <a class="form-action-btn" href="/profiles-page">Cancel</a>
+        </div>
+        <p id="save-status" class="page-header"></p>
+      </div>
     </main>
   </div>
   <script src="/static/nav.js?v=1"></script>
+  <script src="/static/profiles/builder.js?v=1"></script>
 </body>
 </html>

--- a/aquila_web/static/profiles/builder.js
+++ b/aquila_web/static/profiles/builder.js
@@ -1,0 +1,140 @@
+// Structured profile builder (issue #200, Structured Profiles B1).
+// The markup lives in builder.html; this script wires behavior: Stage enable
+// toggles (grey/disable while preserving values) and save. Field validation is
+// B3; Amplification Sub-stage add/remove is B2.
+(function () {
+  "use strict";
+
+  // Stages with an enable checkbox. Amplification is always present (no toggle).
+  var OPTIONAL_STAGES = ["incubation", "denaturation", "finalhold"];
+
+  function valueInputs(card) {
+    // Every editable value field in the card (temp/time) — never the checkbox.
+    return card.querySelectorAll("input:not([type=checkbox])");
+  }
+
+  // Reflect a Stage's checkbox into its card: greyed + inputs disabled when off.
+  // Disabling preserves the inputs' typed values, so re-enabling restores them.
+  function syncStage(key) {
+    var box = document.getElementById("stage-" + key + "-enabled");
+    var card = document.getElementById("stage-" + key);
+    if (!box || !card) return;
+    var enabled = box.checked;
+    card.classList.toggle("stage--disabled", !enabled);
+    valueInputs(card).forEach(function (input) {
+      input.disabled = !enabled;
+    });
+  }
+
+  // ---- Save -----------------------------------------------------------------
+
+  function text(id) {
+    var el = document.getElementById(id);
+    return el ? el.value.trim() : "";
+  }
+
+  // A numeric field's value as a Number, or null when blank/non-numeric. #200
+  // does not validate (that is B3) — it just carries whatever was typed.
+  function num(id) {
+    var el = document.getElementById(id);
+    if (!el) return null;
+    var raw = el.value.trim();
+    if (raw === "") return null;
+    var n = Number(raw);
+    return Number.isFinite(n) ? n : null;
+  }
+
+  function optionalStage(domKey) {
+    var box = document.getElementById("stage-" + domKey + "-enabled");
+    return {
+      enabled: box ? box.checked : true,
+      temp: num("stage-" + domKey + "-temp"),
+      time: num("stage-" + domKey + "-time"),
+    };
+  }
+
+  function subStage(index) {
+    var nameEl = document.getElementById("stage-amp-sub-" + index + "-name");
+    return {
+      name: nameEl ? nameEl.textContent.trim() : "",
+      temp: num("stage-amp-sub-" + index + "-temp"),
+      time: num("stage-amp-sub-" + index + "-time"),
+    };
+  }
+
+  function estimatedMinutes() {
+    var raw = text("profile-estimated-minutes");
+    if (raw === "") return null;
+    var parsed = Math.round(Number(raw));
+    return Number.isFinite(parsed) && parsed > 0 ? parsed : null;
+  }
+
+  // Build the POST body. All four stage keys are always present; an unchecked
+  // Stage rides along as enabled:false with its preserved values.
+  function buildPayload() {
+    return {
+      name: text("profile-name"),
+      fam_label: text("profile-fam-label"),
+      rox_label: text("profile-rox-label"),
+      estimated_minutes: estimatedMinutes(),
+      stages: {
+        incubation: optionalStage("incubation"),
+        denaturation: optionalStage("denaturation"),
+        amplification: {
+          cycles: num("stage-amp-cycles"),
+          subStages: [subStage(0), subStage(1)],
+        },
+        finalHold: optionalStage("finalhold"),
+      },
+    };
+  }
+
+  async function saveProfile() {
+    var status = document.getElementById("save-status");
+    if (status) status.textContent = "Saving...";
+    try {
+      var response = await fetch("/profiles", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(buildPayload()),
+      });
+      if (!response.ok) {
+        var err = {};
+        try {
+          err = await response.json();
+        } catch (e) {
+          /* non-JSON error body */
+        }
+        if (status) status.textContent = err.detail || "Failed to save";
+        return;
+      }
+      if (status) status.textContent = "Saved";
+      window.location.href = "/profiles-page";
+    } catch (e) {
+      if (status) status.textContent = "Failed to save";
+      console.error("Save failed", e);
+    }
+  }
+
+  // ---- Boot -----------------------------------------------------------------
+
+  function init() {
+    OPTIONAL_STAGES.forEach(function (key) {
+      var box = document.getElementById("stage-" + key + "-enabled");
+      if (!box) return;
+      box.addEventListener("change", function () {
+        syncStage(key);
+      });
+      syncStage(key); // sync initial state on load
+    });
+
+    var saveButton = document.getElementById("save-profile-button");
+    if (saveButton) saveButton.addEventListener("click", saveProfile);
+  }
+
+  if (document.readyState === "loading") {
+    document.addEventListener("DOMContentLoaded", init);
+  } else {
+    init();
+  }
+})();

--- a/aquila_web/static/styles.css
+++ b/aquila_web/static/styles.css
@@ -2682,6 +2682,47 @@ a:active {
   gap: 24px;
 }
 
+/* Structured builder Stages (issue #200). */
+.stage__header {
+  display: flex;
+  align-items: center;
+  margin-bottom: 12px;
+}
+
+.stage__toggle {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  cursor: pointer;
+}
+
+.stage__toggle input[type="checkbox"] {
+  width: 22px;
+  height: 22px;
+}
+
+.stage__title {
+  font-size: 16px;
+  font-weight: 600;
+}
+
+.amp-substage {
+  margin-top: 12px;
+}
+
+.amp-substage__name {
+  display: block;
+  font-size: 13px;
+  font-weight: 600;
+  margin-bottom: 8px;
+}
+
+/* An unchecked Stage greys out. Its inputs are also set [disabled] in JS, which
+   keeps their typed values so re-checking the Stage restores them. */
+.stage--disabled {
+  opacity: 0.5;
+}
+
 .field-grid {
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));

--- a/specs/frontend/spec_structured_builder_shell.md
+++ b/specs/frontend/spec_structured_builder_shell.md
@@ -1,0 +1,166 @@
+# Frontend / UI Spec: Structured Builder Shell — Stages, Checkboxes, Save (issue #200)
+
+**Status:** Active
+**Author:** Aquila Engineering Team
+**Last updated:** 2026-06-25
+**GitHub issue:** #200 (Structured Profiles B1)
+**Affected screens:** Create Profile (`/profiles/builder`)
+**Source file(s):** `aquila_web/static/profiles/builder.html`, `aquila_web/static/profiles/builder.js` (new), `aquila_web/static/styles.css`
+**Umbrella PRD:** `specs/prd/structured-profile-editor-prd.md` · **Decisions:** ADR-018, ADR-003 (plain HTML/JS, no build)
+**Depends on:** #197 (the `stages` contract + `/profiles/builder` route — merged)
+
+---
+
+## 1. Overview
+
+The structured profile builder's first vertical slice: render the fixed top fields and the four domain Stages into the editor shell (`#profile-builder-root`, served by `/profiles/builder` from #197), let the operator toggle the three optional Stages with checkboxes, and POST a `stages` payload that redirects to the Profiles list.
+
+This is the **shell only**. It deliberately does **not** validate fields, display "Invalid Value" errors, drive Amplification Sub-stage add/remove, or repopulate from an existing Profile — those are B3 (#202), B2 (#201/#199 area), and the edit/list-routing issues. The backend stores `stages` verbatim (#197); assembly into `steps` and `POST` validation are A1/A2/A3 and are not exercised here.
+
+Context: plain HTML/CSS/JS, no build step (ADR-003); Chromium kiosk on the Pi display, 768×1024 touch viewport (ADR-005).
+
+---
+
+## 2. Screen Inventory
+
+| Screen ID | Name | Entry condition | Exit conditions |
+|-----------|------|----------------|-----------------|
+| `builder` | Create Profile | Navigate to `/profiles/builder` (from Profiles list "Create" — wired later) | Save success → Profiles list; Back/Cancel → Profiles list |
+
+---
+
+## 3. State Machine Transitions
+
+```
+profiles-page --[Create]--> builder
+builder       --[Save success (POST /profiles 200)]--> profiles-page
+builder       --[Back ‹ / Cancel]--> profiles-page
+```
+
+No in-page screen states in B1 (validation error state is B3).
+
+---
+
+## 4. Screen Designs
+
+### Screen: `builder`
+
+Renders inside the existing shell's `<div class="profile-form" id="profile-builder-root">`. Reuses the existing form CSS vocabulary (`card`, `field-grid`, `field`, `form-action-btn`, `button-row`, `is-hidden`).
+
+**Layout (top → bottom):**
+
+1. **Details card** (`#builder-details`) — fixed top fields, mirroring `edit_form.html`:
+   - Profile name — `#profile-name` (text).
+   - FAM Label — `#profile-fam-label` (text, pre-filled `"FAM"`). ROX Label — `#profile-rox-label` (text, pre-filled `"ROX"`). *(Mirrors `edit_form.html`'s defaults — decided over a fully-blank form so a quick save still carries sensible channel labels. The "every field blank" rule in #200 applies to the thermal value fields below.)*
+   - Est. Time (Min) — `#profile-estimated-minutes` (number, `min="1"`, `placeholder="(Optional)"`). Retains the existing estimated-minutes behavior (blank ⇒ `null`).
+
+2. **Four Stage cards**, in order. Each optional Stage is a `card stage` with an enable checkbox in its header; Amplification has no checkbox.
+
+   | Stage | DOM id | Checkbox | Fields (all blank on fresh form) |
+   |-------|--------|----------|----------------------------------|
+   | Incubation | `#stage-incubation` | `#stage-incubation-enabled` (checked) | temp `#stage-incubation-temp`, time `#stage-incubation-time` |
+   | Initial Denaturation | `#stage-denaturation` | `#stage-denaturation-enabled` (checked) | temp `#stage-denaturation-temp`, time `#stage-denaturation-time` |
+   | Amplification | `#stage-amplification` | *(none — always present)* | cycles `#stage-amp-cycles`; 2 fixed Sub-stage rows (see below) |
+   | Final Temp Hold | `#stage-finalhold` | `#stage-finalhold-enabled` (checked) | temp `#stage-finalhold-temp`, time `#stage-finalhold-time` |
+
+   Temp/time/cycles inputs are `type="number"` `inputmode="numeric"`. Temp inputs carry the existing `keyboard-ignore`-style touch conventions as used elsewhere on the form (match `edit_form.html`).
+
+   **Amplification Sub-stages (B1 = static).** Two rows are rendered with fixed name **labels** "Denaturation" and "Annealing & Extension", each with a temp and a time input (`#stage-amp-sub-0-temp/-time`, `#stage-amp-sub-1-temp/-time`), blank on a fresh form. **No add/remove controls and no rename transitions in B1** (that is B2). Sub-stage names are display labels, not editable inputs.
+
+3. **Action row** (`button-row`): Save (`#save-profile-button`, primary) and Cancel (`<a href="/profiles-page">`). A `#save-status` line mirrors `edit_form.html`.
+
+**Fresh-form initial state:**
+- All three optional Stage checkboxes **checked (ON)**.
+- Name and estimate blank; FAM/ROX pre-filled `"FAM"`/`"ROX"`; all temps, all times, **and cycles** blank.
+- No error styling anywhere (no `field-error` shown; no red borders).
+
+**User interactions:**
+- Toggle a Stage checkbox OFF → the Stage card greys out (`.stage--disabled`) and **all its inputs get `disabled`**. The typed values are **kept in the DOM** (not cleared).
+- Toggle it back ON → card un-greys, inputs re-enabled, previously typed values intact.
+- Tap Save → build the `stages` payload (§5), `POST /profiles`, and on `200` redirect to `/profiles-page`.
+
+**Error states (B1):** none rendered. A non-200 from `POST /profiles` sets `#save-status` to the response `detail` (or "Failed to save") and does **not** navigate — same failure handling as `edit.js`. Field-level "Invalid Value" highlighting is B3.
+
+---
+
+## 5. Data Binding
+
+### Save payload — `POST /profiles`
+
+Body (no `steps` — backend assembles those in A1/A3):
+
+```json
+{
+  "name": "<#profile-name>",
+  "fam_label": "<#profile-fam-label>",
+  "rox_label": "<#profile-rox-label>",
+  "estimated_minutes": <int|null>,
+  "stages": {
+    "incubation":   { "enabled": <bool>, "temp": <number|null>, "time": <number|null> },
+    "denaturation": { "enabled": <bool>, "temp": <number|null>, "time": <number|null> },
+    "amplification": {
+      "cycles": <number|null>,
+      "subStages": [
+        { "name": "Denaturation",          "temp": <number|null>, "time": <number|null> },
+        { "name": "Annealing & Extension", "temp": <number|null>, "time": <number|null> }
+      ]
+    },
+    "finalHold":    { "enabled": <bool>, "temp": <number|null>, "time": <number|null> }
+  }
+}
+```
+
+Binding rules:
+- `enabled` = the Stage checkbox's `checked` state. **All four stage keys are always present**; an unchecked Stage is sent with `enabled: false` (its preserved temp/time still ride along).
+- Numeric fields: read `input.value`; an empty string ⇒ `null`, otherwise `Number(value)`. **No range/NaN validation in B1** (B3). The happy-path save uses in-range numeric values.
+- `estimated_minutes`: reuse the existing rule — blank ⇒ `null`, else a positive integer (`Math.round(Number(...))`).
+- `amplification.subStages` is always length 2 in B1 with the fixed names above.
+
+### Redirect
+On `response.ok`, `window.location.href = "/profiles-page"` (matches `edit.js`).
+
+---
+
+## 6. Accessibility / Kiosk Constraints
+
+- Touch targets ≥ 44×44px; checkboxes sized for touch.
+- No hover-only affordances.
+- Disabled-Stage state must be visually obvious (greyed) and the inputs non-interactive (`disabled`), readable at arm's length on the 768×1024 display.
+
+---
+
+## 7. Assets
+
+| Asset | Path | Notes |
+|-------|------|-------|
+| Builder shell | `aquila_web/static/profiles/builder.html` | Exists (#197); B1 fills `#profile-builder-root` and adds the `builder.js` script tag. |
+| Builder script | `aquila_web/static/profiles/builder.js` | New. |
+| Stage-disabled styling | `aquila_web/static/styles.css` | New `.stage--disabled` rule (grey + dim). |
+
+---
+
+## 8. Acceptance Criteria
+
+- [ ] `GET /profiles/builder` renders the four Stage cards and the top fields into `#profile-builder-root`.
+- [ ] Fresh form: all three optional Stages checked ON, thermal value fields (temps/times/cycles) blank, FAM/ROX pre-filled, no error styling shown.
+- [ ] Unchecking a Stage greys it and disables its inputs; re-checking restores the previously typed values.
+- [ ] An unchecked Stage is sent as `enabled: false` in the `stages` payload; all four stage keys always present.
+- [ ] A valid Save POSTs the `stages` shape in §5 and redirects to `/profiles-page`.
+- [ ] Plain HTML/CSS/JS, no build step (ADR-003); no change to `aquila_web/main.py`.
+- [ ] e2e test `tests/e2e/test_profile_builder.py` (marked `e2e`) covers: default state, toggle/preserve, happy-path save. Prior art: `test_countdown_timer.py`, `test_run_dropdowns.py`.
+
+---
+
+## Out of Scope (other issues, other specs)
+
+- Field validation, "Invalid Value" red highlighting, save-blocking — B3 (#202).
+- Amplification Sub-stage add/remove, the 2↔3 rename transitions, and the 2–3 bound — B2.
+- Repopulating the builder from an existing structured Profile on edit — later frontend issue.
+- Profiles-list routing by the `structured` flag and the Legacy read-only view — later frontend issue.
+- Backend `stages → steps` assembly and `POST` validation — A1 (#198) / A2 (#199) / A3 (#201).
+
+---
+
+## 9. Open Questions
+
+- [ ] None — contract and scope resolved in ADR-018 and the PRD.

--- a/tests/e2e/test_profile_builder.py
+++ b/tests/e2e/test_profile_builder.py
@@ -1,0 +1,159 @@
+"""
+E2E tests for the structured profile builder shell (issue #200, Structured Profiles B1).
+
+Covers the builder's observable DOM behavior at the page seam: the fresh-form
+default state, the checkbox toggle that greys/disables a Stage while preserving
+its values, and the happy-path save that POSTs a `stages` payload and redirects.
+Field-level validation (B3) and Amplification Sub-stage add/remove (B2) are out
+of scope here.
+
+Requires a running backend at base_url (default http://localhost:8090; override
+with AQUILA_TEST_URL). Run with: pytest -m e2e tests/e2e/test_profile_builder.py
+Prior art: tests/e2e/test_countdown_timer.py, tests/e2e/test_run_dropdowns.py
+"""
+import pytest
+
+pytestmark = pytest.mark.e2e
+
+# Optional Stages carry an enable checkbox; Amplification is always present.
+OPTIONAL_STAGES = ("incubation", "denaturation", "finalhold")
+ALL_STAGES = ("incubation", "denaturation", "amplification", "finalhold")
+
+
+def _goto_builder(page, base_url):
+    """Navigate to the builder; skip if the backend isn't reachable."""
+    try:
+        page.goto(f"{base_url}/profiles/builder", timeout=10_000)
+    except Exception as exc:
+        pytest.skip(f"Backend not reachable at {base_url}: {exc}")
+    page.wait_for_load_state("domcontentloaded")
+    # The builder renders its Stages from JS; wait for the first card to attach.
+    page.wait_for_selector("#stage-incubation", state="attached", timeout=5_000)
+
+
+def test_fresh_builder_default_state(page, base_url):
+    """A fresh builder shows all four Stages, optional ones checked ON, every
+    thermal field blank, and no validation error styling."""
+    _goto_builder(page, base_url)
+
+    # All four Stage cards are rendered.
+    for stage in ALL_STAGES:
+        assert page.locator(f"#stage-{stage}").count() == 1, f"#stage-{stage} missing"
+
+    # The three optional Stages open checked ON; Amplification has no checkbox.
+    for stage in OPTIONAL_STAGES:
+        assert page.locator(f"#stage-{stage}-enabled").is_checked(), (
+            f"{stage} should default checked ON"
+        )
+    assert page.locator("#stage-amplification-enabled").count() == 0, (
+        "Amplification must not have an enable checkbox"
+    )
+
+    # Every thermal value field is blank on a fresh form, including cycles.
+    blank_fields = [
+        "#stage-incubation-temp", "#stage-incubation-time",
+        "#stage-denaturation-temp", "#stage-denaturation-time",
+        "#stage-amp-cycles",
+        "#stage-amp-sub-0-temp", "#stage-amp-sub-0-time",
+        "#stage-amp-sub-1-temp", "#stage-amp-sub-1-time",
+        "#stage-finalhold-temp", "#stage-finalhold-time",
+    ]
+    for sel in blank_fields:
+        assert page.locator(sel).input_value() == "", f"{sel} should start blank"
+
+    # No error styling shown on a fresh form.
+    assert page.locator(".field-error:visible").count() == 0, "no errors on fresh form"
+
+
+def test_unchecking_stage_greys_and_disables_its_fields(page, base_url):
+    """Unchecking a Stage greys its card and disables its inputs."""
+    _goto_builder(page, base_url)
+
+    card = page.locator("#stage-incubation")
+    temp = page.locator("#stage-incubation-temp")
+    time = page.locator("#stage-incubation-time")
+
+    # Starts enabled: not greyed, inputs editable.
+    assert "stage--disabled" not in (card.get_attribute("class") or "")
+    assert temp.is_enabled() and time.is_enabled()
+
+    page.locator("#stage-incubation-enabled").uncheck()
+
+    assert "stage--disabled" in (card.get_attribute("class") or ""), (
+        "unchecked Stage card should be greyed via .stage--disabled"
+    )
+    assert temp.is_disabled() and time.is_disabled(), (
+        "unchecked Stage inputs should be disabled"
+    )
+
+
+def test_rechecking_stage_preserves_typed_values(page, base_url):
+    """Values typed into a Stage survive an uncheck/re-check round trip."""
+    _goto_builder(page, base_url)
+
+    page.locator("#stage-incubation-temp").fill("37")
+    page.locator("#stage-incubation-time").fill("600")
+
+    page.locator("#stage-incubation-enabled").uncheck()
+    page.locator("#stage-incubation-enabled").check()
+
+    # Re-enabled inputs keep what was typed before the toggle.
+    assert page.locator("#stage-incubation-temp").input_value() == "37"
+    assert page.locator("#stage-incubation-time").input_value() == "600"
+    assert page.locator("#stage-incubation-temp").is_enabled()
+
+
+def test_valid_save_posts_stages_and_redirects(page, base_url):
+    """A valid Save POSTs the expected `stages` shape and redirects to the list.
+
+    Final Temp Hold is unchecked, so it must ride along as enabled:false while
+    the other Stages carry their typed temps/times. All four stage keys are
+    always present.
+    """
+    _goto_builder(page, base_url)
+
+    page.locator("#profile-name").fill("B1 Happy Path")
+
+    page.locator("#stage-incubation-temp").fill("37")
+    page.locator("#stage-incubation-time").fill("600")
+    page.locator("#stage-denaturation-temp").fill("95")
+    page.locator("#stage-denaturation-time").fill("120")
+    page.locator("#stage-amp-cycles").fill("40")
+    page.locator("#stage-amp-sub-0-temp").fill("95")
+    page.locator("#stage-amp-sub-0-time").fill("11")
+    page.locator("#stage-amp-sub-1-temp").fill("60")
+    page.locator("#stage-amp-sub-1-time").fill("38")
+    page.locator("#stage-finalhold-temp").fill("25")
+    page.locator("#stage-finalhold-time").fill("60")
+    page.locator("#stage-finalhold-enabled").uncheck()
+
+    def is_save_post(req):
+        return req.url.rstrip("/").endswith("/profiles") and req.method == "POST"
+
+    with page.expect_request(is_save_post) as req_info, \
+            page.expect_response(lambda r: is_save_post(r.request)) as resp_info:
+        page.locator("#save-profile-button").click()
+
+    payload = req_info.value.post_data_json
+    stages = payload["stages"]
+
+    assert payload["name"] == "B1 Happy Path"
+    assert stages["incubation"] == {"enabled": True, "temp": 37, "time": 600}
+    assert stages["denaturation"] == {"enabled": True, "temp": 95, "time": 120}
+    assert stages["finalHold"]["enabled"] is False
+    amp = stages["amplification"]
+    assert amp["cycles"] == 40
+    assert [s["name"] for s in amp["subStages"]] == ["Denaturation", "Annealing & Extension"]
+    assert amp["subStages"][0] == {"name": "Denaturation", "temp": 95, "time": 11}
+    assert amp["subStages"][1] == {"name": "Annealing & Extension", "temp": 60, "time": 38}
+
+    # Save succeeded and the browser returned to the Profiles list.
+    assert resp_info.value.status == 200
+    page.wait_for_url("**/profiles-page", timeout=5_000)
+
+    # Clean up: the redirect discards the response body, so find the created
+    # profile by its sanitized id in the listing and delete it.
+    listing = page.request.get(f"{base_url}/profiles").json()
+    stale = [p["id"] for p in listing if "B1_Happy_Path" in p.get("id", "")]
+    if stale:
+        page.request.post(f"{base_url}/profiles/delete", data={"profiles": stale})


### PR DESCRIPTION
Closes #200 — the structured profile builder **shell** (Dev B, frontend route). Builds on the `stages` contract from #197 (merged).

## What this does
Fills the `/profiles/builder` page (shell + route shipped in #197) with the structured editor's first vertical slice — the fixed top fields and the four domain Stages, able to POST a `stages` payload.

- **Top fields:** Profile name, FAM/ROX labels, optional Est. Time (Min) (retains existing `estimated_minutes` behavior).
- **Four Stages:** Incubation, Initial Denaturation, Final Temp Hold (each checkbox-toggled, default ON), plus Amplification (always present) with a cycle count and two static Sub-stage rows.
- **Toggle + preserve:** unchecking a Stage greys it (`.stage--disabled`) and disables its inputs **while preserving the typed values** (re-checking restores them).
- **Save:** POSTs `{name, fam_label, rox_label, estimated_minutes, stages}` and redirects to the Profiles list. All four stage keys always present; an unchecked Stage rides along as `enabled: false`.

**No `main.py` change** — pure frontend, so this stays disjoint from the A1/A2/A3 backend branches.

## Spec / docs
- Spec: `specs/frontend/spec_structured_builder_shell.md`
- PRD: `specs/prd/structured-profile-editor-prd.md` · ADR-018, ADR-003 (plain HTML/JS, no build)

## Tests
`tests/e2e/test_profile_builder.py` (Playwright, marked `e2e`) — **4 passing** against a local server:
- `test_fresh_builder_default_state` — Stages render, optional ones checked ON, thermal fields blank, no error styling.
- `test_unchecking_stage_greys_and_disables_its_fields`
- `test_rechecking_stage_preserves_typed_values`
- `test_valid_save_posts_stages_and_redirects` — asserts the `stages` shape (incl. `finalHold.enabled: false`) and redirect.

Built TDD, one RED→GREEN slice at a time. Countdown e2e still passes (no shared-CSS regression).

## Out of scope (other issues)
- Field validation / "Invalid Value" highlighting — **B3**.
- Amplification Sub-stage add/remove + rename transitions — **B2**.
- Repopulate-on-edit and Profiles-list routing by the `structured` flag — later frontend issues.
- Backend `stages → steps` assembly + POST validation — **A1/A2/A3**.

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)