### PR TITLE
#202 Structured Profiles B2 — Amplification Sub-stages (add/remove + rename + cycles)

### DIFF
--- a/aquila_web/static/profiles/builder.html
+++ b/aquila_web/static/profiles/builder.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=768, height=1024, initial-scale=1" />
   <title>Create Profile</title>
-  <link rel="stylesheet" href="/static/styles.css?v=220" />
+  <link rel="stylesheet" href="/static/styles.css?v=228" />
 </head>
 <body class="app-body">
   <div class="app-shell">
@@ -96,12 +96,6 @@
           <header class="stage__header">
             <span class="stage__title">Amplification</span>
           </header>
-          <div class="field-grid">
-            <div class="field">
-              <label for="stage-amp-cycles">Cycles</label>
-              <input id="stage-amp-cycles" type="number" inputmode="numeric" value="" />
-            </div>
-          </div>
           <div class="amp-substages">
             <div class="amp-substage" data-sub="0">
               <span class="amp-substage__name" id="stage-amp-sub-0-name">Denaturation</span>
@@ -128,6 +122,15 @@
                   <input id="stage-amp-sub-1-time" type="number" inputmode="numeric" value="" />
                 </div>
               </div>
+            </div>
+          </div>
+          <!-- Add the third (Extension) Sub-stage (issue #202). Hidden once a
+               third exists; the third row carries its own X remove control. -->
+          <button id="amp-add-substage" class="amp-add-tab" type="button">+ Add sub-stage</button>
+          <div class="field-grid">
+            <div class="field">
+              <label for="stage-amp-cycles">Cycles</label>
+              <input id="stage-amp-cycles" type="number" inputmode="numeric" value="" />
             </div>
           </div>
         </section>

--- a/aquila_web/static/profiles/builder.js
+++ b/aquila_web/static/profiles/builder.js
@@ -62,6 +62,17 @@
     };
   }
 
+  // Collect the Sub-stages as currently rendered (2 or 3, in DOM order), so the
+  // payload reflects add/remove state and the two-/three-step names (#202).
+  function collectSubstages() {
+    var rows = document.querySelectorAll(".amp-substage");
+    var list = [];
+    for (var i = 0; i < rows.length; i++) {
+      list.push(subStage(rows[i].getAttribute("data-sub")));
+    }
+    return list;
+  }
+
   function estimatedMinutes() {
     var raw = text("profile-estimated-minutes");
     if (raw === "") return null;
@@ -82,7 +93,7 @@
         denaturation: optionalStage("denaturation"),
         amplification: {
           cycles: num("stage-amp-cycles"),
-          subStages: [subStage(0), subStage(1)],
+          subStages: collectSubstages(),
         },
         finalHold: optionalStage("finalhold"),
       },
@@ -116,6 +127,77 @@
     }
   }
 
