### PR TITLE
#211 Structured Profiles B4 — Legacy read-only view: lock, summary header, aligned layout, no flash

### DIFF
--- a/aquila_web/static/profiles/edit.js
+++ b/aquila_web/static/profiles/edit.js
@@ -230,7 +230,34 @@ const renderSteps = () => {
   renderSummary();
 };
 
+// Read-view header: profile name, FAM/ROX labels, and estimated minutes when set
+// (issue #211). Values come from the loaded form fields.
+const renderSummaryMeta = () => {
+  const meta = document.getElementById("profile-summary-meta");
+  if (!meta) return;
+  const items = [
+    { label: "Profile Name", value: nameInput ? nameInput.value : "" },
+    { label: "FAM Label", value: famLabelInput ? famLabelInput.value : "" },
+    { label: "ROX Label", value: roxLabelInput ? roxLabelInput.value : "" }
+  ];
+  const est = estimatedMinutesInput ? estimatedMinutesInput.value.trim() : "";
+  if (est !== "" && Number(est) > 0) {
+    items.push({ label: "Est. Time (Min)", value: est });
+  }
+  meta.innerHTML = items
+    .map(
+      (item) => `
+      <div>
+        <span class="profile-summary-label">${esc(item.label)}</span>
+        <span class="profile-summary-value">${esc(String(item.value))}</span>
+      </div>
+    `
+    )
+    .join("");
+};
+
 const renderSummary = () => {
+  renderSummaryMeta();
   if (!summaryList) return;
   summaryList.innerHTML = "";
   stages.forEach((stage, stageIndex) => {
@@ -380,6 +407,8 @@ const applyViewMode = () => {
     summarySection.classList.toggle("is-hidden", !isReadView);
   }
   if (toggleReadViewButton) {
+    // Read-only Legacy view has no escape hatch back to editing (issue #211).
+    toggleReadViewButton.classList.toggle("is-hidden", isReadView);
     toggleReadViewButton.textContent = isReadView ? "Edit View" : "Read View";
   }
   if (pageTitle) {

--- a/aquila_web/static/profiles/edit.js
+++ b/aquila_web/static/profiles/edit.js
@@ -407,8 +407,10 @@ const applyViewMode = () => {
     summarySection.classList.toggle("is-hidden", !isReadView);
   }
   if (toggleReadViewButton) {
-    // Read-only Legacy view has no escape hatch back to editing (issue #211).
-    toggleReadViewButton.classList.toggle("is-hidden", isReadView);
+    // Hide the toggle only for URL-driven read-only entry (?view=1) — a Legacy
+    // Profile has no escape hatch back to editing (issue #211). In normal edit
+    // mode the in-page Read View / Edit View round-trip is preserved.
+    toggleReadViewButton.classList.toggle("is-hidden", viewMode);
     toggleReadViewButton.textContent = isReadView ? "Edit View" : "Read View";
   }
   if (pageTitle) {

--- a/aquila_web/static/profiles/edit_form.html
+++ b/aquila_web/static/profiles/edit_form.html
@@ -114,7 +114,7 @@
     </main>
   </div>
   <script src="/static/nav.js?v=1"></script>
-  <script src="/static/profiles/edit.js?v=22"></script>
+  <script src="/static/profiles/edit.js?v=23"></script>
   <script src="/static/keyboard.js?v=14"></script>
 </body>
 </html>

--- a/aquila_web/static/profiles/edit_form.html
+++ b/aquila_web/static/profiles/edit_form.html
@@ -4,7 +4,18 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=768, height=1024, initial-scale=1" />
   <title>Edit Profile</title>
-  <link rel="stylesheet" href="/static/styles.css?v=219" />
+  <link rel="stylesheet" href="/static/styles.css?v=232" />
+  <script>
+    // Apply read-only before first paint so the editable editor never flashes
+    // when a Legacy Profile opens via ?view=1 (issue #211). edit.js still runs
+    // applyViewMode() to populate the summary and disable inputs.
+    (function () {
+      var p = new URLSearchParams(location.search);
+      if (p.get("view") === "1" || p.get("mode") === "view") {
+        document.documentElement.classList.add("view-only");
+      }
+    })();
+  </script>
 </head>
 <body class="app-body">
   <div class="app-shell">
@@ -61,6 +72,7 @@
             <h2>Profile Summary</h2>
             <p>Read-only overview of every stage and step.</p>
           </header>
+          <div id="profile-summary-meta" class="profile-summary-meta"></div>
           <div id="profile-summary-list" class="profile-summary-list"></div>
         </section>
         <section class="card profile-edit" id="profile-edit-steps">
@@ -102,7 +114,7 @@
     </main>
   </div>
   <script src="/static/nav.js?v=1"></script>
-  <script src="/static/profiles/edit.js?v=20"></script>
+  <script src="/static/profiles/edit.js?v=22"></script>
   <script src="/static/keyboard.js?v=14"></script>
 </body>
 </html>

--- a/aquila_web/static/styles.css
+++ b/aquila_web/static/styles.css
@@ -2470,9 +2470,23 @@ a:active {
   gap: 10px;
 }
 
+/* Pre-paint read-only gating for the Legacy viewer (issue #211): hide the
+   editable sections + the Edit View toggle and reveal the summary before edit.js
+   runs, so the editable editor never flashes on a ?view=1 load. */
+html.view-only .profile-edit,
+html.view-only #toggle-read-view {
+  display: none;
+}
+
+html.view-only #profile-summary {
+  display: block;
+}
+
 .profile-summary-step {
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
+  /* Fixed column tracks so every step row aligns regardless of field count —
+     no field-count zig-zag (issue #211). 5 = the max fields any step type has. */
+  grid-template-columns: repeat(5, minmax(0, 1fr));
   gap: 12px;
   padding: 10px 12px;
   border-radius: 10px;

--- a/specs/frontend/spec_legacy_readonly_view.md
+++ b/specs/frontend/spec_legacy_readonly_view.md
@@ -1,0 +1,107 @@
+# Frontend / UI Spec: Legacy Read-only View — lock, summary header, aligned layout, no flash (issue #211)
+
+**Status:** Active
+**Author:** Aquila Engineering Team
+**Last updated:** 2026-06-26
+**GitHub issue:** #211 (Structured Profiles B4)
+**Affected screens:** Legacy Profile read-only view (`/profiles/edit-form?id=<id>&view=1`)
+**Source file(s):** `aquila_web/static/profiles/edit_form.html`, `aquila_web/static/profiles/edit.js`, `aquila_web/static/styles.css`, `tests/e2e/`
+**Umbrella PRD:** `specs/prd/structured-profile-editor-prd.md` · **Decision:** ADR-018
+**Depends on:** #203 (B3 routes Legacy Profiles to `?view=1` and made `edit.js` honour read-only) — merged.
+
+---
+
+## 1. Overview
+
+B3 routes Legacy Profiles to the existing viewer (`edit_form.html` / `edit.js`) via `?view=1` and made the param actually open read-only. B4 makes that viewer **truly read-only and presentable**, in four parts:
+
+1. **Lock it** — no "Edit View" toggle in read-only mode, so a Legacy Profile has no in-app path back to editing.
+2. **Summary header** — name, FAM/ROX labels, and estimated minutes (when set) at the top of the read view.
+3. **Aligned step layout** — fix the field-count-driven zig-zag so steps line up.
+4. **No flash** — the read-only view renders from first paint; the editable editor never flashes.
+
+Out of scope: any change to the structured builder; re-deriving Legacy `steps`; the integration convergence (C / #204, which has been told about these changes).
+
+Context: plain HTML/CSS/JS, no build step (ADR-003); 768×1024 Pi kiosk (ADR-005). The viewer is reached only from the Profiles list's Legacy "View" affordance (B3).
+
+---
+
+## 2. Screen Inventory
+
+| Screen ID | Name | Entry condition | Exit conditions |
+|-----------|------|----------------|-----------------|
+| `legacy-view` | Profile Details (read-only) | `/profiles/edit-form?id=<id>&view=1` (Legacy row "View") | Back ‹ → Profiles list |
+| `legacy-edit` | Edit Run Profile (unchanged) | `/profiles/edit-form?id=<id>` (no `view` param) | Save / Cancel |
+
+`?view=1` ⇒ `legacy-view` (locked); no param ⇒ `legacy-edit` (editable, toggle present — unchanged).
+
+---
+
+## 3. Behaviour
+
+### 3.1 Lock the read-only view (no escape hatch)
+
+- In read-only mode the **"Edit View" toggle (`#toggle-read-view`) is not shown** — there is no control to flip a Legacy Profile into the editable legacy editor.
+- The toggle remains present and functional in normal edit-mode entry (no `view` param).
+
+### 3.2 Summary header
+
+At the top of the Profile Summary (read view), above the per-stage step list, render a header block showing:
+- **Profile name**
+- **FAM** label and **ROX** label (the values entered on the Profile)
+- **Estimated time (minutes)** — shown **only when an estimate is set**; the row is omitted entirely when there is no estimate.
+
+Values come from the already-loaded Profile (the same data `edit.js` populates into the form fields). The estimate is present iff `estimated_completion_seconds` is a positive number (→ minutes).
+
+### 3.3 Aligned step layout
+
+The summary step rows currently use `grid-template-columns: repeat(auto-fit, minmax(120px, 1fr))`, so a row's column count tracks its field count (setpoint ≈ 5 fields, ramp/enable ≈ 3–4) and the columns don't line up across rows — the zig-zag. Replace with a **fixed column grid** (every step row uses the same column tracks regardless of how many fields it has), so labels/values align top-to-bottom. Rows with fewer fields simply leave trailing tracks empty.
+
+### 3.4 No flash of the editable view
+
+Today `edit_form.html` paints the editable form first; `edit.js` then runs `applyViewMode()` and hides the edit sections — a brief flash of the editor. The read-only state must be applied **before first paint**:
+- A tiny synchronous script (in `<head>`/top of `<body>`) reads the `view`/`mode` param and adds a `view-only` class to `<html>` before the body renders.
+- CSS keyed on `html.view-only` immediately hides the editable sections (`.profile-edit`) and the toggle, and reveals `#profile-summary` — so the editor never paints.
+- `edit.js`'s existing `applyViewMode()` still runs (it populates the summary and disables inputs); the pre-paint CSS only removes the visual flash. The two must agree (same end state).
+
+---
+
+## 4. Data Binding
+
+| UI element | Source | Trigger |
+|------------|--------|---------|
+| Summary header: name / FAM / ROX | loaded Profile (`title`, `labels.fam`, `labels.rox`) | On read-view render |
+| Summary header: est. minutes (if set) | `estimated_completion_seconds` → minutes | On read-view render; omitted when unset |
+| Editable vs read-only at first paint | `?view=1` / `?mode=view` → `html.view-only` | Synchronously before paint |
+
+---
+
+## 5. Accessibility / Kiosk Constraints
+
+- Read view is for inspection only — no editable affordances, no toggle.
+- Summary remains legible on the 768×1024 kiosk; aligned columns improve scanability.
+
+---
+
+## 6. Acceptance Criteria
+
+- [ ] Entering a Legacy Profile (`?view=1`) shows **no "Edit View" toggle**; no in-app path from read view to editing.
+- [ ] The read view shows **name + FAM + ROX** at the top of the summary; the **estimated-minutes row appears only when an estimate is set** and is absent otherwise.
+- [ ] Step rows are **column-aligned** (no zig-zag) whether a row has 2 or 5 fields.
+- [ ] Clicking **View** lands directly on the read-only view with **no momentary flash** of the editable editor (read-only applied before first paint).
+- [ ] Normal (non-`view`) edit entry is **unchanged** — toggle present, sections editable.
+- [ ] e2e tests in `tests/e2e/` for the locked view, the summary header (estimate present/absent), the aligned layout, and the no-flash behaviour.
+
+---
+
+## 7. Out of Scope (other issues)
+
+- Structured builder, validation, round-trip, list routing — B1–B3 (#200/#202/#203), merged.
+- Integration convergence and PR to `main` — C (#204), updated to expect this viewer's new behaviour.
+- Re-authoring the legacy step editor itself (edit mode) — only the read-only presentation changes here.
+
+---
+
+## 8. Open Questions
+
+- [ ] None — scope and decisions resolved in #211 and ADR-018.

--- a/tests/e2e/test_legacy_view.py
+++ b/tests/e2e/test_legacy_view.py
@@ -1,0 +1,143 @@
+"""
+E2E tests for the Legacy Profile read-only view (issue #211, Structured Profiles B4).
+
+The Legacy viewer is the existing `edit_form.html` / `edit.js`, which B3 (#203)
+routes Legacy Profiles to via `?view=1`. B4 locks it (no Edit View toggle), adds a
+summary header (name/FAM/ROX/estimate), aligns the step layout, and removes the
+flash of the editable editor before read-only applies.
+
+Requires a running backend at base_url (default http://localhost:8090; override
+with AQUILA_TEST_URL). Run with: pytest -m e2e tests/e2e/test_legacy_view.py
+"""
+from urllib.parse import quote
+
+import pytest
+
+pytestmark = pytest.mark.e2e
+
+
+def _seed_legacy(page, base_url, name, **fields):
+    """Create a Legacy Profile (no `stages`) and return its id."""
+    body = {"name": name, "steps": [{"setpoint": 95, "duration": 30}], **fields}
+    resp = page.request.post(f"{base_url}/profiles", data=body)
+    assert resp.status == 200, resp.text()
+    return resp.json()["id"]
+
+
+def _delete(page, base_url, pid):
+    page.request.post(f"{base_url}/profiles/delete", data={"profiles": [pid]})
+
+
+def _goto(page, base_url, path):
+    try:
+        page.goto(f"{base_url}{path}", timeout=10_000)
+    except Exception as exc:
+        pytest.skip(f"Backend not reachable at {base_url}: {exc}")
+    page.wait_for_load_state("networkidle")
+
+
+def _view_url(pid, view=True):
+    return f"/profiles/edit-form?id={quote(pid)}" + ("&view=1" if view else "")
+
+
+def test_read_view_hides_edit_toggle_edit_mode_shows_it(page, base_url):
+    """Read-only entry hides the Edit View toggle (no escape to editing); normal
+    edit entry keeps it."""
+    pid = _seed_legacy(page, base_url, "B4 Lock")
+    try:
+        _goto(page, base_url, _view_url(pid, view=True))
+        assert not page.locator("#toggle-read-view").is_visible(), (
+            "Edit View toggle must be hidden in the read-only view"
+        )
+
+        _goto(page, base_url, _view_url(pid, view=False))
+        assert page.locator("#toggle-read-view").is_visible(), (
+            "toggle stays available in normal edit mode"
+        )
+    finally:
+        _delete(page, base_url, pid)
+
+
+def test_summary_header_shows_name_labels_and_estimate(page, base_url):
+    """The read view's summary header shows the profile name, FAM/ROX labels and
+    the estimated minutes when one is set."""
+    pid = _seed_legacy(
+        page, base_url, "B4 Header",
+        fam_label="MyFAM", rox_label="MyROX", estimated_minutes=42,
+    )
+    try:
+        _goto(page, base_url, _view_url(pid, view=True))
+        meta = page.locator("#profile-summary-meta")
+        page.wait_for_selector("#profile-summary-meta", state="attached", timeout=5_000)
+        text = meta.inner_text()
+        assert "B4 Header" in text
+        assert "MyFAM" in text
+        assert "MyROX" in text
+        assert "42" in text  # estimated minutes
+    finally:
+        _delete(page, base_url, pid)
+
+
+def test_summary_header_omits_estimate_when_unset(page, base_url):
+    """With no estimate set, the summary header has no estimated-minutes row."""
+    pid = _seed_legacy(page, base_url, "B4 NoEst", fam_label="FAM", rox_label="ROX")
+    try:
+        _goto(page, base_url, _view_url(pid, view=True))
+        page.wait_for_selector("#profile-summary-meta", state="attached", timeout=5_000)
+        text = page.locator("#profile-summary-meta").inner_text()
+        assert "B4 NoEst" in text
+        assert "Est. Time" not in text and "Estimated" not in text
+    finally:
+        _delete(page, base_url, pid)
+
+
+def test_summary_step_rows_share_one_column_layout(page, base_url):
+    """Step rows align: every row uses the same column tracks regardless of how
+    many fields it has (no field-count zig-zag)."""
+    pid = _seed_legacy(
+        page, base_url, "B4 Align",
+        steps=[
+            {"setpoint": 95, "duration": 30, "description": "Hold"},  # 5 fields
+            {"ramp_rate": 1.6},                                        # 3 fields
+            {"enable": 0, "duration": 1},                              # 4 fields
+        ],
+    )
+    try:
+        _goto(page, base_url, _view_url(pid, view=True))
+        page.wait_for_selector(".profile-summary-step", state="attached", timeout=5_000)
+        cols = page.eval_on_selector_all(
+            ".profile-summary-step",
+            "els => els.map(e => getComputedStyle(e).gridTemplateColumns)",
+        )
+        assert len(cols) >= 2, f"need multiple step rows, got {len(cols)}"
+        # Aligned == every row has the same number of grid tracks regardless of
+        # field count (auto-fit gave 5/3/4; fixed columns give the same count).
+        # Exact px can differ by sub-pixel fr rounding, so compare track counts.
+        track_counts = [len(c.split()) for c in cols]
+        assert len(set(track_counts)) == 1, f"rows must share track count, got {track_counts}"
+    finally:
+        _delete(page, base_url, pid)
+
+
+def test_no_flash_read_only_applied_before_paint(page, base_url):
+    """`?view=1` gets the pre-paint `view-only` class on <html> (so the editable
+    sections never paint); a normal edit load does not."""
+    pid = _seed_legacy(page, base_url, "B4 Flash")
+    try:
+        _goto(page, base_url, _view_url(pid, view=True))
+        assert "view-only" in (page.eval_on_selector("html", "el => el.className") or ""), (
+            "read-only view must set html.view-only before paint"
+        )
+        assert page.locator(".profile-edit").first.is_visible() is False, (
+            "editable sections must not show in the read-only view"
+        )
+
+        _goto(page, base_url, _view_url(pid, view=False))
+        assert "view-only" not in (page.eval_on_selector("html", "el => el.className") or ""), (
+            "edit mode must not be view-only"
+        )
+        assert page.locator("#profile-edit-details").is_visible(), (
+            "edit mode shows the editable sections"
+        )
+    finally:
+        _delete(page, base_url, pid)


### PR DESCRIPTION
Closes #211 — makes the Legacy read-only viewer (`edit_form.html` / `edit.js`) that B3 routes to via `?view=1` truly read-only and presentable. Sequenced before the integration issue (#204, which was updated to expect these changes).

## What this does

1. **Lock** — the "Edit View" toggle (`#toggle-read-view`) is hidden in read-only mode, so a Legacy Profile has no in-app path back to editing. The toggle stays in normal edit-mode entry.
2. **Summary header** — the read view shows the profile **name + FAM/ROX labels** at the top, plus **estimated minutes** only when one is set (the row is omitted otherwise).
3. **Aligned layout** — step rows now use a fixed 5-column grid instead of `auto-fit`, so they align regardless of field count (the previous zig-zag).
4. **No flash** — a tiny synchronous `<head>` script sets `html.view-only` from `?view=1` **before first paint**; CSS hides the editable sections + toggle and reveals the summary via that class, so the editable editor never flashes. `edit.js`'s existing `applyViewMode()` still runs to populate the summary and disable inputs (the two agree on the end state).

**No `main.py` change** — pure frontend on the legacy viewer.

## Tests
`tests/e2e/test_legacy_view.py` — **5 new tests** (lock vs edit mode, summary header present/absent estimate, aligned column tracks, pre-paint `view-only`). Builder + legacy suites **25/25** locally. CI runs no pytest here, so this is a local run.

## Spec
`specs/frontend/spec_legacy_readonly_view.md`

## Notes
- The aligned-layout test compares grid **track counts** (not exact px) because `fr` distribution rounds at sub-pixel; auto-fit gave 5/3/4 tracks, the fix gives a uniform count.
- After this, only **C (#204)** remains: integration e2e vs the real backend + the single PR `updated-profiles` → `main`.

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)