### PR TITLE
#201 (A3) wire stages validation + assembly into endpoints

### DIFF
--- a/aquila_web/main.py
+++ b/aquila_web/main.py
@@ -1,6 +1,7 @@
 from fastapi import FastAPI, Form, Body, HTTPException, Query
 from aq_lib.device_id import inject_hw_serial_env
 from aquila_web.local_db import enqueue_event, init_local_db
+from aquila_web.profile_assembly import assemble_steps, validate_stages
 from fastapi.responses import FileResponse, RedirectResponse, JSONResponse
 from fastapi.staticfiles import StaticFiles
 from pathlib import Path
@@ -1217,6 +1218,7 @@ async def list_profiles():
                 "name": data.get("name"),
                 "label": data.get("name"),
                 "bundled": is_bundled,
+                "structured": "stages" in data,
                 "createdAt": created_at,
                 "modifiedAt": modified_at,
                 "configuration": data.get("configuration", {})
@@ -1229,6 +1231,7 @@ async def list_profiles():
                 "name": data.get("title", path.stem),
                 "label": data.get("title", path.stem),
                 "bundled": is_bundled,
+                "structured": "stages" in data,
                 "createdAt": created_at,
                 "modifiedAt": modified_at,
                 "configuration": _convert_legacy_steps_to_run_config(
@@ -1382,10 +1385,15 @@ async def save_profile(payload: ProfileSave):
     base_profile["post_in_gui"] = "True"
     if payload.steps is not None:
         base_profile["steps"] = payload.steps
-    # Persist the structured `stages` source of truth verbatim when provided
-    # (issue #197). Its presence marks a Structured Profile.
+    # Structured Profile (issue #201): validate the stages, then regenerate steps
+    # from them (stages is the source of truth; any client-sent steps is ignored).
+    # validate_stages runs first so assemble_steps only ever sees valid input.
     if payload.stages is not None:
+        stage_errors = validate_stages(payload.stages)
+        if stage_errors:
+            raise HTTPException(status_code=400, detail={"errors": stage_errors})
         base_profile["stages"] = payload.stages
+        base_profile["steps"] = assemble_steps(payload.stages)
     labels = {}
     if isinstance(base_profile.get("labels"), dict):
         labels.update(base_profile.get("labels", {}))

--- a/specs/backend/spec_profile_endpoints_wiring.md
+++ b/specs/backend/spec_profile_endpoints_wiring.md
@@ -1,0 +1,70 @@
+# Backend Spec: Structured Profile Endpoint Wiring — issue #201 (A3)
+
+**Status:** Draft
+**Author:** Aquila Engineering Team
+**Last updated:** 2026-06-25
+**GitHub issue:** #201
+**Source file(s):** `aquila_web/main.py`, `tests/contract/test_profile_endpoints.py`
+**Umbrella PRD:** `specs/prd/structured-profile-editor-prd.md` · **Decision:** ADR-018
+**Builds on:** `spec_stages_contract_foundation.md` (#197), `spec_profile_step_assembly.md` (#198), `spec_stages_validation.md` (#199)
+
+---
+
+## 1. Overview
+
+Wire the pure `validate_stages` (A2) and `assemble_steps` (A1) into the live profile endpoints. This is the only A-issue that modifies `main.py`. It turns a structured-profile save into: validate → (reject with 4xx, or) assemble `steps` and persist; and exposes a `structured` flag on the profile list so the UI can route rows.
+
+---
+
+## 2. Endpoints
+
+### `POST /profiles` (extended)
+
+When `payload.stages` is present:
+1. Call `validate_stages(stages)` **first**.
+2. If it returns any errors → `HTTPException(status_code=400, detail={"errors": [...]})`; **nothing is written**.
+3. Otherwise set `base_profile["steps"] = assemble_steps(stages)` (regenerate from stages — any client-sent `steps` is ignored for structured saves) and persist both `stages` and `steps`.
+
+When `payload.stages` is absent: unchanged legacy behavior (client `steps` saved as-is, no validation).
+
+**Order guarantee:** `validate_stages` is always called before `assemble_steps`, so the assembler only ever runs on validated input (it assumes well-formed data — A1).
+
+| Code | Condition | Body |
+|------|-----------|------|
+| 200 | valid `stages` (or legacy save) | `{"ok": true, "id": "..."}` |
+| 400 | `stages` present and invalid | `{"detail": {"errors": ["<field>: Invalid Value", ...]}}` |
+| 403 | target inside `profiles/bundled/` | (unchanged) |
+
+### `GET /profiles` (extended)
+
+Each profile entry gains `structured: bool` — `true` iff the profile's JSON contains a `stages` key. Lets the list route: structured → builder, legacy → read-only view. All other fields unchanged.
+
+---
+
+## 5. Persistence
+
+A structured save writes a JSON carrying both `stages` (source of truth) and the regenerated `steps` (what the runner reads). `steps` is never reverse-parsed; on every structured save it is rebuilt from `stages`.
+
+---
+
+## 8. Contract Tests
+
+`tests/contract/test_profile_endpoints.py` (marked `contract`):
+- POST valid `stages` → 200; written JSON has `stages` **and** an assembled `steps` (fixed head/tail + amplification repeat present).
+- POST out-of-range `stages` (e.g. temp 200) → 400; nothing written.
+- POST malformed `stages` (missing sub-stage `name`) → **400, not 500** (validate guards before assemble).
+- `GET /profiles` → a structured profile has `structured: true`; a legacy profile has `structured: false`.
+
+Run: `pytest tests/contract/test_profile_endpoints.py -v`
+
+---
+
+## Out of Scope
+
+- The pure assembler/validator themselves — A1 (#198) / A2 (#199), already merged.
+- The builder UI, validation display, list routing in the browser — B1/B2/B3.
+- `GET /profiles/details` returning `stages` — already shipped in #197.
+
+## 9. Open Questions
+
+- [ ] Error body shape chosen: `detail={"errors": [...]}`. Revisit if the frontend wants a different envelope (B-side validates independently, so no hard dependency).

--- a/tests/contract/test_profile_endpoints.py
+++ b/tests/contract/test_profile_endpoints.py
@@ -436,3 +436,62 @@ def test_sample_stages_fixture_matches_contract():
     assert 2 <= len(amp["subStages"]) <= 3
     for sub in amp["subStages"]:
         assert set(sub) == {"name", "temp", "time"}
+
+
+# ---------------------------------------------------------------------------
+# Structured profiles — endpoint wiring (issue #201 / A3)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.contract
+def test_post_structured_profile_assembles_steps(client):
+    """A valid stages payload is validated, assembled into steps, and persisted."""
+    resp = client.post("/profiles", json={"name": "A3 Assembled", "stages": SAMPLE_STAGES})
+    assert resp.status_code == 200, resp.text
+    pid = resp.json()["id"]
+    try:
+        data = client.get(f"/profiles/details?id={pid}").json()
+        steps = data["steps"]
+        # head, amplification repeat, and tail are all present
+        assert steps[0] == {"disable": 0, "duration": 1, "description": "Record equilibration without power."}
+        assert any("repeat" in s for s in steps)
+        assert steps[-1] == {"pcr_fanoff": 0}
+        # source of truth round-trips too
+        assert data["stages"] == SAMPLE_STAGES
+    finally:
+        _delete_profile(client, pid)
+
+
+@pytest.mark.contract
+def test_post_invalid_stages_returns_400(client):
+    """An out-of-range stages payload is rejected with 400 (validated before assembly)."""
+    bad = json.loads(json.dumps(SAMPLE_STAGES))  # deep copy
+    bad["incubation"]["temp"] = 200  # above the 100 C max
+    resp = client.post("/profiles", json={"name": "A3 Invalid Temp", "stages": bad})
+    assert resp.status_code == 400
+
+
+@pytest.mark.contract
+def test_post_malformed_stages_returns_400_not_500(client):
+    """Malformed structure (missing sub-stage name) is rejected cleanly, never a 500
+    (validate guards before assemble — the trust-boundary payoff)."""
+    bad = json.loads(json.dumps(SAMPLE_STAGES))  # deep copy
+    del bad["amplification"]["subStages"][0]["name"]
+    resp = client.post("/profiles", json={"name": "A3 Malformed", "stages": bad})
+    assert resp.status_code == 400
+
+
+@pytest.mark.contract
+def test_list_profiles_includes_structured_flag(client):
+    """GET /profiles flags structured profiles (have `stages`) vs legacy ones."""
+    structured_id = client.post(
+        "/profiles", json={"name": "A3 Structured Flag", "stages": SAMPLE_STAGES}
+    ).json()["id"]
+    legacy_id = _create_profile(client, name="A3 Legacy Flag")  # steps-based, no stages
+    try:
+        by_id = {p["id"]: p for p in client.get("/profiles").json()}
+        assert by_id[structured_id]["structured"] is True
+        assert by_id[legacy_id]["structured"] is False
+    finally:
+        _delete_profile(client, structured_id)
+        _delete_profile(client, legacy_id)


### PR DESCRIPTION
Closes #201 — A3: wire `validate_stages` + `assemble_steps` into the live profile endpoints. This is the only A-issue that touches `main.py`; it turns the (already-merged) A1 assembler and A2 validator into the actual save path.

## What this does
- **`POST /profiles`** — when `stages` is present: run `validate_stages` **first** → on errors, `HTTPException(400, {"errors": [...]})` and **nothing is written**; otherwise `assemble_steps(stages)` regenerates `steps` (stages is the source of truth — any client-sent `steps` is ignored) and both persist. Legacy `steps`-based saves are unchanged. (Closes the #201 carry-over note: validate runs before assemble.)
- **`GET /profiles`** — each entry gains `structured: bool` (`true` iff the JSON has a `stages` key) so the list can route rows (builder vs read-only).

## Spec / docs
- Spec: `specs/backend/spec_profile_endpoints_wiring.md` · PRD: `specs/prd/structured-profile-editor-prd.md` · ADR-018

## SPEC_WORKFLOW checklist
- [x] Spec linked + accurate
- [x] New contract tests (4, RED→GREEN): assembles steps; out-of-range → 400; **malformed → 400 not 500**; `structured` flag true/false
- [x] `pytest tests/contract/test_profile_endpoints.py` → 23 passed (3 pre-existing env failures unchanged)
- [x] **No regressions — verified against `main` in a throwaway worktree: identical 17 environmental failures on `main` (184 pass) and on this branch (218 pass). Feature lineage added 34 passing tests, 0 failures.**
- [x] No secrets

## Trust-boundary payoff
A hand-crafted POST omitting `name`/`enabled` or out of range now returns a clean **400**, never a 500 — the reason A2 was hardened.

## Out of scope
Builder UI / validation display / list routing in the browser — B1/B2/B3. `GET /profiles/details` returning `stages` — shipped in #197.

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)
