### PR TITLE
#204 (C) integration prep: cache-buster alignment + spec

### DIFF
--- a/aquila_web/static/complete.html
+++ b/aquila_web/static/complete.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=768, height=1024, initial-scale=1" />
   <title>Ready Screen</title>
-  <link rel="stylesheet" href="static/styles.css?v=218" />
+  <link rel="stylesheet" href="static/styles.css?v=233" />
 </head>
 <body class="app-body">
   <div class="app-shell">

--- a/aquila_web/static/help.html
+++ b/aquila_web/static/help.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=768, height=1024, initial-scale=1" />
   <title>Help</title>
-  <link rel="stylesheet" href="/static/styles.css?v=218" />
+  <link rel="stylesheet" href="/static/styles.css?v=233" />
   <link rel="stylesheet" href="/static/icon-colors.css?v=1" />
   <style>
     .help-sub {

--- a/aquila_web/static/history.html
+++ b/aquila_web/static/history.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=768, height=1024, initial-scale=1" />
   <title>Run History</title>
-  <link rel="stylesheet" href="static/styles.css?v=218" />
+  <link rel="stylesheet" href="static/styles.css?v=233" />
 </head>
 <body class="app-body">
   <div class="app-shell">

--- a/aquila_web/static/history_detail.html
+++ b/aquila_web/static/history_detail.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=768, height=1024, initial-scale=1" />
   <title>Run Detail</title>
-  <link rel="stylesheet" href="/static/styles.css?v=218" />
+  <link rel="stylesheet" href="/static/styles.css?v=233" />
 </head>
 <body class="app-body">
   <div class="app-shell">

--- a/aquila_web/static/index.html
+++ b/aquila_web/static/index.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=768, height=1024, initial-scale=1" />
   <title>Ready Screen</title>
-  <link rel="stylesheet" href="static/styles.css?v=218" />
+  <link rel="stylesheet" href="static/styles.css?v=233" />
 </head>
 <body class="app-body">
   <div class="screen">

--- a/aquila_web/static/login.html
+++ b/aquila_web/static/login.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=768, height=1024, initial-scale=1" />
   <title>Login</title>
-  <link rel="stylesheet" href="static/styles.css?v=218" />
+  <link rel="stylesheet" href="static/styles.css?v=233" />
 </head>
 <body class="app-body">
   <div class="login-shell">

--- a/aquila_web/static/profiles.html
+++ b/aquila_web/static/profiles.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=768, height=1024, initial-scale=1" />
   <title>Run Profiles</title>
-  <link rel="stylesheet" href="static/styles.css?v=218" />
+  <link rel="stylesheet" href="static/styles.css?v=233" />
 </head>
 <body class="app-body">
   <div class="app-shell">

--- a/aquila_web/static/profiles/builder.html
+++ b/aquila_web/static/profiles/builder.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=768, height=1024, initial-scale=1" />
   <title>Create Profile</title>
-  <link rel="stylesheet" href="/static/styles.css?v=231" />
+  <link rel="stylesheet" href="/static/styles.css?v=233" />
 </head>
 <body class="app-body">
   <div class="app-shell">

--- a/aquila_web/static/profiles/edit.html
+++ b/aquila_web/static/profiles/edit.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=768, height=1024, initial-scale=1" />
   <title>Edit Profile</title>
-  <link rel="stylesheet" href="/static/styles.css?v=218" />
+  <link rel="stylesheet" href="/static/styles.css?v=233" />
 </head>
 <body class="app-body">
   <div class="app-shell">

--- a/aquila_web/static/profiles/edit_form.html
+++ b/aquila_web/static/profiles/edit_form.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=768, height=1024, initial-scale=1" />
   <title>Edit Profile</title>
-  <link rel="stylesheet" href="/static/styles.css?v=232" />
+  <link rel="stylesheet" href="/static/styles.css?v=233" />
   <script>
     // Apply read-only before first paint so the editable editor never flashes
     // when a Legacy Profile opens via ?view=1 (issue #211). edit.js still runs

--- a/aquila_web/static/profiles/index.html
+++ b/aquila_web/static/profiles/index.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>Run Profiles</title>
-  <link rel="stylesheet" href="/static/styles.css?v=218" />
+  <link rel="stylesheet" href="/static/styles.css?v=233" />
 </head>
 <body class="app-body">
   <div class="app-shell">

--- a/aquila_web/static/ready.html
+++ b/aquila_web/static/ready.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=768, height=1024, initial-scale=1" />
   <title>Ready Screen</title>
-  <link rel="stylesheet" href="static/styles.css?v=218" />
+  <link rel="stylesheet" href="static/styles.css?v=233" />
 </head>
 <body class="app-body">
   <div class="app-shell">

--- a/aquila_web/static/run.html
+++ b/aquila_web/static/run.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=768, height=1024, initial-scale=1" />
   <title>Run</title>
-  <link rel="stylesheet" href="static/styles.css?v=223" />
+  <link rel="stylesheet" href="static/styles.css?v=233" />
 </head>
 <body class="app-body">
   <div class="app-shell">

--- a/aquila_web/static/settings.html
+++ b/aquila_web/static/settings.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=768, height=1024, initial-scale=1" />
   <title>Settings</title>
-  <link rel="stylesheet" href="/static/styles.css?v=218" />
+  <link rel="stylesheet" href="/static/styles.css?v=233" />
   <link rel="stylesheet" href="/static/icon-colors.css?v=1" />
   <style>
     .settings-sub {

--- a/specs/backend/spec_integration_promotion.md
+++ b/specs/backend/spec_integration_promotion.md
@@ -1,0 +1,57 @@
+# Spec: Structured Profile Editor — Integration & Promotion (C) — issue #204
+
+**Status:** Draft
+**Author:** Aquila Engineering Team
+**Last updated:** 2026-06-26
+**GitHub issue:** #204
+**Type:** Integration / verification + promotion (HITL) — not a red-green feature build
+**Umbrella PRD:** `specs/prd/structured-profile-editor-prd.md` · **Decision:** ADR-018
+
+---
+
+## 1. Overview
+
+The convergence step. A1–A4 (backend) and B1–B4 (frontend) were built and tested **in isolation** — the backend against hand-written `stages` payloads, the frontend against the #197 stub. C is the first time they run **together** against the real endpoints on `updated-profiles`: it verifies the assembled whole end-to-end, resolves any contract drift, then promotes the entire feature to `main` in one reviewed PR that closes the whole epic.
+
+No new feature code is expected. C's "tests" are the **already-written** e2e suites (from B1–B4), now pointed at the real backend for the first time; C makes the integrated system pass them and fixes any integration-only gaps it surfaces.
+
+---
+
+## 2. Scope of merged work being integrated
+
+- **Backend:** A1 #198 (`assemble_steps`), A2 #199 (`validate_stages`), A3 #201 (POST/GET wiring + `structured` flag), A4 #213 (canonical key order).
+- **Frontend:** B1 #200 (builder shell), B2 #202 (sub-stages), B3 #203 (validation UX + edit round-trip + list routing), B4 #211 (legacy read-only view).
+
+---
+
+## 3. Verification steps
+
+1. **Backend/unit/contract suite:** `venv/Scripts/python -m pytest unit_tests tests/contract -q`. Expect green except the known pre-existing environmental failures (button/ready-screen state-bleed, device-filtering/results fixtures, profile-dir-state tests). These are identical on `main` (verified during A3) — not introduced here.
+2. **e2e against the real backend** (the deferred convergence): with a simulate-mode server running (`AQ_DEV_SIMULATE=1 … uvicorn aquila_web.main:app --port 8090`), run
+   `venv/Scripts/python -m pytest tests/e2e/test_profile_builder.py tests/e2e/test_legacy_view.py -q`
+   (requires `playwright install chromium`). These exercise: structured create → real validate/assemble → save → reopen → repopulate from `stages`; save-time validation display; sub-stage add/remove; list routing (structured → builder, legacy → read-only view).
+3. **Resolve integration drift** if any surfaces — most likely the stylesheet cache-buster uniformity check (`test_settings_nav`) now that `builder.html` is a live page, or any field-id/payload mismatch between what the builder POSTs and what the backend expects.
+
+## 4. Promotion
+
+- Open a single PR **`updated-profiles` → `main`**.
+- Body must list: `Closes #197, #198, #199, #200, #201, #202, #203, #211, #213` so merging to the default branch auto-closes the whole epic.
+- Reviewed + merged as one unit. (#204 itself closed manually or via the PR.)
+
+---
+
+## 5. Acceptance criteria
+
+- [ ] Full `pytest unit_tests tests/contract` run reviewed; only known pre-existing environmental failures remain.
+- [ ] e2e `test_profile_builder` + `test_legacy_view` pass against the real backend.
+- [ ] Any integration drift fixed (or explicitly deferred with a tracked issue).
+- [ ] Promotion PR `updated-profiles` → `main` opened with the full `Closes …` list.
+
+## 6. Out of scope
+
+- New feature behavior — owned by A1–A4 / B1–B4.
+- Rewriting already-saved profile files (A4 normalizes on next save only).
+
+## 7. Open Questions
+
+- [ ] If the cache-buster uniformity test fails, fix here (align `?v=` across pages) or split into its own follow-up issue? (Lean: quick fix here if trivial.)

--- a/tests/contract/test_settings_nav.py
+++ b/tests/contract/test_settings_nav.py
@@ -276,6 +276,7 @@ LIVE_NAV_PAGE_FILES = [
     "history_detail.html",
     "profiles/index.html",
     "profiles/edit_form.html",
+    "profiles/builder.html",
     "complete.html",
     "help.html",
     "settings.html",


### PR DESCRIPTION
Part of #204 (C) — integration prep. This is **PR 1 of 2**: it lands the integration fix + spec on `updated-profiles`. The promotion PR (`updated-profiles` → `main`, which closes the whole epic) follows separately once this is reviewed.

## What this does
- **Cache-buster alignment** — every live HTML page now pins `styles.css?v=233`. They had drifted (`?v=` 218/223/231/232), so some pages could serve stale CSS. Fixes `test_stylesheet_cache_buster_is_uniform_across_live_pages` (the only fixable one of the suite's failures — dropped from 17 → 16).
- **Integration spec** — `specs/backend/spec_integration_promotion.md` documenting C's verification + promotion plan.

## Integration verification done on this branch (for the promotion PR's confidence)
- **e2e against the REAL backend: 25/25 pass** (`tests/e2e/test_profile_builder.py` + `test_legacy_view.py`) — structured create → validate/assemble → save → reopen → repopulate; sub-stage add/remove; save-time validation; list routing (structured → builder, legacy → read-only). First time the frontend ran against live endpoints rather than the #197 stub.
- **Full suite: 224 passed, 16 failed** — the 16 are the known pre-existing environmental failures (button/ready-screen state-bleed, device-filtering/results fixtures, profile-dir-state), identical to `main`. Zero new failures.
- **Data-loss check:** confirmed a structured save regenerates `steps` from `stages` via `assemble_steps`, so the optics read is always preserved (the old `edit.js` drop-unknown-steps bug does not affect structured profiles; legacy profiles are read-only in-app).

## Not in scope
The promotion to `main` (separate PR). The 16 pre-existing environmental failures (unrelated; tracked as long-standing).

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)
