### PR TITLE
#213 (A4) canonical JSON key order for structured profiles

### DIFF
--- a/aquila_web/main.py
+++ b/aquila_web/main.py
@@ -226,6 +226,37 @@ def _order_time_fields(profile: dict) -> dict:
     return ordered
 
 
+# Canonical top-level key order for structured profiles (issue #213 / A4):
+# metadata first, then the human-authored stages, then the derived steps last.
+CANONICAL_PROFILE_KEY_ORDER = (
+    "output_dir",
+    "post_in_gui",
+    "title",
+    "rox_unavailable",
+    "time_unavailable",
+    "estimated_completion_seconds",
+    "labels",
+    "stages",
+    "steps",
+)
+
+
+def _order_profile_keys(profile: dict) -> dict:
+    """Return a copy of *profile* with top-level keys in CANONICAL_PROFILE_KEY_ORDER.
+
+    Only keys that are present are emitted (no injection). Any keys not in the
+    canonical list are preserved and appended in their original relative order
+    (never dropped). See spec_profile_key_order.md."""
+    ordered: dict = {}
+    for key in CANONICAL_PROFILE_KEY_ORDER:
+        if key in profile:
+            ordered[key] = profile[key]
+    for key, value in profile.items():
+        if key not in ordered:
+            ordered[key] = value
+    return ordered
+
+
 class ProfileSelect(BaseModel):
     profile: str
 
@@ -1438,7 +1469,12 @@ async def save_profile(payload: ProfileSave):
                 candidate_path = profile_dir / f"{sanitized_title}_{int(datetime.now().timestamp())}.json"
             profile_path = candidate_path
 
-    base_profile = _order_time_fields(base_profile)
+    # Structured profiles (issue #213) get the full canonical key order; legacy
+    # steps-based saves keep the narrower time-field ordering unchanged.
+    if "stages" in base_profile:
+        base_profile = _order_profile_keys(base_profile)
+    else:
+        base_profile = _order_time_fields(base_profile)
 
     try:
         with profile_path.open("w") as f:

--- a/specs/backend/spec_profile_key_order.md
+++ b/specs/backend/spec_profile_key_order.md
@@ -1,0 +1,67 @@
+# Backend Spec: Canonical Profile JSON Key Order — issue #213 (A4)
+
+**Status:** Draft
+**Author:** Aquila Engineering Team
+**Last updated:** 2026-06-26
+**GitHub issue:** #213
+**Source file(s):** `aquila_web/main.py`, `tests/contract/test_profile_endpoints.py`
+**Umbrella PRD:** `specs/prd/structured-profile-editor-prd.md` · **Decision:** ADR-018
+**Supersedes helper:** `_order_time_fields()` (the targeted 2-key reorder this generalizes)
+
+---
+
+## 1. Overview
+
+Structured Profiles save their top-level JSON keys in an inconsistent order vs Legacy Profiles (`steps` floats to the top, `post_in_gui`/`stages`/`labels` land in the wrong spots) because `save_profile` builds the dict by insertion order. This issue enforces one canonical key order on every saved profile. Purely a serialization/ordering change — **no values or semantics change**.
+
+---
+
+## 2. Canonical order
+
+Order the keys that are present into this sequence; any other/unknown top-level keys are preserved and appended after, in their original relative order (never dropped):
+
+1. `output_dir`
+2. `post_in_gui`
+3. `title`
+4. `rox_unavailable` *(when present)*
+5. `time_unavailable`
+6. `estimated_completion_seconds`
+7. `labels`
+8. `stages` *(structured profiles only)*
+9. `steps`
+
+Rationale: metadata first (matches legacy), then the human-authored `stages`, then the large machine-facing `steps` last. `stages` immediately precedes `steps`.
+
+**Decisions (resolved):**
+- **`labels` placement:** with the metadata, after `estimated_completion_seconds`, before `stages`. ✔
+- **Scope:** **structured saves only** (a profile whose `base_profile` has a `stages` key). Legacy/`steps`-based saves keep the existing `_order_time_fields` behavior unchanged. ✔
+
+---
+
+## 3. Implementation
+
+- Add `_order_profile_keys(profile: dict) -> dict` in `main.py`: build a new dict by walking the canonical list and copying present keys, then append any leftover keys. Pure dict→dict.
+- `save_profile` calls `_order_profile_keys(base_profile)` immediately before writing **when `base_profile` has a `stages` key** (structured); otherwise it keeps the existing `_order_time_fields(base_profile)` call. The countdown keys are already set on `base_profile` before this point, so ordering need not inject them.
+- Keep the existing "both countdown fields always present, positioned after the anchor" guarantee intact (canonical order keeps `time_unavailable` → `estimated_completion_seconds` right after `title`/`rox_unavailable`).
+
+---
+
+## 8. Tests
+
+`tests/contract/test_profile_endpoints.py` (marked `contract`; prior art: `test_saved_file_always_carries_both_fields_after_anchor`, which reads the written file from disk):
+- A saved **structured** profile's top-level keys equal the canonical order (filtered to present keys); `stages` immediately precedes `steps`; `steps` is last. (`tests/contract/test_profile_endpoints.py::test_structured_profile_keys_in_canonical_order`)
+- Unit tests for the pure `_order_profile_keys`: canonical order regardless of input order; only-present keys emitted; `rox_unavailable` placement; **unknown keys preserved, never dropped** (`unit_tests/test_profile_key_order.py`).
+- **Legacy/steps-based saves are unchanged** — the existing countdown-field ordering test (`test_saved_file_always_carries_both_fields_after_anchor`) still passes.
+
+Run: `pytest tests/contract/test_profile_endpoints.py -v`
+
+---
+
+## Out of Scope
+
+- Re-ordering already-saved profile files on disk (this only affects writes; existing files normalize on their next save).
+- Any change to `stages`/`steps` content — A1/A2/A3 own those.
+
+## 9. Open Questions
+
+- None — `labels` placement and structured-only scope both resolved above.

