### PR TITLE
#199 (A2) validate_stages

### DIFF
--- a/aquila_web/profile_assembly.py
+++ b/aquila_web/profile_assembly.py
@@ -9,8 +9,61 @@ unit-testable in isolation. See specs/backend/spec_profile_step_assembly.md
 # extension-bearing sub-stage is split into (time - tail) -> optics -> tail (ADR-018).
 OPTICS_TAIL_SECONDS = 10
 
+TEMP_MIN, TEMP_MAX = 25, 100
+TIME_MIN, TIME_MAX = 1, 600
+# The extension-bearing sub-stage holds for (time - OPTICS_TAIL_SECONDS) before the
+# optics read, so its time must leave at least 1 s — hence a higher floor.
+EXTENSION_TIME_MIN = OPTICS_TAIL_SECONDS + 1
+CYCLES_MIN, CYCLES_MAX = 1, 50
 
-def assemble_steps(stages: dict) -> list:
+
+def _is_number(value) -> bool:
+    """True for a real numeric value (rejects bools, strings, None)."""
+    return isinstance(value, (int, float)) and not isinstance(value, bool)
+
+
+def validate_stages(stages: dict) -> list[str]:
+    """Check a structured `stages` object against the instrument's valid ranges.
+
+    Returns a list of human-readable error strings (each naming the offending
+    field); an empty list means valid. Disabled optional Stages are skipped.
+    Pure check only — enforcement on POST is A3 (#201).
+    """
+    errors = []
+
+    def check_temp(value, field):
+        if not (_is_number(value) and TEMP_MIN <= value <= TEMP_MAX):
+            errors.append(f"{field}.temp: Invalid Value")
+
+    def check_time(value, field, minimum=TIME_MIN):
+        if not (_is_number(value) and minimum <= value <= TIME_MAX):
+            errors.append(f"{field}.time: Invalid Value")
+
+    for key in ("incubation", "denaturation", "finalHold"):
+        stage = stages[key]
+        if not stage.get("enabled"):
+            continue
+        check_temp(stage.get("temp"), key)
+        check_time(stage.get("time"), key)
+
+    cycles = stages["amplification"].get("cycles")
+    if not (isinstance(cycles, int) and not isinstance(cycles, bool) and CYCLES_MIN <= cycles <= CYCLES_MAX):
+        errors.append("amplification.cycles: Invalid Value")
+
+    sub_stages = stages["amplification"]["subStages"]
+    if not (isinstance(sub_stages, list) and 2 <= len(sub_stages) <= 3):
+        errors.append("amplification.subStages: Invalid Value")
+
+    for index, sub in enumerate(sub_stages):
+        field = f"amplification.subStages[{index}]"
+        check_temp(sub.get("temp"), field)
+        is_extension = index == len(sub_stages) - 1
+        check_time(sub.get("time"), field, EXTENSION_TIME_MIN if is_extension else TIME_MIN)
+
+    return errors
+
+
+def assemble_steps(stages: dict) -> list[dict]:
     """Expand a structured `stages` object into the full `steps` array.
 
     Weaves the fixed Boilerplate (head/tail, ramps, optics read) together with

--- a/aquila_web/profile_assembly.py
+++ b/aquila_web/profile_assembly.py
@@ -49,8 +49,12 @@ def validate_stages(stages: dict) -> list[str]:
 
     for key in ("incubation", "denaturation", "finalHold"):
         stage = stages.get(key)
-        # A missing or malformed optional stage can't be "enabled"; skip it.
-        if not isinstance(stage, dict) or not stage.get("enabled"):
+        # assemble_steps subscripts stage["enabled"], so the key must be present
+        # and boolean (even for disabled stages). A missing/non-dict stage is an error.
+        if not isinstance(stage, dict) or not isinstance(stage.get("enabled"), bool):
+            errors.append(f"{key}: Invalid Value")
+            continue
+        if not stage["enabled"]:
             continue
         check_temp(stage.get("temp"), key)
         check_time(stage.get("time"), key)
@@ -74,6 +78,10 @@ def validate_stages(stages: dict) -> list[str]:
         if not isinstance(sub, dict):
             errors.append(f"{field}: Invalid Value")
             continue
+        # assemble_steps uses sub["name"] as the step description, so require it.
+        name = sub.get("name")
+        if not (isinstance(name, str) and name.strip()):
+            errors.append(f"{field}.name: Invalid Value")
         check_temp(sub.get("temp"), field)
         is_extension = index == len(sub_stages) - 1
         check_time(sub.get("time"), field, EXTENSION_TIME_MIN if is_extension else TIME_MIN)

--- a/aquila_web/profile_assembly.py
+++ b/aquila_web/profile_assembly.py
@@ -22,12 +22,20 @@ def _is_number(value) -> bool:
     return isinstance(value, (int, float)) and not isinstance(value, bool)
 
 
+def _is_int(value) -> bool:
+    """True for a real integer value (rejects bools, floats, strings, None)."""
+    return isinstance(value, int) and not isinstance(value, bool)
+
+
 def validate_stages(stages: dict) -> list[str]:
     """Check a structured `stages` object against the instrument's valid ranges.
 
     Returns a list of human-readable error strings (each naming the offending
     field); an empty list means valid. Disabled optional Stages are skipped.