+  // ---- Amplification Sub-stages (issue #202) --------------------------------
+
+  // Sub-stage 1's name depends on whether amplification is two- or three-step.
+  var SECOND_NAME_TWO_STEP = "Annealing & Extension";
+  var SECOND_NAME_THREE_STEP = "Annealing";
+  var THIRD_NAME = "Extension";
+  var MIN_SUBSTAGES = 2;
+  var MAX_SUBSTAGES = 3;
+
+  function substageRows() {
+    return document.querySelectorAll(".amp-substage");
+  }
+
+  // The add tab shows only at two Sub-stages; at three the Extension row's own
+  // X is the way back down, so the tab hides.
+  function showAddTab(show) {
+    var tab = document.getElementById("amp-add-substage");
+    if (tab) tab.classList.toggle("is-hidden", !show);
+  }
+
+  // Build the third (Extension) row. It carries its own X remove control in a
+  // header, since removal happens from the row itself, not a persistent button.
+  function buildSubstageRow(index, name) {
+    var row = document.createElement("div");
+    row.className = "amp-substage amp-substage--removable";
+    row.setAttribute("data-sub", String(index));
+    // The name + fields live in a body column; the X is its sibling so it can
+    // centre vertically against the whole row rather than hug the name line.
+    row.innerHTML =
+      '<div class="amp-substage__body">' +
+      '<span class="amp-substage__name" id="stage-amp-sub-' + index + '-name"></span>' +
+      '<div class="field-grid">' +
+      '<div class="field">' +
+      '<label for="stage-amp-sub-' + index + '-temp">Temp (°C)</label>' +
+      '<input id="stage-amp-sub-' + index + '-temp" type="number" inputmode="numeric" value="" />' +
+      '</div>' +
+      '<div class="field">' +
+      '<label for="stage-amp-sub-' + index + '-time">Time (s)</label>' +
+      '<input id="stage-amp-sub-' + index + '-time" type="number" inputmode="numeric" value="" />' +
+      '</div>' +
+      '</div>' +
+      '</div>' +
+      '<button id="amp-remove-substage" class="amp-substage__remove" type="button" aria-label="Remove sub-stage">&times;</button>';
+    // Set the name as text (never innerHTML) so it can't inject markup.
+    row.querySelector(".amp-substage__name").textContent = name;
+    row.querySelector("#amp-remove-substage").addEventListener("click", removeSubstage);
+    return row;
+  }
+
+  // Two-step -> three-step: rename Sub-stage 1, append a blank Extension row, and
+  // hide the add tab.
+  function addSubstage() {
+    if (substageRows().length >= MAX_SUBSTAGES) return;
+    var second = document.getElementById("stage-amp-sub-1-name");
+    if (second) second.textContent = SECOND_NAME_THREE_STEP;
+    var container = document.querySelector(".amp-substages");
+    if (container) container.appendChild(buildSubstageRow(2, THIRD_NAME));
+    showAddTab(false);
+  }
+
+  // Three-step -> two-step: drop the Extension row, revert Sub-stage 1's name,
+  // and bring the add tab back.
+  function removeSubstage() {
+    if (substageRows().length <= MIN_SUBSTAGES) return;
+    var third = document.querySelector('.amp-substage[data-sub="2"]');
+    if (third) third.remove();
+    var second = document.getElementById("stage-amp-sub-1-name");
+    if (second) second.textContent = SECOND_NAME_TWO_STEP;
+    showAddTab(true);
+  }
+
   // ---- Boot -----------------------------------------------------------------
 
   function init() {
@@ -127,6 +209,10 @@
       });
       syncStage(key); // sync initial state on load
     });
+
+    var addBtn = document.getElementById("amp-add-substage");
+    if (addBtn) addBtn.addEventListener("click", addSubstage);
+    showAddTab(substageRows().length < MAX_SUBSTAGES);
 
     var saveButton = document.getElementById("save-profile-button");
     if (saveButton) saveButton.addEventListener("click", saveProfile);