--- a/tests/contract/test_profile_endpoints.py
+++ b/tests/contract/test_profile_endpoints.py
@@ -495,3 +495,33 @@ def test_list_profiles_includes_structured_flag(client):
     finally:
         _delete_profile(client, structured_id)
         _delete_profile(client, legacy_id)
+
+
+# ---------------------------------------------------------------------------
+# Structured profiles — canonical JSON key order (issue #213 / A4)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.contract
+def test_structured_profile_keys_in_canonical_order(client):
+    """A saved structured profile writes its top-level keys in canonical order:
+    output_dir, post_in_gui, title, countdown fields, labels, stages, steps."""
+    from aquila_web import main as web_main
+
+    resp = client.post("/profiles", json={
+        "name": "A4 Key Order",
+        "fam_label": "FAM",
+        "rox_label": "ROX",
+        "stages": SAMPLE_STAGES,
+    })
+    assert resp.status_code == 200, resp.text
+    pid = resp.json()["id"]
+    try:
+        keys = list(json.loads((web_main.resolve_profile_dir() / pid).read_text()).keys())
+        assert keys == [
+            "output_dir", "post_in_gui", "title",
+            "time_unavailable", "estimated_completion_seconds",
+            "labels", "stages", "steps",
+        ]
+    finally:
+        _delete_profile(client, pid)