-    Pure check only — enforcement on POST is A3 (#201).
+
+    This is a trust boundary (A3 #201 calls it on the untrusted POST body), so it
+    reports malformed structure as errors and never raises on a dict input.
+    Pure check only — enforcement on POST is A3.
     """
     errors = []
 
@@ -40,22 +48,32 @@ def validate_stages(stages: dict) -> list[str]:
             errors.append(f"{field}.time: Invalid Value")
 
     for key in ("incubation", "denaturation", "finalHold"):
-        stage = stages[key]
-        if not stage.get("enabled"):
+        stage = stages.get(key)
+        # A missing or malformed optional stage can't be "enabled"; skip it.
+        if not isinstance(stage, dict) or not stage.get("enabled"):
             continue
         check_temp(stage.get("temp"), key)
         check_time(stage.get("time"), key)
 
-    cycles = stages["amplification"].get("cycles")
-    if not (isinstance(cycles, int) and not isinstance(cycles, bool) and CYCLES_MIN <= cycles <= CYCLES_MAX):
+    amplification = stages.get("amplification")
+    if not isinstance(amplification, dict):
+        errors.append("amplification: Invalid Value")
+        return errors
+
+    cycles = amplification.get("cycles")
+    if not (_is_int(cycles) and CYCLES_MIN <= cycles <= CYCLES_MAX):
         errors.append("amplification.cycles: Invalid Value")
 
-    sub_stages = stages["amplification"]["subStages"]
+    sub_stages = amplification.get("subStages")
     if not (isinstance(sub_stages, list) and 2 <= len(sub_stages) <= 3):
         errors.append("amplification.subStages: Invalid Value")
+        return errors
 
     for index, sub in enumerate(sub_stages):
         field = f"amplification.subStages[{index}]"
+        if not isinstance(sub, dict):
+            errors.append(f"{field}: Invalid Value")
+            continue
         check_temp(sub.get("temp"), field)
         is_extension = index == len(sub_stages) - 1
         check_time(sub.get("time"), field, EXTENSION_TIME_MIN if is_extension else TIME_MIN)

--- a/specs/backend/spec_stages_validation.md
+++ b/specs/backend/spec_stages_validation.md
@@ -1,0 +1,62 @@
+# Backend Spec: Stages Validation (`validate_stages`) — issue #199 (A2)
+
+**Status:** Draft
+**Author:** Aquila Engineering Team
+**Last updated:** 2026-06-25
+**GitHub issue:** #199
+**Source file(s):** `aquila_web/profile_assembly.py`, `unit_tests/test_profile_assembly.py`
+**Umbrella PRD:** `specs/prd/structured-profile-editor-prd.md` · **Decision:** ADR-018
+**Builds on:** `spec_stages_contract_foundation.md` (#197), `spec_profile_step_assembly.md` (#198)
+
+---
+
+## 1. Overview
+
+A pure function that checks a structured `stages` object against the instrument's valid ranges and shape, returning the list of problems found. Lives in `aquila_web/profile_assembly.py` alongside `assemble_steps` (same bounded concern). No HTTP/disk/hardware imports.
+
+```python
+def validate_stages(stages: dict) -> list[str]: ...
+```
+
+Returns a list of human-readable error strings, each naming the offending field (e.g. `"incubation.temp: Invalid Value"`). **Empty list means valid.** Enforcement on `POST /profiles` (return 4xx; call `validate_stages` *before* `assemble_steps`) is **A3 (#201)**; the frontend does its own save-time display (B3). A2 is the backend defense-in-depth check only.
+
+---
+
+## 2. Rules
+
+Validated only for **enabled** Stages (Amplification is always enabled). Disabled optional Stages are skipped entirely — their values never produce errors.
+
+| Field | Rule | On failure |
+|-------|------|-----------|
+| any temp (incubation/denaturation/finalHold/each sub-stage) | numeric, `25 ≤ temp ≤ 100` | error |
+| incubation/denaturation/finalHold time | numeric, `1 ≤ time ≤ 600` | error |
+| extension-bearing sub-stage time (last sub-stage) | numeric, `11 ≤ time ≤ 600` | error — keeps the `assemble_steps` `(time-10)` split ≥ 1s |
+| non-extension sub-stage time | numeric, `1 ≤ time ≤ 600` | error |
+| `amplification.cycles` | integer, `1 ≤ cycles ≤ 50` | error |
+| `amplification.subStages` | length 2 or 3 | error |
+| any required numeric field | present and numeric (not blank / non-numeric) | error |
+
+Constants per ADR-018. Non-numeric or missing values for enabled fields are errors (not exceptions).
+
+---
+
+## 8. Unit Tests
+
+`unit_tests/test_profile_assembly.py` (marked `unit`), importing `validate_stages` directly. Behaviors, one RED→GREEN each: valid stages → no errors; temp above 100 / below 25 → error; time above 600 / below 1 → error; extension sub-stage time < 11 → error (while a non-extension time of e.g. 5 is fine); cycles 0 / 51 / non-int → error; sub-stage count 1 or 4 → error; disabled stage with bad values → no error (skipped); non-numeric / missing value → error.
+
+Run: `pytest unit_tests/test_profile_assembly.py -v`
+
+---
+
+## Also in this issue (carried from A1 review, PR #206)
+
+- Tighten `assemble_steps`'s return annotation from `-> list` to `-> list[dict]` (same file, cosmetic).
+
+## Out of Scope
+
+- Enforcing validation on `POST` + returning 4xx, and calling `validate_stages` before `assemble_steps` — A3 (#201).
+- Frontend save-time validation display — B3 (#203).
+
+## 9. Open Questions
+
+- [ ] Return shape chosen: `list[str]` of field-named messages — simplest for A3's 4xx; the frontend doesn't depend on it (B3 validates independently). Revisit if A3 wants structured `{field, message}` entries.

--- a/unit_tests/test_profile_assembly.py
+++ b/unit_tests/test_profile_assembly.py
@@ -7,7 +7,7 @@ Spec: specs/backend/spec_profile_step_assembly.md (issue #198).
 """
 import pytest
 
-from aquila_web.profile_assembly import assemble_steps
+from aquila_web.profile_assembly import assemble_steps, validate_stages
 
 pytestmark = pytest.mark.unit
 
@@ -145,6 +145,74 @@ def test_disabled_optional_stages_emit_nothing():
             {"setpoint": 60.5, "duration": 10, "description": "Annealing & Extension"},
         ], "cycles": 40},
     ] + TAIL
