### PR TITLE
#203 Structured Profiles B3 — validation UX + edit round-trip + list routing

### DIFF
--- a/aquila_web/static/profiles/builder.html
+++ b/aquila_web/static/profiles/builder.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=768, height=1024, initial-scale=1" />
   <title>Create Profile</title>
-  <link rel="stylesheet" href="/static/styles.css?v=228" />
+  <link rel="stylesheet" href="/static/styles.css?v=231" />
 </head>
 <body class="app-body">
   <div class="app-shell">
@@ -12,7 +12,7 @@
       <header class="run-header">
         <h1 class="run-header__title" id="builder-page-title">
           <a class="back-icon back-icon--inline" href="/profiles-page" aria-label="Back">&#x2039;</a>
-          Create Profile
+          <span id="builder-title-text">Create Profile</span>
         </h1>
         <nav class="run-header__nav">
           <a class="run-nav-link" href="/run">Run</a>
@@ -50,6 +50,7 @@
             <div class="field">
               <label for="profile-estimated-minutes">Est. Time (Min)</label>
               <input id="profile-estimated-minutes" type="number" inputmode="numeric" min="1" step="1" value="" placeholder="(Optional)" />
+              <p class="field-error is-hidden" id="profile-estimated-error">Invalid Estimated Time</p>
             </div>
           </div>
         </section>
@@ -163,6 +164,6 @@
     </main>
   </div>
   <script src="/static/nav.js?v=1"></script>
-  <script src="/static/profiles/builder.js?v=1"></script>
+  <script src="/static/profiles/builder.js?v=4"></script>
 </body>
 </html>

--- a/aquila_web/static/profiles/builder.js
+++ b/aquila_web/static/profiles/builder.js
@@ -8,6 +8,12 @@
   // Stages with an enable checkbox. Amplification is always present (no toggle).
   var OPTIONAL_STAGES = ["incubation", "denaturation", "finalhold"];
 
+  // When the URL carries ?id= (or ?profile=) the builder is editing an existing
+  // structured Profile: it repopulates from `stages` and saves in place (#203).
+  var editId =
+    new URLSearchParams(window.location.search).get("id") ||
+    new URLSearchParams(window.location.search).get("profile");
+
   function valueInputs(card) {
     // Every editable value field in the card (temp/time) — never the checkbox.
     return card.querySelectorAll("input:not([type=checkbox])");
@@ -81,9 +87,10 @@
   }
 
   // Build the POST body. All four stage keys are always present; an unchecked