--- a/unit_tests/test_profile_key_order.py
+++ b/unit_tests/test_profile_key_order.py
@@ -1,0 +1,82 @@
+"""
+Unit tests for aquila_web.main._order_profile_keys — canonical top-level key
+ordering for structured profiles (issue #213 / A4).
+
+Pure dict->dict logic. Marked ``unit``. Spec: specs/backend/spec_profile_key_order.md.
+"""
+import os
+import sys
+import types
+from pathlib import Path
+
+import pytest
+
+pytestmark = pytest.mark.unit
+
+# Stub heavy hardware deps before importing main (same approach as the other
+# unit test modules so importing aquila_web.main works on a dev machine / CI).
+for _mod in ("RPi", "RPi.GPIO"):
+    sys.modules.setdefault(_mod, types.ModuleType(_mod))
+
+if "serial" not in sys.modules:
+    _s = types.ModuleType("serial")
+    _st = types.ModuleType("serial.tools")
+    _lp = types.ModuleType("serial.tools.list_ports")
+    _lp.comports = lambda: []
+    _s.tools = _st
+    _st.list_ports = _lp
+    sys.modules.update({"serial": _s, "serial.tools": _st, "serial.tools.list_ports": _lp})
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(REPO_ROOT))
+sys.path.insert(0, str(REPO_ROOT / "aquila_web"))
+os.environ.setdefault("AQ_DEV_SIMULATE", "1")
+
+from aquila_web.main import _order_profile_keys
+
+
+def test_orders_keys_canonically_regardless_of_input_order():
+    """Keys are emitted in canonical order even when the input is scrambled."""
+    scrambled = {
+        "steps": [],
+        "labels": {"fam": "FAM"},
+        "title": "X",
+        "stages": {},
+        "output_dir": "pcr_data",
+        "estimated_completion_seconds": 60,
+        "post_in_gui": "True",
+        "time_unavailable": False,
+    }
+    assert list(_order_profile_keys(scrambled).keys()) == [
+        "output_dir", "post_in_gui", "title",
+        "time_unavailable", "estimated_completion_seconds",
+        "labels", "stages", "steps",
+    ]
+
+
+def test_only_present_keys_are_emitted():
+    """Absent canonical keys (e.g. rox_unavailable, labels) are not invented."""
+    profile = {"steps": [], "title": "X", "output_dir": "pcr_data"}
+    assert list(_order_profile_keys(profile).keys()) == ["output_dir", "title", "steps"]
+
+
+def test_rox_unavailable_placed_before_countdown_when_present():
+    """rox_unavailable sits after title, before the countdown fields."""
+    profile = {
+        "steps": [], "title": "X", "output_dir": "pcr_data",
+        "rox_unavailable": True, "time_unavailable": False,
+    }
+    assert list(_order_profile_keys(profile).keys()) == [
+        "output_dir", "title", "rox_unavailable", "time_unavailable", "steps",
+    ]
+
+
+def test_unknown_keys_are_preserved_and_appended():
+    """Keys not in the canonical list are kept (never dropped) and trail in order."""
+    profile = {
+        "steps": [], "output_dir": "pcr_data", "title": "X",
+        "custom_one": 1, "custom_two": 2,
+    }
+    result = _order_profile_keys(profile)
+    assert result["custom_one"] == 1 and result["custom_two"] == 2
+    assert list(result.keys()) == ["output_dir", "title", "steps", "custom_one", "custom_two"]


### PR DESCRIPTION
Closes #213 — A4: write structured-profile JSON keys in a canonical order.

## Problem
New structured profiles serialized their top-level keys in insertion order — `steps` jumped to the top, `post_in_gui`/`stages`/`labels` trailed — inconsistent with the legacy convention (metadata first, `steps` last).

## What this does
- Adds `CANONICAL_PROFILE_KEY_ORDER` + a pure `_order_profile_keys(profile)` in `main.py`.
- `save_profile` applies it **only for structured saves** (when `stages` is present); legacy/`steps`-based saves keep the existing `_order_time_fields` behavior **unchanged**.
- Canonical order: `output_dir → post_in_gui → title → [rox_unavailable] → time_unavailable → estimated_completion_seconds → labels → stages → steps`.
- **Pure ordering only — no values change.** Only present keys are emitted; unknown keys are preserved (never dropped).

## Before / after (collapsed)
Before: `output_dir, steps, title, time_unavailable, estimated_completion_seconds, post_in_gui, stages, labels`
After:  `output_dir, post_in_gui, title, time_unavailable, estimated_completion_seconds, labels, stages, steps`

## Spec / docs
- Spec: `specs/backend/spec_profile_key_order.md` · PRD: `specs/prd/structured-profile-editor-prd.md` · ADR-018

## SPEC_WORKFLOW checklist
- [x] Spec linked + accurate (scope = structured-only; `labels` placement confirmed)
- [x] New tests: 1 contract (end-to-end key order) + 4 unit (`unit_tests/test_profile_key_order.py`: ordering, only-present keys, `rox_unavailable` placement, unknown-keys-preserved)
- [x] Regression: 94 passed in `unit_tests + test_profile_endpoints.py`; legacy ordering test (`test_saved_file_always_carries_both_fields_after_anchor`) still passes; 3 failures are the known pre-existing environmental ones
- [x] No secrets

## Scope
Structured saves only. Does not rewrite already-saved files on disk (they normalize on next save). No change to `stages`/`steps` content.

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)