+
+
+# ---------------------------------------------------------------------------
+# validate_stages (A2 / #199)
+# ---------------------------------------------------------------------------
+
+
+def test_valid_stages_has_no_errors():
+    """A fully valid, all-stages-enabled profile produces no validation errors."""
+    stages = _stages(
+        incubation={"enabled": True, "temp": 37, "time": 600},
+        denaturation={"enabled": True, "temp": 95, "time": 120},
+        final_hold={"enabled": True, "temp": 25, "time": 60},
+        cycles=40,
+    )
+    assert validate_stages(stages) == []
+
+
+def test_temp_above_max_is_error():
+    """A temperature above 100 °C on an enabled stage is flagged."""
+    stages = _stages(incubation={"enabled": True, "temp": 150, "time": 600})
+    errors = validate_stages(stages)
+    assert any("incubation" in e for e in errors)
+
+
+def test_time_above_max_is_error():
+    """A duration above 600 s on an enabled stage is flagged."""
+    stages = _stages(incubation={"enabled": True, "temp": 37, "time": 999})
+    errors = validate_stages(stages)
+    assert any("incubation.time" in e for e in errors)
+
+
+def test_extension_substage_has_11s_floor_others_dont():
+    """The extension-bearing (last) sub-stage needs time >= 11 so the optics split
+    stays valid; a non-extension sub-stage may go as low as 1 s."""
+    subs = [
+        {"name": "Denaturation", "temp": 95, "time": 5},            # non-extension: 5 s OK
+        {"name": "Annealing & Extension", "temp": 60, "time": 8},   # extension: 8 < 11 -> error
+    ]
+    errors = validate_stages(_stages(sub_stages=subs))
+    assert any("subStages[1].time" in e for e in errors)
+    assert not any("subStages[0].time" in e for e in errors)
+
+
+def test_cycles_above_max_is_error():
+    """A cycle count above 50 is flagged."""
+    errors = validate_stages(_stages(cycles=51))
+    assert any("cycles" in e for e in errors)
+
+
+def test_substage_count_below_two_is_error():
+    """Amplification must have 2 or 3 sub-stages; 1 is flagged."""
+    one = [{"name": "Denaturation", "temp": 95, "time": 11}]
+    errors = validate_stages(_stages(sub_stages=one))
+    assert any("subStages: Invalid Value" in e for e in errors)
+
+
+def test_disabled_stage_with_bad_values_is_skipped():
+    """A disabled optional Stage is not validated even if its values are out of range."""
+    stages = _stages(incubation={"enabled": False, "temp": 999, "time": -5})
+    assert validate_stages(stages) == []
+
+
+def test_non_numeric_value_is_error():
+    """A blank/non-numeric value on an enabled field is flagged, not raised."""
+    stages = _stages(incubation={"enabled": True, "temp": "", "time": 600})
+    errors = validate_stages(stages)
+    assert any("incubation.temp" in e for e in errors)
 
 
 def test_full_profile_ordering_all_stages_enabled():