--- a/aquila_web/static/styles.css
+++ b/aquila_web/static/styles.css
@@ -2694,11 +2694,15 @@ a:active {
   align-items: center;
   gap: 10px;
   cursor: pointer;
+  /* Kiosk touch target: keep the tappable label >= 44px tall (issue #202). */
+  min-height: 44px;
 }
 
 .stage__toggle input[type="checkbox"] {
   width: 22px;
   height: 22px;
+  /* Checked fill matches the Save Profile button's green (issue #202 follow-up). */
+  accent-color: var(--icon-acorn-green);
 }
 
 .stage__title {
@@ -2706,8 +2710,13 @@ a:active {
   font-weight: 600;
 }
 
+/* Reserve a right gutter on every Sub-stage row so all temp/time inputs line up,
+   whether or not the row carries an X. The removable (Extension) row drops its X
+   into this gutter via absolute positioning, so it never shrinks the fields. */
 .amp-substage {
+  position: relative;
   margin-top: 12px;
+  padding-right: 39px;
 }
 
 .amp-substage__name {
@@ -2715,6 +2724,58 @@ a:active {
   font-size: 13px;
   font-weight: 600;
   margin-bottom: 8px;
+}
+
+/* Two-/three-step Sub-stage controls (issue #202). */
+
+/* Red X in a square red-outlined box, sitting in the reserved gutter. `top` is
+   tuned so the box centres on the midpoint between the Annealing and Extension
+   time fields. Kept compact (below the 44px kiosk minimum) by design. */
+.amp-substage__remove {
+  position: absolute;
+  top: 4px;
+  right: 0;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 27px;
+  height: 27px;
+  padding: 0;
+  border: 2px solid #dc2626;
+  border-radius: 6px;
+  background: none;
+  color: #dc2626;
+  font-size: 18px;
+  line-height: 1;
+  cursor: pointer;
+}
+
+/* Full-width "+ Add sub-stage" tab; hidden via .is-hidden once a third exists.
+   Kiosk touch target: >= 44px tall. */
+.amp-add-tab {
+  display: block;
+  width: 100%;
+  min-height: 44px;
+  margin-top: 16px;
+  border: 1px dashed #cbd5e1;
+  border-radius: 10px;
+  background: #f8fafc;
+  color: #475569;
+  font-size: 15px;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  cursor: pointer;
+}
+
+/* Override .amp-add-tab's display:block when hidden (same-specificity tie that
+   the later .amp-add-tab rule would otherwise win). */
+.amp-add-tab.is-hidden {
+  display: none;
+}
+
+/* Cycles is the last field in the Amplification card (issue #202). */
+#stage-amplification > .field-grid {
+  margin-top: 16px;
 }
 
 /* An unchecked Stage greys out. Its inputs are also set [disabled] in JS, which

--- a/specs/frontend/spec_amplification_substages.md
+++ b/specs/frontend/spec_amplification_substages.md
@@ -1,0 +1,148 @@
+# Frontend / UI Spec: Amplification Sub-stages — add/remove + rename + cycles (issue #202)
+
+**Status:** Active
+**Author:** Aquila Engineering Team
+**Last updated:** 2026-06-25
+**GitHub issue:** #202 (Structured Profiles B2)
+**Affected screens:** Create Profile (`/profiles/builder`)
+**Source file(s):** `aquila_web/static/profiles/builder.html`, `aquila_web/static/profiles/builder.js`, `aquila_web/static/styles.css`, `tests/e2e/test_profile_builder.py`
+**Umbrella PRD:** `specs/prd/structured-profile-editor-prd.md` · **Decision:** ADR-018, ADR-003 (plain HTML/JS, no build)
+**Depends on:** #200 (the builder shell — merged into `updated-profiles`)
+
+---
+
+## 1. Overview
+
+B2 makes the Amplification Stage's Sub-stages interactive. B1 (#200) shipped two static Sub-stage rows; this issue lets the operator switch between a two-step and three-step amplification by adding/removing the third Sub-stage, with the name transitions the domain requires, bounded to 2–3 Sub-stages. The Amplification cycle count (the `#stage-amp-cycles` field shipped in B1) and the now-dynamic Sub-stage list both feed the posted `stages.amplification` object.
+
+It deliberately does **not** validate field ranges or enforce the extension-bearing Sub-stage's 11 s minimum (B3 / A2), assemble `steps` or place the optics split (A1), or repopulate from a saved Profile on edit (later issue).
+
+**Carry-over cleanups from the B1 PR review (#207), folded in because B2 edits these same files:**
+- Fix the misleading `_goto_builder` comment in `test_profile_builder.py` that claims the Stages are JS-rendered (they are static HTML; `builder.js` only wires behavior).
+- Bring tap targets to the spec's **≥44×44px** kiosk rule (§6): the new add/remove controls, and the existing B1 Stage enable checkbox whose 22px box + unpadded label currently misses it.
+
+Context: plain HTML/CSS/JS, no build step (ADR-003); Chromium kiosk on the 768×1024 Pi touch display (ADR-005).
+
+---
+
+## 2. Screen Inventory
+
+| Screen ID | Name | Entry condition | Exit conditions |
+|-----------|------|----------------|-----------------|
+| `builder` | Create Profile | Navigate to `/profiles/builder` | Save → Profiles list; Back/Cancel → Profiles list |
+
+No new screens — this extends the Amplification card on the existing builder.
+
+---
+
+## 3. State Machine Transitions
+
+Sub-stage count is a small local state machine inside the Amplification card:
+
+```
+[2 sub-stages] --[+ Add sub-stage tab]----> [3 sub-stages]
+[3 sub-stages] --[Extension row's X]-------> [2 sub-stages]
+```
+
+- At `[2]`: add tab visible, no `X` present. At `[3]`: add tab hidden, Extension row carries the `X`. Count never leaves {2, 3}.
+
+---
+
+## 4. Screen Designs
+
+### Amplification card (`#stage-amplification`)
+
+**Sub-stage names are display labels driven by the count, not editable inputs:**
+
+| Count | Sub-stage 0 | Sub-stage 1 | Sub-stage 2 |
+|-------|-------------|-------------|-------------|
+| 2 (two-step) | `Denaturation` | `Annealing & Extension` | — |
+| 3 (three-step) | `Denaturation` | `Annealing` | `Extension` |
+
+Each Sub-stage row keeps its B1 DOM shape: a name label `#stage-amp-sub-{i}-name` and temp/time inputs `#stage-amp-sub-{i}-temp` / `#stage-amp-sub-{i}-time` (`i` = 0,1,2).
+
+**Card layout (top → bottom):** Amplification header → the Sub-stage rows → the add-tab (when at two) → **Cycles** (`#stage-amp-cycles`) as the last field. Cycles sits at the bottom of the card, below the last Sub-stage.
+
+**Controls:**
+- Add: `#amp-add-substage` — a **full-width "+ Add sub-stage" tab** rendered below the Sub-stage rows. Visible **only at two Sub-stages**; hidden once a third exists.
+- Remove: `#amp-remove-substage` — an **`X` button on the right of the Extension row's header**. It exists **only while the third Sub-stage exists** (created with that row), not a persistent control.
+
+**Interactions:**
+- **Add (count 2 → 3):** rename Sub-stage 1's label `Annealing & Extension` → `Annealing`; append a third row `#stage-amp-sub-2-*` named `Extension` (blank temp/time) carrying its `X` remove button; **hide the add tab**.
+- **Remove via the Extension row's `X` (count 3 → 2):** delete the third row; rename Sub-stage 1's label back to `Annealing & Extension`; **show the add tab** again.
+- A fresh builder opens at count 2 (two-step) with the add tab visible and no `X`, matching B1.
+
+**Touch targets:** the add tab and the Stage enable checkbox (B1, via its `.stage__toggle` label) guarantee a ≥44×44px hit area. The Extension row's `X` is a deliberate exception — kept compact (red, no 44px minimum) so the Extension header is the same height as a plain Sub-stage name and the spacing between Sub-stages stays uniform; it trades the touch minimum for visual rhythm on this one rarely-used control.
+
+**Error states:** none in B2 (validation is B3). The 2–3 bound is enforced structurally by the disabled controls, not by an error message.
+
+---
+
+## 5. Data Binding
+
+### Save payload — `stages.amplification`
+
+The amplification object in the POST body becomes **dynamic** over the rendered Sub-stage rows (B1 hardcoded exactly two):
+
+```json
+"amplification": {
+  "cycles": <number|null>,
+  "subStages": [
+    { "name": "<row 0 label>", "temp": <number|null>, "time": <number|null> },
+    { "name": "<row 1 label>", "temp": <number|null>, "time": <number|null> }
+    // ...plus row 2 when present (three-step)
+  ]
+}
+```
+
+Binding rules:
+- `subStages` is built by iterating the rendered `.amp-substage` rows in DOM order — length 2 or 3 — reading each row's name label and its temp/time inputs. Names reflect the current two-/three-step state.
+- `cycles` = `#stage-amp-cycles` (blank ⇒ `null`, else `Number`). No validation in B2 (B3).
+- All other payload fields (`name`, `fam_label`, `rox_label`, `estimated_minutes`, and the other three Stages) are unchanged from B1.
+
+---
+
+## 6. Accessibility / Kiosk Constraints
+
+- All interactive controls ≥ 44×44px (frontend spec §6; 768×1024 Pi kiosk). This is a hard criterion B2 must satisfy for its add/remove controls **and** retroactively for the B1 Stage checkbox.
+- No hover-only affordances; disabled controls visibly non-interactive.
+
+---
+
+## 7. Assets
+
+| Asset | Path | Notes |
+|-------|------|-------|
+| Builder markup | `aquila_web/static/profiles/builder.html` | Add the add/remove controls; the third Sub-stage row is created in JS on demand. |
+| Builder script | `aquila_web/static/profiles/builder.js` | Sub-stage add/remove + rename + bound enforcement; dynamic `subStages` in `buildPayload`. |
+| Styles | `aquila_web/static/styles.css` | Add/remove control sizing; checkbox ≥44px hit area. |
+
+---
+
+## 8. Acceptance Criteria
+
+- [ ] Amplification starts with exactly two Sub-stages named `Denaturation` and `Annealing & Extension`.
+- [ ] The full-width add tab shows at two Sub-stages; adding a third renames Sub-stage 1 to `Annealing`, appends a blank `Extension` row, and hides the add tab.
+- [ ] The Extension row carries an `X` (right of its header); clicking it removes the third Sub-stage, reverts Sub-stage 1's name to `Annealing & Extension`, and brings the add tab back.
+- [ ] Count is bounded to {2, 3}: no `X` at two, no add tab at three.
+- [ ] Cycles is the last field in the Amplification card (below the Sub-stages).
+- [ ] The posted `stages.amplification` reflects the current Sub-stages (2 or 3, with correct names) and `cycles`.
+- [ ] The add tab and the B1 Stage enable checkbox meet the ≥44×44px touch-target rule (the Extension `X` is intentionally exempt, kept compact for uniform spacing).
+- [ ] The Extension `X` is red and small enough that the gap between Sub-stages 2 and 3 matches the gap between 1 and 2.
+- [ ] `_goto_builder`'s comment in `test_profile_builder.py` no longer claims the Stages are JS-rendered.
+- [ ] e2e in `tests/e2e/test_profile_builder.py` covers add/remove + the rename transitions and the 2–3 bound; existing B1 tests still pass.
+
+---
+
+## Out of Scope (other issues, other specs)
+
+- Field validation, "Invalid Value" highlighting, the extension-bearing Sub-stage's 11 s minimum, save-blocking — B3 (#203) / A2 (#199).
+- Assembling `stages → steps` and placing the optics split inside the extension Sub-stage — A1 (#198).
+- Repopulating the builder (including 3-Sub-stage state) from a saved Profile on edit, and Profiles-list routing — B3 (#203).
+- Making Sub-stage names free-text editable — they remain count-driven labels.
+
+---
+
+## 9. Open Questions
+
+- [ ] None — Sub-stage transitions and the 2–3 bound are fixed by PRD user stories 13–18 and ADR-018.

--- a/tests/e2e/test_profile_builder.py
+++ b/tests/e2e/test_profile_builder.py
@@ -27,7 +27,8 @@ def _goto_builder(page, base_url):
     except Exception as exc:
         pytest.skip(f"Backend not reachable at {base_url}: {exc}")
     page.wait_for_load_state("domcontentloaded")
-    # The builder renders its Stages from JS; wait for the first card to attach.
+    # The Stage cards are static HTML in builder.html (builder.js only wires
+    # behavior); wait for the shell to attach before driving it.
     page.wait_for_selector("#stage-incubation", state="attached", timeout=5_000)
 
 
@@ -157,3 +158,125 @@ def test_valid_save_posts_stages_and_redirects(page, base_url):
     stale = [p["id"] for p in listing if "B1_Happy_Path" in p.get("id", "")]
     if stale:
         page.request.post(f"{base_url}/profiles/delete", data={"profiles": stale})
+
+
+# ---------------------------------------------------------------------------
+# Amplification Sub-stages — add/remove + rename + cycles (issue #202, B2)
+# ---------------------------------------------------------------------------
+
+TWO_STEP_NAMES = ["Denaturation", "Annealing & Extension"]
+THREE_STEP_NAMES = ["Denaturation", "Annealing", "Extension"]
+
+
+def _substage_names(page):
+    return page.locator(".amp-substage .amp-substage__name").all_inner_texts()
+
+
+def test_amplification_starts_two_step_with_add_tab(page, base_url):
+    """A fresh builder shows two Sub-stages and the add tab, with no remove X."""
+    _goto_builder(page, base_url)
+
+    assert page.locator(".amp-substage").count() == 2
+    assert _substage_names(page) == TWO_STEP_NAMES
+
+    # The add tab is shown; there is no remove control until a third exists.
+    assert page.locator("#amp-add-substage").is_visible(), "add tab should show at two"
+    assert page.locator("#amp-remove-substage").count() == 0, "no X at two Sub-stages"
+
+
+def test_adding_third_substage_renames_appends_and_hides_add_tab(page, base_url):
+    """Adding a third Sub-stage renames the 2nd to 'Annealing', appends a blank
+    'Extension' carrying its X, and hides the add tab."""
+    _goto_builder(page, base_url)
+
+    page.locator("#amp-add-substage").click()
+
+    assert page.locator(".amp-substage").count() == 3
+    assert _substage_names(page) == THREE_STEP_NAMES
+
+    # The appended Extension Sub-stage starts blank.
+    assert page.locator("#stage-amp-sub-2-temp").input_value() == ""
+    assert page.locator("#stage-amp-sub-2-time").input_value() == ""
+
+    # At three: the add tab is hidden and the Extension row carries the X.
+    assert not page.locator("#amp-add-substage").is_visible(), "add tab hidden at three"
+    assert page.locator("#amp-remove-substage").is_visible(), "Extension X should show"
+
+
+def test_removing_third_substage_via_x_reverts_to_two_step(page, base_url):
+    """The Extension row's X removes the third Sub-stage, reverts the 2nd's name,
+    and brings the add tab back."""
+    _goto_builder(page, base_url)
+
+    page.locator("#amp-add-substage").click()      # 2 -> 3
+    assert page.locator(".amp-substage").count() == 3
+
+    page.locator("#amp-remove-substage").click()   # X on the Extension row, 3 -> 2
+
+    assert page.locator(".amp-substage").count() == 2
+    assert page.locator("#stage-amp-sub-2-name").count() == 0, "third row should be gone"
+    assert _substage_names(page) == TWO_STEP_NAMES
+
+    # Back at two: the add tab returns and the X is gone.
+    assert page.locator("#amp-add-substage").is_visible(), "add tab should return"
+    assert page.locator("#amp-remove-substage").count() == 0, "X should be gone at two"
+
+
+def test_three_step_save_posts_three_substages(page, base_url):
+    """With a third Sub-stage added, Save POSTs all three in order with their
+    three-step names and the cycle count."""
+    _goto_builder(page, base_url)
+
+    page.locator("#profile-name").fill("B2 Three Step")
+    page.locator("#stage-amp-cycles").fill("35")
+    page.locator("#amp-add-substage").click()  # -> three Sub-stages
+
+    page.locator("#stage-amp-sub-0-temp").fill("95")
+    page.locator("#stage-amp-sub-0-time").fill("10")
+    page.locator("#stage-amp-sub-1-temp").fill("60")
+    page.locator("#stage-amp-sub-1-time").fill("30")
+    page.locator("#stage-amp-sub-2-temp").fill("72")
+    page.locator("#stage-amp-sub-2-time").fill("20")
+
+    def is_save_post(req):
+        return req.url.rstrip("/").endswith("/profiles") and req.method == "POST"
+
+    with page.expect_request(is_save_post) as req_info, \
+            page.expect_response(lambda r: is_save_post(r.request)) as resp_info:
+        page.locator("#save-profile-button").click()
+
+    amp = req_info.value.post_data_json["stages"]["amplification"]
+    assert amp["cycles"] == 35
+    assert [s["name"] for s in amp["subStages"]] == THREE_STEP_NAMES
+    assert amp["subStages"][0] == {"name": "Denaturation", "temp": 95, "time": 10}
+    assert amp["subStages"][1] == {"name": "Annealing", "temp": 60, "time": 30}
+    assert amp["subStages"][2] == {"name": "Extension", "temp": 72, "time": 20}
+
+    assert resp_info.value.status == 200
+    page.wait_for_url("**/profiles-page", timeout=5_000)
+
+    listing = page.request.get(f"{base_url}/profiles").json()
+    stale = [p["id"] for p in listing if "B2_Three_Step" in p.get("id", "")]
+    if stale:
+        page.request.post(f"{base_url}/profiles/delete", data={"profiles": stale})
+
+
+def test_touch_targets_meet_kiosk_minimum(page, base_url):
+    """The add tab and each Stage enable toggle meet the >=44x44px kiosk
+    touch-target rule (spec §6).
+
+    The Extension row's X is intentionally exempt: it is kept compact so the
+    Sub-stage spacing stays uniform (issue #202 follow-up), accepting a smaller
+    hit area for that one rarely-used control.
+    """
+    _goto_builder(page, base_url)
+    MIN = 44
+
+    add_box = page.locator("#amp-add-substage").bounding_box()
+    assert add_box["width"] >= MIN and add_box["height"] >= MIN, f"add tab small: {add_box}"
+
+    toggles = page.locator(".stage__toggle")
+    assert toggles.count() == 3
+    for i in range(toggles.count()):
+        box = toggles.nth(i).bounding_box()
+        assert box["height"] >= MIN, f"stage toggle {i} too short: {box['height']}px"


### PR DESCRIPTION
Closes #202 — the Amplification Stage's Sub-stage interactions and cycle count. Builds on B1 (#200, merged into `updated-profiles`).

## What this does
- **Add tab:** a full-width "+ Add sub-stage" tab (shown only at two Sub-stages) adds the third — renaming Sub-stage 1 `Annealing & Extension` → `Annealing` and appending a blank `Extension` row — then hides itself.
- **Remove:** the Extension row carries a compact **red X** (in a reserved right gutter) that removes the third Sub-stage, reverts the name back to `Annealing & Extension`, and brings the add tab back. Bounded to **2–3** Sub-stages.
- **Cycles** moved to the bottom of the Amplification card.
- **Payload:** `stages.amplification.subStages` is now built dynamically from the rendered rows (2 or 3, with the current names), plus `cycles`.
- **Checkboxes** fill acorn-green (the Save button's colour, via `--icon-acorn-green`) when checked.

**No `main.py` change** — pure frontend, disjoint from the A1/A2/A3 backend branches.

## PR-review carry-overs from B1 (#207), folded in
- Fixed the misleading `_goto_builder` comment (Stages are static HTML, not JS-rendered).
- ≥44px kiosk touch targets for the add tab and the Stage enable checkboxes.

## Deliberate deviations (flagging so they're not surprises)
- The Extension **X is intentionally below the 44px** touch minimum — kept compact for uniform Sub-stage spacing and to center it between the Annealing/Extension time fields. Documented in the spec; the X is excluded from the touch-target test.
- Sub-stage temp/time fields are inset ~39px on the right (reserved X gutter), uniform across all three rows, vs the full-width Cycles field.

## Tests
`tests/e2e/test_profile_builder.py` (Playwright, `e2e`) — **9 passing** locally (4 B1 + 5 B2): add tab/rename/append, X remove + revert, 2–3 bound, three-step save payload, touch targets. CI runs no pytest here, so this is a local run.

## Spec
`specs/frontend/spec_amplification_substages.md`

## Out of scope (other issues)
- Field validation / "Invalid Value" highlighting, the extension 11 s minimum — B3 (#203) / A2 (#199).
- `stages → steps` assembly + optics split — A1 (#198).
- Edit-repopulate and list routing — B3 (#203).

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)