-  // Stage rides along as enabled:false with its preserved values.
+  // Stage rides along as enabled:false with its preserved values. In edit mode
+  // profile_id is included so the backend updates that profile in place.
   function buildPayload() {
-    return {
+    var payload = {
       name: text("profile-name"),
       fam_label: text("profile-fam-label"),
       rox_label: text("profile-rox-label"),
@@ -98,10 +105,105 @@
         finalHold: optionalStage("finalhold"),
       },
     };
+    if (editId) payload.profile_id = editId;
+    return payload;
+  }
+
+  // ---- Validation (issue #203) ----------------------------------------------
+  // Ranges mirror aquila_web/profile_assembly.py::validate_stages so a
+  // client-valid form never trips the server's 400 (which stays the safety net).
+  var TEMP_MIN = 25, TEMP_MAX = 100;
+  var TIME_MIN = 1, TIME_MAX = 600, EXTENSION_TIME_MIN = 11;
+  var CYCLES_MIN = 1, CYCLES_MAX = 50;
+
+  function validTemp(v) {
+    return typeof v === "number" && v >= TEMP_MIN && v <= TEMP_MAX;
+  }
+  function validTime(v, min) {
+    return typeof v === "number" && v >= min && v <= TIME_MAX;
+  }
+  function validCycles(v) {
+    return Number.isInteger(v) && v >= CYCLES_MIN && v <= CYCLES_MAX;
+  }
+
+  // Ensure a hidden "Invalid Value" message exists right after the input.
+  function errorEl(input) {
+    var next = input.nextElementSibling;
+    if (next && next.classList.contains("field-error")) return next;
+    var p = document.createElement("p");
+    p.className = "field-error is-hidden";
+    p.textContent = "Invalid Value";
+    input.insertAdjacentElement("afterend", p);
+    return p;
+  }
+
+  function setFieldValid(id, ok) {
+    var input = document.getElementById(id);
+    if (!input) return ok;
+    input.classList.toggle("is-invalid", !ok);
+    errorEl(input).classList.toggle("is-hidden", ok);
+    return ok;
+  }
+
+  // Est. Time (Min) — optional; blank is fine, otherwise a positive integer.
+  // Mirrors the legacy editor's check (edit.js) so the field behaves the same.
+  function validEstimated() {
+    var el = document.getElementById("profile-estimated-minutes");
+    if (!el) return true;
+    var raw = el.value.trim();
+    if (raw === "") return true;
+    var parsed = Math.round(Number(raw));
+    return Number.isFinite(parsed) && parsed > 0;
+  }
+
+  function setEstimatedValid(ok) {
+    var input = document.getElementById("profile-estimated-minutes");
+    var err = document.getElementById("profile-estimated-error");
+    if (input) input.classList.toggle("is-invalid", !ok);
+    if (err) err.classList.toggle("is-hidden", ok);
+    return ok;
+  }
+
+  // Validate every enabled-Stage field; flag all offenders at once. Disabled
+  // Stages are skipped (and any stale error on them cleared). Returns validity.
+  function validateForm() {
+    var valid = setEstimatedValid(validEstimated());
+
+    OPTIONAL_STAGES.forEach(function (key) {
+      var box = document.getElementById("stage-" + key + "-enabled");
+      var enabled = !box || box.checked;
+      if (!enabled) {
+        setFieldValid("stage-" + key + "-temp", true);
+        setFieldValid("stage-" + key + "-time", true);
+        return;
+      }
+      valid = setFieldValid("stage-" + key + "-temp", validTemp(num("stage-" + key + "-temp"))) && valid;
+      valid = setFieldValid("stage-" + key + "-time", validTime(num("stage-" + key + "-time"), TIME_MIN)) && valid;
+    });
+
+    valid = setFieldValid("stage-amp-cycles", validCycles(num("stage-amp-cycles"))) && valid;
+
+    var rows = document.querySelectorAll(".amp-substage");
+    for (var i = 0; i < rows.length; i++) {
+      var idx = rows[i].getAttribute("data-sub");
+      var isLast = i === rows.length - 1; // extension-bearing Sub-stage
+      var minTime = isLast ? EXTENSION_TIME_MIN : TIME_MIN;
+      valid = setFieldValid("stage-amp-sub-" + idx + "-temp", validTemp(num("stage-amp-sub-" + idx + "-temp"))) && valid;
+      valid = setFieldValid("stage-amp-sub-" + idx + "-time", validTime(num("stage-amp-sub-" + idx + "-time"), minTime)) && valid;
+    }
+
+    return valid;
   }
 
   async function saveProfile() {
     var status = document.getElementById("save-status");
+    // Validate on save only (never on load); block + flag every offender.
+    if (!validateForm()) {
+      var firstBad = document.querySelector(".is-invalid");
+      if (firstBad) firstBad.scrollIntoView({ block: "center", behavior: "smooth" });
+      if (status) status.textContent = "";
+      return;
+    }
     if (status) status.textContent = "Saving...";
     try {
       var response = await fetch("/profiles", {
@@ -198,6 +300,60 @@
     showAddTab(true);
   }
 
+  // ---- Edit round-trip (issue #203) -----------------------------------------
+
+  function setVal(id, value) {
+    var el = document.getElementById(id);
+    if (el && value !== undefined && value !== null) el.value = value;
+  }
+
+  function populateOptionalStage(key, stage) {
+    if (!stage) return;
+    var box = document.getElementById("stage-" + key + "-enabled");
+    if (box) box.checked = !!stage.enabled;
+    setVal("stage-" + key + "-temp", stage.temp);
+    setVal("stage-" + key + "-time", stage.time);
+    syncStage(key); // grey/disable when restored as unchecked
+  }
+
+  // Repopulate the builder from an existing structured Profile's `stages`.
+  async function loadForEdit(id) {
+    try {
+      var resp = await fetch("/profiles/details?id=" + encodeURIComponent(id));
+      if (!resp.ok) return;
+      var data = await resp.json();
+      var stages = data.stages;
+      if (!stages) return; // not a Structured Profile — leave blank defaults
+
+      var titleText = document.getElementById("builder-title-text");
+      if (titleText) titleText.textContent = "Edit Profile";
+
+      setVal("profile-name", data.title);
+      var labels = data.labels || {};
+      setVal("profile-fam-label", labels.fam);
+      setVal("profile-rox-label", labels.rox);
+      var secs = data.estimated_completion_seconds;
+      if (typeof secs === "number" && secs > 0) {
+        setVal("profile-estimated-minutes", Math.round(secs / 60));
+      }
+
+      populateOptionalStage("incubation", stages.incubation);
+      populateOptionalStage("denaturation", stages.denaturation);
+      populateOptionalStage("finalhold", stages.finalHold);
+
+      var amp = stages.amplification || {};
+      setVal("stage-amp-cycles", amp.cycles);
+      var subs = amp.subStages || [];
+      if (subs.length === 3) addSubstage(); // build + name the third row
+      for (var i = 0; i < subs.length; i++) {
+        setVal("stage-amp-sub-" + i + "-temp", subs[i].temp);
+        setVal("stage-amp-sub-" + i + "-time", subs[i].time);
+      }
+    } catch (e) {
+      console.error("Failed to load profile for edit", e);
+    }
+  }
+
   // ---- Boot -----------------------------------------------------------------
 
   function init() {
@@ -216,6 +372,8 @@
 
     var saveButton = document.getElementById("save-profile-button");
     if (saveButton) saveButton.addEventListener("click", saveProfile);
+
+    if (editId) loadForEdit(editId);
   }
 
   if (document.readyState === "loading") {

--- a/aquila_web/static/profiles/edit.js
+++ b/aquila_web/static/profiles/edit.js
@@ -33,10 +33,9 @@ const toggleReadViewButton = document.getElementById("toggle-read-view");
 const editSections = document.querySelectorAll(".profile-edit");
 const summarySection = document.getElementById("profile-summary");
 
+// Honour an explicit ?view=1 (or ?mode=view): Legacy Profiles route here to open
+// read-only (issue #203). Without the param the editor opens editable as before.
 let isReadView = viewMode;
-if (isReadView && toggleReadViewButton) {
-  isReadView = false;
-}
 const DEFAULT_DYE_LABELS = { fam: "FAM", rox: "ROX" };
 
 const parseDuration = (value) => {

--- a/aquila_web/static/profiles/edit_form.html
+++ b/aquila_web/static/profiles/edit_form.html
@@ -102,7 +102,7 @@
     </main>
   </div>
   <script src="/static/nav.js?v=1"></script>
-  <script src="/static/profiles/edit.js?v=19"></script>
+  <script src="/static/profiles/edit.js?v=20"></script>
   <script src="/static/keyboard.js?v=14"></script>
 </body>
 </html>

--- a/aquila_web/static/profiles/index.html
+++ b/aquila_web/static/profiles/index.html
@@ -26,7 +26,7 @@
       <div class="profiles-shell">
         <div class="profiles-toolbar profiles-toolbar--minimal">
           <div class="profiles-actions">
-            <a class="run-secondary-btn" href="/profiles/edit-form">New profile</a>
+            <a class="run-secondary-btn" href="/profiles/builder">New profile</a>
             <button class="run-secondary-btn" id="profiles-delete-button" type="button">Delete</button>
           </div>
         </div>
@@ -55,6 +55,6 @@
     </main>
   </div>
   <script src="/static/nav.js?v=1"></script>
-  <script src="/static/profiles/profiles.js?v=6"></script>
+  <script src="/static/profiles/profiles.js?v=7"></script>
 </body>
 </html>

--- a/aquila_web/static/profiles/profiles.js
+++ b/aquila_web/static/profiles/profiles.js
@@ -128,7 +128,13 @@
     const editCell = document.createElement("td");
     if (!isBundled) {
       const idParam = encodeURIComponent(profile.id || "");
-      editCell.appendChild(createActionLink("Edit", `/profiles/edit-form?id=${idParam}`));
+      if (profile.structured) {
+        // Structured Profiles edit in the guided builder.
+        editCell.appendChild(createActionLink("Edit", `/profiles/builder?id=${idParam}`));
+      } else {
+        // Legacy Profiles are read-only in-app — open the viewer (?view=1).
+        editCell.appendChild(createActionLink("View", `/profiles/edit-form?id=${idParam}&view=1`));
+      }
     }
     row.appendChild(editCell);
 

--- a/aquila_web/static/styles.css
+++ b/aquila_web/static/styles.css
@@ -2784,6 +2784,14 @@ a:active {
   opacity: 0.5;
 }
 
+/* A field that failed save-time validation (issue #203). Red border pairs with
+   the "Invalid Value" .field-error text — colour is never the only signal. The
+   `.field input` qualifier beats the base `.field input` border specificity. */
+.field input.is-invalid,
+.is-invalid {
+  border: 2px solid #dc2626;
+}
+
 .field-grid {
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
@@ -2821,10 +2829,12 @@ a:active {
   color: #64748b;
 }
 
+/* `.card .field-error` qualifier beats `.card p`'s grey, so the message is red. */
+.card .field-error,
 .field-error {
   margin: 0;
   font-size: 12px;
-  color: #b91c1c;
+  color: #dc2626;
 }
 
 .profile-steps {

--- a/specs/frontend/spec_validation_roundtrip_routing.md
+++ b/specs/frontend/spec_validation_roundtrip_routing.md
@@ -1,0 +1,140 @@
+# Frontend / UI Spec: Validation UX + Edit Round-trip + List Routing (issue #203)
+
+**Status:** Active
+**Author:** Aquila Engineering Team
+**Last updated:** 2026-06-26
+**GitHub issue:** #203 (Structured Profiles B3)
+**Affected screens:** Create/Edit Profile (`/profiles/builder`), Profiles list (`/profiles-page`)
+**Source file(s):** `aquila_web/static/profiles/builder.html`, `aquila_web/static/profiles/builder.js`, `aquila_web/static/profiles/profiles.js`, `aquila_web/static/profiles/index.html`, `aquila_web/static/styles.css`, `tests/e2e/test_profile_builder.py`
+**Umbrella PRD:** `specs/prd/structured-profile-editor-prd.md` · **Decision:** ADR-018, ADR-003 (plain HTML/JS, no build)
+**Depends on:** #200 (builder shell), #202 (Sub-stages), #201 (A3 — endpoints now validate, assemble `steps`, and return the `structured` flag) — all merged into `updated-profiles`.
+
+---
+
+## 1. Overview
+
+B3 is the final frontend slice: it makes the structured builder **trustworthy** (can't save an invalid program), **complete** (can edit existing profiles, not just create), and **wired into the app** (the Profiles list and the New button send each profile to the right editor). It builds against the real merged backend (A3), not a stub.
+
+Three capabilities:
+1. **Validation on save** — client-side, mirroring the server's `validate_stages` ranges so a client-valid form never trips the server 400 (which remains the safety net).
+2. **Edit round-trip** — opening a structured Profile repopulates every Stage/Sub-stage/value from its `stages` object; saving updates that profile in place.
+3. **List routing** — structured Profiles → the builder; Legacy → the existing read-only view; bundled stay read-only. "New profile" → the builder.
+
+Out of scope: changing the assembled `steps`, ranges, or any backend logic (A-side, done); the Legacy editor's internals.
+
+Context: plain HTML/CSS/JS, no build step (ADR-003); 768×1024 Pi kiosk (ADR-005).
+
+---
+
+## 2. Screen Inventory
+
+| Screen ID | Name | Entry condition | Exit conditions |
+|-----------|------|----------------|-----------------|
+| `builder-new` | Create Profile | `/profiles/builder` (from "New profile") | Valid Save → list; Cancel → list |
+| `builder-edit` | Edit Profile | `/profiles/builder?id=<id>` (from a structured row's "Edit") | Valid Save → list; Cancel → list |
+| `legacy-view` | View Profile (read-only) | `/profiles/edit-form?id=<id>&view=1` (from a Legacy row's "View") | Back → list |
+
+---
+
+## 3. State Machine Transitions
+
+```
+profiles-page --[New profile]----------------> builder-new
+profiles-page --[structured row · Edit]-------> builder-edit
+profiles-page --[legacy row · View]-----------> legacy-view (read-only)
+builder-* --[Save · all enabled fields valid]-> profiles-page
+builder-* --[Save · any invalid]--------------> builder-* (errors shown, no navigation)
+```
+
+---
+
+## 4. Screen Designs
+
+### 4.1 Validation on save (`builder-*`)
+
+Each validatable numeric field (Stage temp/time, each Sub-stage temp/time, cycles) gets an adjacent error element `<p class="field-error is-hidden">Invalid Value</p>` and, when invalid, the input gets an `is-invalid` red-border class.
+
+**Trigger:** validation runs **only on Save attempt** — never on initial load, so a pristine blank form shows no errors (PRD story 28).
+
+**On Save:**
+- Validate every field in **enabled** Stages plus Amplification (always enabled). **Disabled (unchecked) Stages are skipped entirely** — their blanks never block save.
+- A field is invalid if blank, non-numeric, or out of range. Ranges (mirroring `validate_stages`):
+  - temp: **25–100** °C
+  - time: **1–600** s
+  - **last (extension-bearing) Sub-stage** time: **11–600** s — the last Sub-stage row, i.e. "Annealing & Extension" (2-step) or "Extension" (3-step)
+  - cycles: integer **1–50**
+- **All** offending fields flag at once (red border + "Invalid Value"); the first invalid field scrolls into view.
+- If anything is invalid: **do not POST, do not navigate**.
+- If all valid: clear any error styling and POST as today (B1/B2). The server still re-validates; a 400 `{detail:{errors:[…]}}` surfaces in `#save-status` (defense in depth — should not normally happen given client parity).
+
+**Est. Time (Min):** the optional estimate field is validated on save exactly like the legacy editor (`edit.js`) — blank is fine; a value must be a positive integer, else the field flags `is-invalid` with its "Invalid Estimated Time" message (`#profile-estimated-error`) and blocks the save.
+
+### 4.2 Edit round-trip (`builder-edit`)
+
+On load, if the URL carries `?id=<id>` (or `?profile=`):
+- `GET /profiles/details?id=<id>`; read the returned `stages` object.
+- Repopulate: `#profile-name` (title), FAM/ROX labels, estimated minutes; each optional Stage's checkbox (`enabled`) + temp/time (triggering the B1 grey/disable sync); Amplification `cycles`; and the Sub-stages — **including adding the third row** when `subStages.length === 3` (reusing B2's add path so names/X/controls are correct), then filling each temp/time.
+- Title affordance: the header reads "Edit Profile" in edit mode (vs "Create Profile" for new).
+- **Save updates in place:** the payload includes `profile_id: <id>` so the backend overwrites the existing profile rather than creating a copy. (`save_profile` already keys off `profile_id`.)
+- A profile with no `stages` should not normally reach here (the list routes Legacy → the read-only view); if `?id` resolves to one, fall back gracefully (leave the form at its blank defaults).
+
+### 4.3 List routing (`profiles.js`)
+
+Replace the single "Edit → `/profiles/edit-form`" affordance with per-row routing keyed on the `structured` and `bundled` flags from `GET /profiles`:
+
+| Row type | Flag | Affordance | Target |
+|----------|------|-----------|--------|
+| Structured | `structured === true`, not bundled | **Edit** | `/profiles/builder?id=<id>` |
+| Legacy | `structured` falsy, not bundled | **View** | `/profiles/edit-form?id=<id>&view=1` |
+| Bundled | `bundled === true` | read-only (unchanged — lock icon, no edit affordance) | — |
+
+"New profile" (`index.html`) → `/profiles/builder`.
+
+**`edit.js` read-only fix:** `?view=1` previously got reset back to editable whenever the "Edit View" toggle existed, so the legacy viewer opened editable. That reset is removed so `?view=1` honours read-only. (Fully locking the viewer + the summary header + aligned step layout are **B4 / #211**, deliberately deferred — this issue only guarantees Legacy *opens* read-only.)
+
+---
+
+## 5. Data Binding
+
+| UI element | Source | Trigger |
+|------------|--------|---------|
+| Builder fields (edit mode) | `GET /profiles/details?id=` → `stages`, title, labels, `estimated_completion_seconds` | On load when `?id` present |
+| Row Edit/View affordance | `GET /profiles` → `structured`, `bundled` | On list render |
+| Save (create) | `POST /profiles` `{name, fam_label, rox_label, estimated_minutes, stages}` | Save, all valid |
+| Save (edit) | as above **plus** `profile_id` | Save, all valid, `?id` present |
+
+Client validation ranges must equal `aquila_web/profile_assembly.py::validate_stages`. If those constants change server-side, the client values here must change too (documented coupling).
+
+---
+
+## 6. Accessibility / Kiosk Constraints
+
+- Error state must be unmistakable on the kiosk: red border **and** the "Invalid Value" text (not colour alone).
+- No new tap targets below 44px; existing controls unchanged.
+
+---
+
+## 7. Acceptance Criteria
+
+- [ ] Save with blanks/invalid flags **every** offending enabled field red with "Invalid Value" and does **not** navigate.
+- [ ] A pristine blank form shows no errors until a Save is attempted.
+- [ ] Disabled Stages never block save (their blank/invalid fields are skipped).
+- [ ] The last Sub-stage enforces the 11 s minimum; other times enforce 1 s.
+- [ ] Opening a structured Profile (`?id`) repopulates all Stages, Sub-stages (incl. a 3rd when present), and values from `stages`; Save updates it in place (`profile_id`).
+- [ ] Profiles list routes structured → builder (Edit), Legacy → read-only view (View); bundled stay read-only.
+- [ ] "New profile" opens the builder.
+- [ ] e2e tests in `tests/e2e/` for validation display, round-trip repopulation, and list routing; existing B1/B2 tests still pass.
+
+---
+
+## 8. Out of Scope (other issues)
+
+- Backend assembly/validation/ranges and the `structured` flag — A1/A2/A3 (#198/#199/#201), merged.
+- The integration issue's real-backend convergence checklist — C (#204).
+- Re-authoring the Legacy read-only viewer — it is reused as-is via `?view=1`.
+
+---
+
+## 9. Open Questions
+
+- [ ] None — backend contract is merged (A3) and routing/validation decisions are resolved in ADR-018 and the PRD.

--- a/tests/e2e/test_profile_builder.py
+++ b/tests/e2e/test_profile_builder.py
@@ -228,6 +228,10 @@ def test_three_step_save_posts_three_substages(page, base_url):
     _goto_builder(page, base_url)
 
     page.locator("#profile-name").fill("B2 Three Step")
+    # Focus on amplification: disable the other Stages so save-time validation
+    # (B3) doesn't flag their blank fields.
+    for stage in ("incubation", "denaturation", "finalhold"):
+        page.locator(f"#stage-{stage}-enabled").uncheck()
     page.locator("#stage-amp-cycles").fill("35")
     page.locator("#amp-add-substage").click()  # -> three Sub-stages
 
@@ -280,3 +284,297 @@ def test_touch_targets_meet_kiosk_minimum(page, base_url):
     for i in range(toggles.count()):
         box = toggles.nth(i).bounding_box()
         assert box["height"] >= MIN, f"stage toggle {i} too short: {box['height']}px"
+
+
+# ---------------------------------------------------------------------------
+# Validation on save (issue #203, B3)
+# ---------------------------------------------------------------------------
+
+# Every validatable field on a fresh (two-Sub-stage) form, all Stages enabled.
+ENABLED_FIELDS = [
+    "#stage-incubation-temp", "#stage-incubation-time",
+    "#stage-denaturation-temp", "#stage-denaturation-time",
+    "#stage-finalhold-temp", "#stage-finalhold-time",
+    "#stage-amp-cycles",
+    "#stage-amp-sub-0-temp", "#stage-amp-sub-0-time",
+    "#stage-amp-sub-1-temp", "#stage-amp-sub-1-time",
+]
+
+
+def _is_invalid(page, sel):
+    return "is-invalid" in (page.locator(sel).get_attribute("class") or "")
+
+
+def test_pristine_form_has_no_validation_errors(page, base_url):
+    """A freshly loaded builder shows no error styling until a Save is tried."""
+    _goto_builder(page, base_url)
+    assert page.locator(".is-invalid").count() == 0
+    assert page.locator(".field-error:visible").count() == 0
+
+
+def test_blank_save_flags_every_enabled_field_and_blocks(page, base_url):
+    """Saving an all-blank form flags every enabled field red with 'Invalid
+    Value' and does not navigate away."""
+    _goto_builder(page, base_url)
+    page.locator("#profile-name").fill("B3 Blank")
+
+    page.locator("#save-profile-button").click()
+
+    for sel in ENABLED_FIELDS:
+        assert _is_invalid(page, sel), f"{sel} should be flagged invalid"
+    errors = page.locator(".field-error:visible")
+    assert errors.count() >= 1
+    assert "Invalid Value" in errors.first.inner_text()
+
+    # Blocked: still on the builder, no redirect to the Profiles list.
+    assert page.url.rstrip("/").endswith("/profiles/builder")
+
+
+def test_disabled_stage_does_not_block_save(page, base_url):
+    """A disabled (unchecked) Stage's blank fields are skipped by validation, so
+    an otherwise-valid form still saves."""
+    _goto_builder(page, base_url)
+
+    page.locator("#profile-name").fill("B3 Disabled Skip")
+    page.locator("#stage-incubation-enabled").uncheck()  # left blank, must not block
+
+    page.locator("#stage-denaturation-temp").fill("95")
+    page.locator("#stage-denaturation-time").fill("120")
+    page.locator("#stage-finalhold-temp").fill("25")
+    page.locator("#stage-finalhold-time").fill("60")
+    page.locator("#stage-amp-cycles").fill("40")
+    page.locator("#stage-amp-sub-0-temp").fill("95")
+    page.locator("#stage-amp-sub-0-time").fill("11")
+    page.locator("#stage-amp-sub-1-temp").fill("60")
+    page.locator("#stage-amp-sub-1-time").fill("38")
+
+    def is_save_post(req):
+        return req.url.rstrip("/").endswith("/profiles") and req.method == "POST"
+
+    with page.expect_response(lambda r: is_save_post(r.request)) as resp_info:
+        page.locator("#save-profile-button").click()
+
+    assert resp_info.value.status == 200
+    page.wait_for_url("**/profiles-page", timeout=5_000)
+
+    listing = page.request.get(f"{base_url}/profiles").json()
+    stale = [p["id"] for p in listing if "B3_Disabled_Skip" in p.get("id", "")]
+    if stale:
+        page.request.post(f"{base_url}/profiles/delete", data={"profiles": stale})
+
+
+def _fill_valid_two_step(page):
+    """Fill a fully valid two-Sub-stage form (caller tweaks one field to test edges)."""
+    page.locator("#profile-name").fill("B3 Ranges")
+    page.locator("#stage-incubation-temp").fill("37")
+    page.locator("#stage-incubation-time").fill("600")
+    page.locator("#stage-denaturation-temp").fill("95")
+    page.locator("#stage-denaturation-time").fill("120")
+    page.locator("#stage-finalhold-temp").fill("25")
+    page.locator("#stage-finalhold-time").fill("60")
+    page.locator("#stage-amp-cycles").fill("40")
+    page.locator("#stage-amp-sub-0-temp").fill("95")
+    page.locator("#stage-amp-sub-0-time").fill("11")
+    page.locator("#stage-amp-sub-1-temp").fill("60")
+    page.locator("#stage-amp-sub-1-time").fill("38")
+
+
+def test_extension_min_applies_only_to_last_substage(page, base_url):
+    """The 11s minimum applies to the last (extension-bearing) Sub-stage only:
+    a 5s first Sub-stage is fine, a 10s last Sub-stage is rejected."""
+    _goto_builder(page, base_url)
+    _fill_valid_two_step(page)
+    page.locator("#stage-amp-sub-0-time").fill("5")   # not last -> min 1, OK
+    page.locator("#stage-amp-sub-1-time").fill("10")  # last -> min 11, invalid
+
+    page.locator("#save-profile-button").click()
+
+    assert _is_invalid(page, "#stage-amp-sub-1-time"), "last sub-stage <11s must flag"
+    assert not _is_invalid(page, "#stage-amp-sub-0-time"), "first sub-stage 5s is valid"
+    assert page.url.rstrip("/").endswith("/profiles/builder")  # blocked
+
+
+def test_out_of_range_temp_and_cycles_block_then_pass(page, base_url):
+    """Out-of-range temp (24) and cycles (51) are flagged and block; fixing them
+    to the valid edges (25 / 50) lets the save through."""
+    _goto_builder(page, base_url)
+    _fill_valid_two_step(page)
+    page.locator("#stage-incubation-temp").fill("24")  # below 25
+    page.locator("#stage-amp-cycles").fill("51")       # above 50
+
+    page.locator("#save-profile-button").click()
+    assert _is_invalid(page, "#stage-incubation-temp")
+    assert _is_invalid(page, "#stage-amp-cycles")
+    assert page.url.rstrip("/").endswith("/profiles/builder")
+
+    # Fix to the valid boundary values; save now succeeds.
+    page.locator("#stage-incubation-temp").fill("25")
+    page.locator("#stage-amp-cycles").fill("50")
+
+    def is_save_post(req):
+        return req.url.rstrip("/").endswith("/profiles") and req.method == "POST"
+
+    with page.expect_response(lambda r: is_save_post(r.request)) as resp_info:
+        page.locator("#save-profile-button").click()
+    assert resp_info.value.status == 200
+    page.wait_for_url("**/profiles-page", timeout=5_000)
+
+    listing = page.request.get(f"{base_url}/profiles").json()
+    stale = [p["id"] for p in listing if "B3_Ranges" in p.get("id", "")]
+    if stale:
+        page.request.post(f"{base_url}/profiles/delete", data={"profiles": stale})
+
+
+# ---------------------------------------------------------------------------
+# Edit round-trip (issue #203, B3)
+# ---------------------------------------------------------------------------
+
+ROUNDTRIP_STAGES = {
+    "incubation": {"enabled": True, "temp": 37, "time": 600},
+    "denaturation": {"enabled": True, "temp": 95, "time": 120},
+    "amplification": {
+        "cycles": 40,
+        "subStages": [
+            {"name": "Denaturation", "temp": 95, "time": 11},
+            {"name": "Annealing", "temp": 60, "time": 30},
+            {"name": "Extension", "temp": 72, "time": 20},
+        ],
+    },
+    "finalHold": {"enabled": False, "temp": 25, "time": 60},
+}
+
+
+def test_edit_roundtrip_repopulates_and_updates_in_place(page, base_url):
+    """Opening a structured Profile by id repopulates every Stage/Sub-stage/value
+    from its `stages`, and saving updates that same profile (carries profile_id)."""
+    # Seed a structured profile straight through the API.
+    created = page.request.post(
+        f"{base_url}/profiles",
+        data={"name": "B3 Roundtrip", "stages": ROUNDTRIP_STAGES},
+    )
+    assert created.status == 200, created.text()
+    pid = created.json()["id"]
+
+    try:
+        page.goto(f"{base_url}/profiles/builder?id={pid}", timeout=10_000)
+        page.wait_for_load_state("domcontentloaded")
+        # Repopulation is async (fetch /details); wait for a known value to land.
+        page.wait_for_function(
+            "() => document.getElementById('stage-amp-cycles')?.value === '40'",
+            timeout=5_000,
+        )
+
+        assert page.locator("#profile-name").input_value() == "B3 Roundtrip"
+        # Enabled Stage values restored.
+        assert page.locator("#stage-incubation-enabled").is_checked()
+        assert page.locator("#stage-incubation-temp").input_value() == "37"
+        assert page.locator("#stage-incubation-time").input_value() == "600"
+        # Disabled Stage restored as unchecked + greyed.
+        assert not page.locator("#stage-finalhold-enabled").is_checked()
+        assert "stage--disabled" in (page.locator("#stage-finalhold").get_attribute("class") or "")
+        # Three Sub-stages with their three-step names and values.
+        assert page.locator(".amp-substage").count() == 3
+        assert _substage_names(page) == THREE_STEP_NAMES
+        assert page.locator("#stage-amp-sub-2-temp").input_value() == "72"
+        assert page.locator("#stage-amp-sub-2-time").input_value() == "20"
+
+        # Saving updates in place: the POST carries profile_id.
+        def is_save_post(req):
+            return req.url.rstrip("/").endswith("/profiles") and req.method == "POST"
+
+        with page.expect_request(is_save_post) as req_info:
+            page.locator("#save-profile-button").click()
+        assert req_info.value.post_data_json.get("profile_id") == pid
+        page.wait_for_url("**/profiles-page", timeout=5_000)
+    finally:
+        _delete_profile_by_fragment(page, base_url, "B3_Roundtrip")
+
+
+def _delete_profile_by_fragment(page, base_url, fragment):
+    listing = page.request.get(f"{base_url}/profiles").json()
+    stale = [p["id"] for p in listing if fragment in p.get("id", "")]
+    if stale:
+        page.request.post(f"{base_url}/profiles/delete", data={"profiles": stale})
+
+
+# ---------------------------------------------------------------------------
+# Profiles-list routing (issue #203, B3)
+# ---------------------------------------------------------------------------
+
+def test_list_routes_structured_legacy_and_bundled(page, base_url):
+    """The list routes structured rows to the builder (Edit), Legacy rows to the
+    read-only view (View), and never gives bundled rows an edit affordance."""
+    page.request.post(f"{base_url}/profiles", data={"name": "B3 Routing Structured", "stages": ROUNDTRIP_STAGES})
+    page.request.post(f"{base_url}/profiles", data={"name": "B3 Routing Legacy", "steps": [{"setpoint": 95, "duration": 30}]})
+
+    try:
+        page.goto(f"{base_url}/profiles-page", timeout=10_000)
+        page.wait_for_selector("a.profiles-action-btn[href*='B3_Routing']", timeout=5_000)
+
+        edit = page.locator("a.profiles-action-btn[href*='B3_Routing_Structured']")
+        assert edit.count() == 1
+        assert "edit" in edit.inner_text().lower()  # CSS uppercases the label
+        assert "/profiles/builder" in edit.get_attribute("href")
+
+        view = page.locator("a.profiles-action-btn[href*='B3_Routing_Legacy']")
+        assert view.count() == 1
+        assert "view" in view.inner_text().lower()
+        href = view.get_attribute("href")
+        assert "/profiles/edit-form" in href and "view=1" in href
+
+        # Bundled rows (lock icon) carry no Edit/View action link.
+        assert page.locator("tr:has(.profile-lock-icon) a.profiles-action-btn").count() == 0
+    finally:
+        _delete_profile_by_fragment(page, base_url, "B3_Routing")
+
+
+def test_new_profile_button_opens_builder(page, base_url):
+    """The Profiles list 'New profile' button opens the structured builder."""
+    try:
+        page.goto(f"{base_url}/profiles-page", timeout=10_000)
+    except Exception as exc:
+        pytest.skip(f"Backend not reachable: {exc}")
+    new_btn = page.locator("a", has_text="New profile").first
+    assert new_btn.get_attribute("href") == "/profiles/builder"
+
+
+# ---------------------------------------------------------------------------
+# B3 follow-ups: Est Time validation, legacy read-only, red error text
+# ---------------------------------------------------------------------------
+
+def test_invalid_estimated_time_blocks_save(page, base_url):
+    """A non-positive / non-numeric Est. Time is flagged and blocks save, like
+    the legacy editor on main."""
+    _goto_builder(page, base_url)
+    _fill_valid_two_step(page)
+    page.locator("#profile-estimated-minutes").fill("-5")
+
+    page.locator("#save-profile-button").click()
+
+    assert _is_invalid(page, "#profile-estimated-minutes")
+    assert page.locator("#profile-estimated-error").is_visible()
+    assert page.url.rstrip("/").endswith("/profiles/builder")  # blocked
+
+
+def test_legacy_profile_opens_read_only(page, base_url):
+    """Routing a Legacy Profile to ?view=1 opens the viewer read-only (inputs
+    disabled), not the editable legacy editor."""
+    from urllib.parse import quote
+    leg = page.request.post(
+        f"{base_url}/profiles",
+        data={"name": "B3 ReadOnly", "steps": [{"setpoint": 95, "duration": 30}]},
+    ).json()["id"]
+    try:
+        page.goto(f"{base_url}/profiles/edit-form?id={quote(leg)}&view=1", timeout=10_000)
+        page.wait_for_load_state("networkidle")
+        assert page.locator("#profile-name").is_disabled(), "legacy view must be read-only"
+    finally:
+        page.request.post(f"{base_url}/profiles/delete", data={"profiles": [leg]})
+
+
+def test_invalid_value_message_is_red(page, base_url):
+    """The 'Invalid Value' message renders red, not the muted card-text grey."""
+    _goto_builder(page, base_url)
+    page.locator("#save-profile-button").click()  # all-blank -> errors shown
+    color = page.eval_on_selector(".field-error:visible", "el => getComputedStyle(el).color")
+    assert color == "rgb(220, 38, 38)", f"expected red #dc2626, got {color}"


### PR DESCRIPTION
Closes #203 — the final structured-editor frontend slice: makes the builder trustworthy (validation), complete (edit existing profiles), and wired into the app (list routing). Builds on the merged backend (A1–A3) and B1/B2.

## What this does

**Validation on save** (client-side, mirrors `profile_assembly.validate_stages`):
- On Save, every enabled-Stage field that's blank, non-numeric, or out of range flags red with "Invalid Value" — **all offenders at once** — and the save is **blocked** (no POST, no navigation). Ranges: temp 25–100, time 1–600, last (extension) Sub-stage 11–600, cycles 1–50.
- Disabled Stages are skipped. A pristine form shows **no** errors until Save is attempted.
- **Est. Time (Min)** is now validated like the legacy editor (positive integer), which it wasn't before.

**Edit round-trip:**
- `/profiles/builder?id=<id>` repopulates every Stage/Sub-stage/value from `stages` (including rebuilding the 3rd Sub-stage); Save updates in place via `profile_id`; header reads "Edit Profile".

**List routing** (`profiles.js` / `index.html`):
- Structured rows → **Edit** → builder; Legacy rows → **View** → read-only viewer (`?view=1`); bundled stay locked. "New profile" → builder.

## Bug fixes folded in (from live review)
- **`edit.js`**: `?view=1` was being reset back to editable whenever the "Edit View" toggle existed, so Legacy opened editable. Removed the reset so Legacy genuinely **opens read-only**.
- **`.field-error`** rendered grey (beaten by `.card p`); now red.

## Deferred to B4 (#211)
Fully locking the legacy viewer (hide the Edit View toggle), the read-only **summary header** (name/FAM/ROX/est-time), and the **aligned step layout** are B4 — to be done before integration (#204), which has been updated to expect them.

## Tests
`tests/e2e/test_profile_builder.py` — **20 passing** locally (B1/B2/B3): validation display, disabled-skip, range edges, Est-Time, edit round-trip, list routing, legacy read-only, red error text. CI runs no pytest here, so this is a local run. **No `main.py` change.**

## Spec
`specs/frontend/spec_validation_roundtrip_routing.md`

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)