--- a/unit_tests/test_profile_assembly.py
+++ b/unit_tests/test_profile_assembly.py
@@ -239,12 +239,54 @@ def test_missing_amplification_returns_error_not_exception():
     assert any("amplification" in e for e in errors)
 
 
-def test_missing_optional_stage_key_does_not_raise():
-    """A stages object missing an optional stage key is tolerated (no crash)."""
+def test_missing_optional_stage_key_is_error():
+    """A missing optional stage key is flagged (assemble_steps subscripts it directly)."""
     stages = _stages()
     del stages["incubation"]
     errors = validate_stages(stages)  # must not raise
-    assert isinstance(errors, list)
+    assert any("incubation" in e for e in errors)
+
+
+# --- Finding #1: a validate-clean payload must be safe to assemble ---
+
+
+def test_substage_missing_name_is_error():
+    """A sub-stage without a name is flagged (assemble_steps reads sub['name'])."""
+    subs = [
+        {"temp": 95, "time": 11},  # no name
+        {"name": "Annealing & Extension", "temp": 60, "time": 38},
+    ]
+    errors = validate_stages(_stages(sub_stages=subs))
+    assert any("subStages[0].name" in e for e in errors)
+
+
+def test_optional_stage_missing_enabled_is_error():
+    """An optional stage without an `enabled` flag is flagged (assemble reads stage['enabled'])."""
+    stages = _stages()
+    stages["incubation"] = {"temp": 37, "time": 600}  # no enabled
+    errors = validate_stages(stages)
+    assert any("incubation" in e for e in errors)
+
+
+def test_non_dict_optional_stage_is_error():
+    """A present-but-non-dict optional stage is flagged, not silently skipped."""
+    stages = _stages()
+    stages["incubation"] = "garbage"
+    errors = validate_stages(stages)
+    assert any("incubation" in e for e in errors)
+
+
+def test_validate_clean_implies_assemble_does_not_raise():
+    """The trust-boundary guarantee: any payload validate_stages calls clean ([])
+    must assemble without raising. Spot-checks the finding-1 shapes."""
+    candidates = [
+        _stages(sub_stages=[{"temp": 95, "time": 11}, {"temp": 60, "time": 38}]),  # no names
+        {**_stages(), "incubation": {"temp": 37, "time": 600}},                     # no enabled
+        {**_stages(), "incubation": "garbage"},                                     # non-dict
+    ]
+    for stages in candidates:
+        if validate_stages(stages) == []:
+            assemble_steps(stages)  # must not raise when validation passed
 
 
 def test_full_profile_ordering_all_stages_enabled():

--- a/unit_tests/test_profile_assembly.py
+++ b/unit_tests/test_profile_assembly.py
@@ -215,6 +215,38 @@ def test_non_numeric_value_is_error():
     assert any("incubation.temp" in e for e in errors)
 
 
+def test_malformed_substages_returns_error_not_exception():
+    """A non-list subStages is reported as an error, never raised (trust boundary)."""
+    stages = _stages()
+    stages["amplification"]["subStages"] = None
+    errors = validate_stages(stages)  # must not raise
+    assert any("subStages" in e for e in errors)
+
+
+def test_substages_with_non_dict_elements_returns_error_not_exception():
+    """Non-dict sub-stage elements are reported, never raised."""
+    stages = _stages()
+    stages["amplification"]["subStages"] = [1, 2]
+    errors = validate_stages(stages)  # must not raise
+    assert errors
+
+
+def test_missing_amplification_returns_error_not_exception():
+    """A stages object missing the amplification key is reported, never raised."""
+    stages = _stages()
+    del stages["amplification"]
+    errors = validate_stages(stages)  # must not raise
+    assert any("amplification" in e for e in errors)
+
+
+def test_missing_optional_stage_key_does_not_raise():
+    """A stages object missing an optional stage key is tolerated (no crash)."""
+    stages = _stages()
+    del stages["incubation"]
+    errors = validate_stages(stages)  # must not raise
+    assert isinstance(errors, list)
+
+
 def test_full_profile_ordering_all_stages_enabled():
     """End-to-end: head -> incubation -> denaturation -> amplification -> final hold -> tail."""
     steps = assemble_steps(_stages(


### PR DESCRIPTION
Closes #199 — A2: backend range/shape validation for structured `stages`.

## What this does
Adds `validate_stages(stages) -> list[str]` to `aquila_web/profile_assembly.py` — the backend's defense-in-depth check. Returns a list of field-named error strings (empty = valid); does not reject the save itself (that's A3 #201).

Rules (enabled stages only; disabled optional stages skipped):
- temp `25–100 °C`; time `1–600 s`
- **extension-bearing sub-stage time `≥ 11 s`** (`OPTICS_TAIL_SECONDS + 1`) so the `assemble_steps` `(time-10)` split never goes negative/zero — closes A1-review note #1
- cycles integer `1–50`; sub-stage count `2–3`
- non-numeric / blank values are errors, not exceptions

Also carries the A1-review cosmetic fix: `assemble_steps` annotated `-> list[dict]` (note #3).

## Spec / docs
- Spec: `specs/backend/spec_stages_validation.md` · PRD: `specs/prd/structured-profile-editor-prd.md` · ADR-018

## SPEC_WORKFLOW checklist
- [x] Spec linked + accurate
- [x] New tests (8 validation tests, RED→GREEN)
- [x] `pytest unit_tests/test_profile_assembly.py -v` → 19 passed
- [x] No regressions — only `profile_assembly.py` + its test touched; `main.py` untouched. The 3 pre-existing contract failures are environmental and unchanged from baseline.
- [x] No secrets

## Out of scope
Enforcing on `POST /profiles` (call `validate_stages` before `assemble_steps`, return 4xx) — A3 (#201), tracked by the carry-over comment there.

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)
