### PR TITLE
Structured Profile Editor — promotion to main (#204)

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -36,6 +36,30 @@ The operator-facing name for a Protocol. The Run screen labels the protocol pick
 **Run**
 A single execution of a Protocol on a Sentri, producing results for up to 4 Wells. A Run has a start time, end time, and status (completed, aborted). A Run is the unit of event emission — one `run_complete` event per Run.
 
+### Profile Authoring
+
+Terms for the structured profile editor. These name the user-facing phases of a [[Profile]]; they are an authoring abstraction over the raw JSON `steps` array, not stored fields.
+
+**Stage**
+One of the four fixed top-level phases the structured editor presents: Incubation, Initial Denaturation, Amplification, and Final Temp Hold. Distinct from the old editor's generic, free-form "stage." Incubation, Initial Denaturation, and Final Temp Hold are optional (toggled by a checkbox); Amplification is always present.
+_Avoid_: "step" (a Step is the raw JSON unit; a Stage expands into one or more Steps).
+
+**Sub-stage**
+One temperature/time phase within the Amplification Stage, repeated each cycle. There are 2 or 3: with 2, they are Denaturation and "Annealing & Extension"; adding a 3rd splits the second into Annealing and Extension. The Extension-bearing Sub-stage (the 2nd of two, or the 3rd of three) is where the optics read fires.
+_Avoid_: calling these "stages" — the editor mockup labels them "Stage 1/Stage 2," but they are Sub-stages of Amplification, not top-level Stages.
+
+**Step**
+The raw JSON unit inside a Profile's `steps` array — a `setpoint`, `ramp_rate`, `optics`, `enable`/`disable`, or fan command. Stages and Sub-stages are assembled into Steps by the backend; operators never see Steps directly in the structured editor.
+
+**Boilerplate**
+The fixed head and tail Steps the backend injects around the user's Stages on every structured Profile (equilibration, fan, optics init, entry/exit ramps, cooldown). Not user-editable and not represented in the structured editor.
+
+**Structured Profile**
+A [[Profile]] authored by the structured editor. Identified solely by the presence of a top-level `stages` object in its JSON, which is the editable source of truth; its `steps` array is regenerated from `stages` by the backend on every save. Re-opening a Structured Profile populates the editor from `stages` — `steps` is never reverse-parsed.
+
+**Legacy Profile**
+Any [[Profile]] without a `stages` object — every Profile that predates the structured editor, plus all bundled Profiles. Opens read-only in the app (no in-app editing); still runnable and still hand-editable as a JSON file on disk. Adding a valid `stages` block to a Legacy Profile's file promotes it to a Structured Profile.
+
 **Well**
 One of 4 sample positions (numbered 1–4) in the Sentri carousel. Each Well is read independently.
 

--- a/aquila_web/main.py
+++ b/aquila_web/main.py
@@ -226,6 +226,37 @@ def _order_time_fields(profile: dict) -> dict:
     return ordered
 
 
+# Canonical top-level key order for structured profiles (issue #213 / A4):
+# metadata first, then the human-authored stages, then the derived steps last.
+CANONICAL_PROFILE_KEY_ORDER = (
+    "output_dir",
+    "post_in_gui",
+    "title",
+    "rox_unavailable",
+    "time_unavailable",
+    "estimated_completion_seconds",
+    "labels",
+    "stages",
+    "steps",
+)
+
+
+def _order_profile_keys(profile: dict) -> dict:
+    """Return a copy of *profile* with top-level keys in CANONICAL_PROFILE_KEY_ORDER.
+
+    Only keys that are present are emitted (no injection). Any keys not in the
+    canonical list are preserved and appended in their original relative order
+    (never dropped). See spec_profile_key_order.md."""
+    ordered: dict = {}
+    for key in CANONICAL_PROFILE_KEY_ORDER:
+        if key in profile:
+            ordered[key] = profile[key]
+    for key, value in profile.items():
+        if key not in ordered:
+            ordered[key] = value
+    return ordered
+
+
 class ProfileSelect(BaseModel):
     profile: str
 
@@ -1438,7 +1469,12 @@ async def save_profile(payload: ProfileSave):
                 candidate_path = profile_dir / f"{sanitized_title}_{int(datetime.now().timestamp())}.json"
             profile_path = candidate_path
 
-    base_profile = _order_time_fields(base_profile)
+    # Structured profiles (issue #213) get the full canonical key order; legacy
+    # steps-based saves keep the narrower time-field ordering unchanged.
+    if "stages" in base_profile:
+        base_profile = _order_profile_keys(base_profile)
+    else:
+        base_profile = _order_time_fields(base_profile)
 
     try:
         with profile_path.open("w") as f:

--- a/aquila_web/main.py
+++ b/aquila_web/main.py
@@ -1464,9 +1464,12 @@ async def save_profile(payload: ProfileSave):
     elif requested_title:
         sanitized_title = sanitize_name(requested_title)
         if sanitized_title and profile_path.stem != sanitized_title:
-            candidate_path = profile_dir / f"{sanitized_title}.json"
+            # Rename within the profile's own directory (e.g. local/) rather than
+            # the profiles root, so editing+renaming doesn't relocate the file (#218 review).
+            rename_dir = profile_path.parent
+            candidate_path = rename_dir / f"{sanitized_title}.json"
             if candidate_path.exists() and candidate_path != profile_path:
-                candidate_path = profile_dir / f"{sanitized_title}_{int(datetime.now().timestamp())}.json"
+                candidate_path = rename_dir / f"{sanitized_title}_{int(datetime.now().timestamp())}.json"
             profile_path = candidate_path
 
     # Structured profiles (issue #213) get the full canonical key order; legacy

--- a/aquila_web/main.py
+++ b/aquila_web/main.py
@@ -1476,9 +1476,21 @@ async def save_profile(payload: ProfileSave):
     else:
         base_profile = _order_time_fields(base_profile)
 
+    # Serialize first with allow_nan=False so a non-finite value (NaN/Infinity)
+    # anywhere — including a disabled stage that validation skips — fails loudly
+    # with a 400 instead of writing invalid JSON that 500s on every later read.
+    # Serializing before opening the file also prevents truncating an existing
+    # profile when re-saving an edit that turns out to be invalid.
+    try:
+        profile_text = json.dumps(base_profile, indent=2, allow_nan=False)
+    except ValueError:
+        raise HTTPException(
+            status_code=400,
+            detail={"errors": ["Profile contains non-finite numeric values (NaN/Infinity)."]},
+        )
     try:
         with profile_path.open("w") as f:
-            json.dump(base_profile, f, indent=2)
+            f.write(profile_text)
     except Exception:
         raise HTTPException(status_code=500, detail="Failed to save profile")
 

--- a/aquila_web/main.py
+++ b/aquila_web/main.py
@@ -236,6 +236,10 @@ class ProfileSave(BaseModel):
     rox_label: Optional[str] = None
     # Optional estimated completion time, in minutes. None clears any existing estimate.
     estimated_minutes: Optional[int] = None
+    # Structured-editor source of truth (issue #197 contract). When present, the
+    # profile is a Structured Profile; assembly/validation of these stages into
+    # `steps` is handled separately (A1/A2/A3). Persisted verbatim here.
+    stages: Optional[dict] = None
 
 class ProfileDelete(BaseModel):
     profiles: list[str]
@@ -914,6 +918,15 @@ async def profiles_edit_form_page():
         headers={"Cache-Control": "no-store"}
     )
 
+@app.get("/profiles/builder")
+async def profiles_builder_page():
+    # Structured profile editor (issue #197). Serves the shell; the Stage UI,
+    # validation, and save wiring are layered on in the frontend route (B1/B2/B3).
+    return FileResponse(
+        static_dir / "profiles/builder.html",
+        headers={"Cache-Control": "no-store"}
+    )
+
 @app.get("/history")
 async def history_page():
     return FileResponse(static_dir / "history.html")
@@ -1369,6 +1382,10 @@ async def save_profile(payload: ProfileSave):
     base_profile["post_in_gui"] = "True"
     if payload.steps is not None:
         base_profile["steps"] = payload.steps
+    # Persist the structured `stages` source of truth verbatim when provided
+    # (issue #197). Its presence marks a Structured Profile.
+    if payload.stages is not None:
+        base_profile["stages"] = payload.stages
     labels = {}
     if isinstance(base_profile.get("labels"), dict):
         labels.update(base_profile.get("labels", {}))
@@ -1503,7 +1520,7 @@ async def profile_details(id: str | None = Query(default=None), name: str | None
             "steps": _convert_run_config_to_steps(data.get("configuration", {}))
         }
 
-    return {
+    details = {
         "id": profile_path.name,
         "title": data.get("title", profile_path.stem),
         "labels": data.get("labels", {}),
@@ -1512,6 +1529,11 @@ async def profile_details(id: str | None = Query(default=None), name: str | None
         "estimated_completion_seconds": data.get("estimated_completion_seconds"),
         "steps": data.get("steps", [])
     }
+    # Structured Profiles carry the `stages` source of truth; Legacy Profiles
+    # omit it entirely so the editor can branch on its presence (issue #197).
+    if data.get("stages") is not None:
+        details["stages"] = data["stages"]
+    return details
 
 @app.websocket("/ws")
 async def websocket_endpoint(websocket: WebSocket):

--- a/aquila_web/main.py
+++ b/aquila_web/main.py
@@ -1,6 +1,7 @@
 from fastapi import FastAPI, Form, Body, HTTPException, Query
 from aq_lib.device_id import inject_hw_serial_env
 from aquila_web.local_db import enqueue_event, init_local_db
+from aquila_web.profile_assembly import assemble_steps, validate_stages
 from fastapi.responses import FileResponse, RedirectResponse, JSONResponse
 from fastapi.staticfiles import StaticFiles
 from pathlib import Path
@@ -1217,6 +1218,7 @@ async def list_profiles():
                 "name": data.get("name"),
                 "label": data.get("name"),
                 "bundled": is_bundled,
+                "structured": "stages" in data,
                 "createdAt": created_at,
                 "modifiedAt": modified_at,
                 "configuration": data.get("configuration", {})
@@ -1229,6 +1231,7 @@ async def list_profiles():
                 "name": data.get("title", path.stem),
                 "label": data.get("title", path.stem),
                 "bundled": is_bundled,
+                "structured": "stages" in data,
                 "createdAt": created_at,
                 "modifiedAt": modified_at,
                 "configuration": _convert_legacy_steps_to_run_config(
@@ -1382,10 +1385,15 @@ async def save_profile(payload: ProfileSave):
     base_profile["post_in_gui"] = "True"
     if payload.steps is not None:
         base_profile["steps"] = payload.steps
-    # Persist the structured `stages` source of truth verbatim when provided
-    # (issue #197). Its presence marks a Structured Profile.
+    # Structured Profile (issue #201): validate the stages, then regenerate steps
+    # from them (stages is the source of truth; any client-sent steps is ignored).
+    # validate_stages runs first so assemble_steps only ever sees valid input.
     if payload.stages is not None:
+        stage_errors = validate_stages(payload.stages)
+        if stage_errors:
+            raise HTTPException(status_code=400, detail={"errors": stage_errors})
         base_profile["stages"] = payload.stages
+        base_profile["steps"] = assemble_steps(payload.stages)
     labels = {}
     if isinstance(base_profile.get("labels"), dict):
         labels.update(base_profile.get("labels", {}))

--- a/aquila_web/profile_assembly.py
+++ b/aquila_web/profile_assembly.py
@@ -5,6 +5,8 @@ unit-testable in isolation. See specs/backend/spec_profile_step_assembly.md
 (#198) and ADR-018 for the fixed Boilerplate constants and ordering.
 """
 
+import math
+
 # Seconds held at the extension temperature after the optics read fires; the
 # extension-bearing sub-stage is split into (time - tail) -> optics -> tail (ADR-018).
 OPTICS_TAIL_SECONDS = 10
@@ -18,8 +20,12 @@ CYCLES_MIN, CYCLES_MAX = 1, 50
 
 
 def _is_number(value) -> bool:
-    """True for a real numeric value (rejects bools, strings, None)."""
-    return isinstance(value, (int, float)) and not isinstance(value, bool)
+    """True for a real, finite numeric value (rejects bools, strings, None, NaN, Inf)."""
+    return (
+        isinstance(value, (int, float))
+        and not isinstance(value, bool)
+        and math.isfinite(value)
+    )
 
 
 def _is_int(value) -> bool:

--- a/aquila_web/profile_assembly.py
+++ b/aquila_web/profile_assembly.py
@@ -9,8 +9,61 @@ unit-testable in isolation. See specs/backend/spec_profile_step_assembly.md
 # extension-bearing sub-stage is split into (time - tail) -> optics -> tail (ADR-018).
 OPTICS_TAIL_SECONDS = 10
 
+TEMP_MIN, TEMP_MAX = 25, 100
+TIME_MIN, TIME_MAX = 1, 600
+# The extension-bearing sub-stage holds for (time - OPTICS_TAIL_SECONDS) before the
+# optics read, so its time must leave at least 1 s — hence a higher floor.
+EXTENSION_TIME_MIN = OPTICS_TAIL_SECONDS + 1
+CYCLES_MIN, CYCLES_MAX = 1, 50
 
-def assemble_steps(stages: dict) -> list:
+
+def _is_number(value) -> bool:
+    """True for a real numeric value (rejects bools, strings, None)."""
+    return isinstance(value, (int, float)) and not isinstance(value, bool)
+
+
+def validate_stages(stages: dict) -> list[str]:
+    """Check a structured `stages` object against the instrument's valid ranges.
+
+    Returns a list of human-readable error strings (each naming the offending
+    field); an empty list means valid. Disabled optional Stages are skipped.
+    Pure check only — enforcement on POST is A3 (#201).
+    """
+    errors = []
+
+    def check_temp(value, field):
+        if not (_is_number(value) and TEMP_MIN <= value <= TEMP_MAX):
+            errors.append(f"{field}.temp: Invalid Value")
+
+    def check_time(value, field, minimum=TIME_MIN):
+        if not (_is_number(value) and minimum <= value <= TIME_MAX):
+            errors.append(f"{field}.time: Invalid Value")
+
+    for key in ("incubation", "denaturation", "finalHold"):
+        stage = stages[key]
+        if not stage.get("enabled"):
+            continue
+        check_temp(stage.get("temp"), key)
+        check_time(stage.get("time"), key)
+
+    cycles = stages["amplification"].get("cycles")
+    if not (isinstance(cycles, int) and not isinstance(cycles, bool) and CYCLES_MIN <= cycles <= CYCLES_MAX):
+        errors.append("amplification.cycles: Invalid Value")
+
+    sub_stages = stages["amplification"]["subStages"]
+    if not (isinstance(sub_stages, list) and 2 <= len(sub_stages) <= 3):
+        errors.append("amplification.subStages: Invalid Value")
+
+    for index, sub in enumerate(sub_stages):
+        field = f"amplification.subStages[{index}]"
+        check_temp(sub.get("temp"), field)
+        is_extension = index == len(sub_stages) - 1
+        check_time(sub.get("time"), field, EXTENSION_TIME_MIN if is_extension else TIME_MIN)
+
+    return errors
+
+
+def assemble_steps(stages: dict) -> list[dict]:
     """Expand a structured `stages` object into the full `steps` array.
 
     Weaves the fixed Boilerplate (head/tail, ramps, optics read) together with

--- a/aquila_web/profile_assembly.py
+++ b/aquila_web/profile_assembly.py
@@ -49,8 +49,12 @@ def validate_stages(stages: dict) -> list[str]:
 
     for key in ("incubation", "denaturation", "finalHold"):
         stage = stages.get(key)
-        # A missing or malformed optional stage can't be "enabled"; skip it.
-        if not isinstance(stage, dict) or not stage.get("enabled"):
+        # assemble_steps subscripts stage["enabled"], so the key must be present
+        # and boolean (even for disabled stages). A missing/non-dict stage is an error.
+        if not isinstance(stage, dict) or not isinstance(stage.get("enabled"), bool):
+            errors.append(f"{key}: Invalid Value")
+            continue
+        if not stage["enabled"]:
             continue
         check_temp(stage.get("temp"), key)
         check_time(stage.get("time"), key)
@@ -74,6 +78,10 @@ def validate_stages(stages: dict) -> list[str]:
         if not isinstance(sub, dict):
             errors.append(f"{field}: Invalid Value")
             continue
+        # assemble_steps uses sub["name"] as the step description, so require it.
+        name = sub.get("name")
+        if not (isinstance(name, str) and name.strip()):
+            errors.append(f"{field}.name: Invalid Value")
         check_temp(sub.get("temp"), field)
         is_extension = index == len(sub_stages) - 1
         check_time(sub.get("time"), field, EXTENSION_TIME_MIN if is_extension else TIME_MIN)

--- a/aquila_web/profile_assembly.py
+++ b/aquila_web/profile_assembly.py
@@ -1,0 +1,79 @@
+"""Assemble a structured `stages` object into the runnable `steps` array.
+
+Pure functions only — no HTTP, disk, or hardware imports — so this module is
+unit-testable in isolation. See specs/backend/spec_profile_step_assembly.md
+(#198) and ADR-018 for the fixed Boilerplate constants and ordering.
+"""
+
+# Seconds held at the extension temperature after the optics read fires; the
+# extension-bearing sub-stage is split into (time - tail) -> optics -> tail (ADR-018).
+OPTICS_TAIL_SECONDS = 10
+
+
+def assemble_steps(stages: dict) -> list:
+    """Expand a structured `stages` object into the full `steps` array.
+
+    Weaves the fixed Boilerplate (head/tail, ramps, optics read) together with
+    the user's enabled Stages. Assumes well-formed input (validation is A2/#199).
+    """
+    steps = [
+        {"disable": 0, "duration": 1, "description": "Record equilibration without power."},
+        {"ramp_rate": 1.6},
+        {"pcr_fanon": 1},
+        {"enable": 0, "duration": 1, "description": "Turn on and record temperature for a little bit"},
+        {"optics": ""},
+        {"setpoint": 25, "duration": 1, "description": "Presetting temperature"},
+    ]
+
+    # Incubation (optional): one setpoint between the head and amplification.
+    incubation = stages["incubation"]
+    if incubation["enabled"]:
+        steps.append(
+            {"setpoint": incubation["temp"], "duration": incubation["time"], "description": "Incubation"}
+        )
+
+    # Initial Denaturation (optional): one setpoint before amplification.
+    denaturation = stages["denaturation"]
+    if denaturation["enabled"]:
+        steps.append(
+            {"setpoint": denaturation["temp"], "duration": denaturation["time"], "description": "Initial Denaturation"}
+        )
+
+    # Amplification (always present): mid ramp, then the cycled repeat block.
+    amplification = stages["amplification"]
+    sub_stages = amplification["subStages"]
+    repeat_steps = []
+    for index, sub in enumerate(sub_stages):
+        is_extension = index == len(sub_stages) - 1
+        if is_extension:
+            # The optics read fires mid-hold on the extension-bearing sub-stage:
+            # hold (time - tail) -> read -> hold tail (ADR-018).
+            repeat_steps.append(
+                {"setpoint": sub["temp"], "duration": sub["time"] - OPTICS_TAIL_SECONDS, "description": sub["name"]}
+            )
+            repeat_steps.append({"optics": ""})
+            repeat_steps.append(
+                {"setpoint": sub["temp"], "duration": OPTICS_TAIL_SECONDS, "description": sub["name"]}
+            )
+        else:
+            repeat_steps.append(
+                {"setpoint": sub["temp"], "duration": sub["time"], "description": sub["name"]}
+            )
+    steps.append({"ramp_rate": 1.75})
+    steps.append({"repeat": repeat_steps, "cycles": amplification["cycles"]})
+
+    # Final Temp Hold (optional): one setpoint after amplification, before the tail.
+    final_hold = stages["finalHold"]
+    if final_hold["enabled"]:
+        steps.append(
+            {"setpoint": final_hold["temp"], "duration": final_hold["time"], "description": "Final Temp Hold"}
+        )
+
+    steps += [
+        {"ramp_rate": 1.6},
+        {"setpoint": 40, "duration": 20, "description": "Initial cooling"},
+        {"setpoint": 25, "duration": 10, "description": "Restoring setpoint to RT"},
+        {"disable": 0, "duration": 5, "description": "Turn off and record temperature for a little bit"},
+        {"pcr_fanoff": 0},
+    ]
+    return steps

--- a/aquila_web/profile_assembly.py
+++ b/aquila_web/profile_assembly.py
@@ -22,12 +22,20 @@ def _is_number(value) -> bool:
     return isinstance(value, (int, float)) and not isinstance(value, bool)
 
 
+def _is_int(value) -> bool:
+    """True for a real integer value (rejects bools, floats, strings, None)."""
+    return isinstance(value, int) and not isinstance(value, bool)
+
+
 def validate_stages(stages: dict) -> list[str]:
     """Check a structured `stages` object against the instrument's valid ranges.
 
     Returns a list of human-readable error strings (each naming the offending
     field); an empty list means valid. Disabled optional Stages are skipped.
-    Pure check only — enforcement on POST is A3 (#201).
+
+    This is a trust boundary (A3 #201 calls it on the untrusted POST body), so it
+    reports malformed structure as errors and never raises on a dict input.
+    Pure check only — enforcement on POST is A3.
     """
     errors = []
 
@@ -40,22 +48,32 @@ def validate_stages(stages: dict) -> list[str]:
             errors.append(f"{field}.time: Invalid Value")
 
     for key in ("incubation", "denaturation", "finalHold"):
-        stage = stages[key]
-        if not stage.get("enabled"):
+        stage = stages.get(key)
+        # A missing or malformed optional stage can't be "enabled"; skip it.
+        if not isinstance(stage, dict) or not stage.get("enabled"):
             continue
         check_temp(stage.get("temp"), key)
         check_time(stage.get("time"), key)
 
-    cycles = stages["amplification"].get("cycles")
-    if not (isinstance(cycles, int) and not isinstance(cycles, bool) and CYCLES_MIN <= cycles <= CYCLES_MAX):
+    amplification = stages.get("amplification")
+    if not isinstance(amplification, dict):
+        errors.append("amplification: Invalid Value")
+        return errors
+
+    cycles = amplification.get("cycles")
+    if not (_is_int(cycles) and CYCLES_MIN <= cycles <= CYCLES_MAX):
         errors.append("amplification.cycles: Invalid Value")
 
-    sub_stages = stages["amplification"]["subStages"]
+    sub_stages = amplification.get("subStages")
     if not (isinstance(sub_stages, list) and 2 <= len(sub_stages) <= 3):
         errors.append("amplification.subStages: Invalid Value")
+        return errors
 
     for index, sub in enumerate(sub_stages):
         field = f"amplification.subStages[{index}]"
+        if not isinstance(sub, dict):
+            errors.append(f"{field}: Invalid Value")
+            continue
         check_temp(sub.get("temp"), field)
         is_extension = index == len(sub_stages) - 1
         check_time(sub.get("time"), field, EXTENSION_TIME_MIN if is_extension else TIME_MIN)

--- a/aquila_web/static/complete.html
+++ b/aquila_web/static/complete.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=768, height=1024, initial-scale=1" />
   <title>Ready Screen</title>
-  <link rel="stylesheet" href="static/styles.css?v=218" />
+  <link rel="stylesheet" href="static/styles.css?v=233" />
 </head>
 <body class="app-body">
   <div class="app-shell">

--- a/aquila_web/static/help.html
+++ b/aquila_web/static/help.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=768, height=1024, initial-scale=1" />
   <title>Help</title>
-  <link rel="stylesheet" href="/static/styles.css?v=218" />
+  <link rel="stylesheet" href="/static/styles.css?v=233" />
   <link rel="stylesheet" href="/static/icon-colors.css?v=1" />
   <style>
     .help-sub {

--- a/aquila_web/static/history.html
+++ b/aquila_web/static/history.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=768, height=1024, initial-scale=1" />
   <title>Run History</title>
-  <link rel="stylesheet" href="static/styles.css?v=218" />
+  <link rel="stylesheet" href="static/styles.css?v=233" />
 </head>
 <body class="app-body">
   <div class="app-shell">

--- a/aquila_web/static/history_detail.html
+++ b/aquila_web/static/history_detail.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=768, height=1024, initial-scale=1" />
   <title>Run Detail</title>
-  <link rel="stylesheet" href="/static/styles.css?v=218" />
+  <link rel="stylesheet" href="/static/styles.css?v=233" />
 </head>
 <body class="app-body">
   <div class="app-shell">

--- a/aquila_web/static/index.html
+++ b/aquila_web/static/index.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=768, height=1024, initial-scale=1" />
   <title>Ready Screen</title>
-  <link rel="stylesheet" href="static/styles.css?v=218" />
+  <link rel="stylesheet" href="static/styles.css?v=233" />
 </head>
 <body class="app-body">
   <div class="screen">

--- a/aquila_web/static/login.html
+++ b/aquila_web/static/login.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=768, height=1024, initial-scale=1" />
   <title>Login</title>
-  <link rel="stylesheet" href="static/styles.css?v=218" />
+  <link rel="stylesheet" href="static/styles.css?v=233" />
 </head>
 <body class="app-body">
   <div class="login-shell">

--- a/aquila_web/static/profiles.html
+++ b/aquila_web/static/profiles.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=768, height=1024, initial-scale=1" />
   <title>Run Profiles</title>
-  <link rel="stylesheet" href="static/styles.css?v=218" />
+  <link rel="stylesheet" href="static/styles.css?v=233" />
 </head>
 <body class="app-body">
   <div class="app-shell">

--- a/aquila_web/static/profiles/builder.html
+++ b/aquila_web/static/profiles/builder.html
@@ -1,0 +1,36 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=768, height=1024, initial-scale=1" />
+  <title>Create Profile</title>
+  <link rel="stylesheet" href="/static/styles.css?v=219" />
+</head>
+<body class="app-body">
+  <div class="app-shell">
+    <main class="main run-main">
+      <header class="run-header">
+        <h1 class="run-header__title" id="builder-page-title">
+          <a class="back-icon back-icon--inline" href="/profiles-page" aria-label="Back">&#x2039;</a>
+          Create Profile
+        </h1>
+        <nav class="run-header__nav">
+          <a class="run-nav-link" href="/run">Run</a>
+          <a class="run-nav-link" href="/history">History</a>
+          <a class="run-nav-link" href="/profiles-page">Profiles</a>
+          <a class="run-nav-link settings-link" href="/settings">Settings</a>
+          <a class="help-link" href="/help">
+            <span>?</span>
+            <span class="help-tooltip">How to run a test</span>
+          </a>
+        </nav>
+      </header>
+      <div class="run-divider"></div>
+      <!-- Structured profile editor shell (issue #197). The Stage/Sub-stage UI,
+           validation, and save wiring are built in B1/B2/B3. -->
+      <div class="profile-form" id="profile-builder-root"></div>
+    </main>
+  </div>
+  <script src="/static/nav.js?v=1"></script>
+</body>
+</html>

--- a/aquila_web/static/profiles/builder.html
+++ b/aquila_web/static/profiles/builder.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=768, height=1024, initial-scale=1" />
   <title>Create Profile</title>
-  <link rel="stylesheet" href="/static/styles.css?v=228" />
+  <link rel="stylesheet" href="/static/styles.css?v=231" />
 </head>
 <body class="app-body">
   <div class="app-shell">
@@ -12,7 +12,7 @@
       <header class="run-header">
         <h1 class="run-header__title" id="builder-page-title">
           <a class="back-icon back-icon--inline" href="/profiles-page" aria-label="Back">&#x2039;</a>
-          Create Profile
+          <span id="builder-title-text">Create Profile</span>
         </h1>
         <nav class="run-header__nav">
           <a class="run-nav-link" href="/run">Run</a>
@@ -50,6 +50,7 @@
             <div class="field">
               <label for="profile-estimated-minutes">Est. Time (Min)</label>
               <input id="profile-estimated-minutes" type="number" inputmode="numeric" min="1" step="1" value="" placeholder="(Optional)" />
+              <p class="field-error is-hidden" id="profile-estimated-error">Invalid Estimated Time</p>
             </div>
           </div>
         </section>
@@ -163,6 +164,6 @@
     </main>
   </div>
   <script src="/static/nav.js?v=1"></script>
-  <script src="/static/profiles/builder.js?v=1"></script>
+  <script src="/static/profiles/builder.js?v=4"></script>
 </body>
 </html>

--- a/aquila_web/static/profiles/builder.html
+++ b/aquila_web/static/profiles/builder.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=768, height=1024, initial-scale=1" />
   <title>Create Profile</title>
-  <link rel="stylesheet" href="/static/styles.css?v=219" />
+  <link rel="stylesheet" href="/static/styles.css?v=220" />
 </head>
 <body class="app-body">
   <div class="app-shell">
@@ -26,11 +26,140 @@
         </nav>
       </header>
       <div class="run-divider"></div>
-      <!-- Structured profile editor shell (issue #197). The Stage/Sub-stage UI,
-           validation, and save wiring are built in B1/B2/B3. -->
-      <div class="profile-form" id="profile-builder-root"></div>
+      <!-- Structured profile editor (issues #197 shell, #200 builder). Field
+           validation is B3; Amplification Sub-stage add/remove is B2. -->
+      <div class="profile-form" id="profile-builder-root">
+        <section class="card" id="builder-details">
+          <div class="field-grid">
+            <div class="field">
+              <label for="profile-name">Profile name</label>
+              <input id="profile-name" type="text" value="" />
+            </div>
+          </div>
+          <div class="field-grid">
+            <div class="field">
+              <label for="profile-fam-label">FAM Label</label>
+              <input id="profile-fam-label" type="text" value="FAM" />
+            </div>
+            <div class="field">
+              <label for="profile-rox-label">ROX Label</label>
+              <input id="profile-rox-label" type="text" value="ROX" />
+            </div>
+          </div>
+          <div class="field-grid">
+            <div class="field">
+              <label for="profile-estimated-minutes">Est. Time (Min)</label>
+              <input id="profile-estimated-minutes" type="number" inputmode="numeric" min="1" step="1" value="" placeholder="(Optional)" />
+            </div>
+          </div>
+        </section>
+
+        <section class="card stage" id="stage-incubation">
+          <header class="stage__header">
+            <label class="stage__toggle">
+              <input type="checkbox" id="stage-incubation-enabled" checked />
+              <span class="stage__title">Incubation</span>
+            </label>
+          </header>
+          <div class="field-grid">
+            <div class="field">
+              <label for="stage-incubation-temp">Temp (&deg;C)</label>
+              <input id="stage-incubation-temp" type="number" inputmode="numeric" value="" />
+            </div>
+            <div class="field">
+              <label for="stage-incubation-time">Time (s)</label>
+              <input id="stage-incubation-time" type="number" inputmode="numeric" value="" />
+            </div>
+          </div>
+        </section>
+
+        <section class="card stage" id="stage-denaturation">
+          <header class="stage__header">
+            <label class="stage__toggle">
+              <input type="checkbox" id="stage-denaturation-enabled" checked />
+              <span class="stage__title">Initial Denaturation</span>
+            </label>
+          </header>
+          <div class="field-grid">
+            <div class="field">
+              <label for="stage-denaturation-temp">Temp (&deg;C)</label>
+              <input id="stage-denaturation-temp" type="number" inputmode="numeric" value="" />
+            </div>
+            <div class="field">
+              <label for="stage-denaturation-time">Time (s)</label>
+              <input id="stage-denaturation-time" type="number" inputmode="numeric" value="" />
+            </div>
+          </div>
+        </section>
+
+        <section class="card stage" id="stage-amplification">
+          <header class="stage__header">
+            <span class="stage__title">Amplification</span>
+          </header>
+          <div class="field-grid">
+            <div class="field">
+              <label for="stage-amp-cycles">Cycles</label>
+              <input id="stage-amp-cycles" type="number" inputmode="numeric" value="" />
+            </div>
+          </div>
+          <div class="amp-substages">
+            <div class="amp-substage" data-sub="0">
+              <span class="amp-substage__name" id="stage-amp-sub-0-name">Denaturation</span>
+              <div class="field-grid">
+                <div class="field">
+                  <label for="stage-amp-sub-0-temp">Temp (&deg;C)</label>
+                  <input id="stage-amp-sub-0-temp" type="number" inputmode="numeric" value="" />
+                </div>
+                <div class="field">
+                  <label for="stage-amp-sub-0-time">Time (s)</label>
+                  <input id="stage-amp-sub-0-time" type="number" inputmode="numeric" value="" />
+                </div>
+              </div>
+            </div>
+            <div class="amp-substage" data-sub="1">
+              <span class="amp-substage__name" id="stage-amp-sub-1-name">Annealing &amp; Extension</span>
+              <div class="field-grid">
+                <div class="field">
+                  <label for="stage-amp-sub-1-temp">Temp (&deg;C)</label>
+                  <input id="stage-amp-sub-1-temp" type="number" inputmode="numeric" value="" />
+                </div>
+                <div class="field">
+                  <label for="stage-amp-sub-1-time">Time (s)</label>
+                  <input id="stage-amp-sub-1-time" type="number" inputmode="numeric" value="" />
+                </div>
+              </div>
+            </div>
+          </div>
+        </section>
+
+        <section class="card stage" id="stage-finalhold">
+          <header class="stage__header">
+            <label class="stage__toggle">
+              <input type="checkbox" id="stage-finalhold-enabled" checked />
+              <span class="stage__title">Final Temp Hold</span>
+            </label>
+          </header>
+          <div class="field-grid">
+            <div class="field">
+              <label for="stage-finalhold-temp">Temp (&deg;C)</label>
+              <input id="stage-finalhold-temp" type="number" inputmode="numeric" value="" />
+            </div>
+            <div class="field">
+              <label for="stage-finalhold-time">Time (s)</label>
+              <input id="stage-finalhold-time" type="number" inputmode="numeric" value="" />
+            </div>
+          </div>
+        </section>
+
+        <div class="button-row" id="builder-actions">
+          <button id="save-profile-button" class="form-action-btn form-action-btn--primary" type="button">Save profile</button>
+          <a class="form-action-btn" href="/profiles-page">Cancel</a>
+        </div>
+        <p id="save-status" class="page-header"></p>
+      </div>
     </main>
   </div>
   <script src="/static/nav.js?v=1"></script>
+  <script src="/static/profiles/builder.js?v=1"></script>
 </body>
 </html>

--- a/aquila_web/static/profiles/builder.html
+++ b/aquila_web/static/profiles/builder.html
@@ -164,6 +164,6 @@
     </main>
   </div>
   <script src="/static/nav.js?v=1"></script>
-  <script src="/static/profiles/builder.js?v=4"></script>
+  <script src="/static/profiles/builder.js?v=5"></script>
 </body>
 </html>

--- a/aquila_web/static/profiles/builder.html
+++ b/aquila_web/static/profiles/builder.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=768, height=1024, initial-scale=1" />
   <title>Create Profile</title>
-  <link rel="stylesheet" href="/static/styles.css?v=231" />
+  <link rel="stylesheet" href="/static/styles.css?v=233" />
 </head>
 <body class="app-body">
   <div class="app-shell">

--- a/aquila_web/static/profiles/builder.html
+++ b/aquila_web/static/profiles/builder.html
@@ -164,6 +164,6 @@
     </main>
   </div>
   <script src="/static/nav.js?v=1"></script>
-  <script src="/static/profiles/builder.js?v=5"></script>
+  <script src="/static/profiles/builder.js?v=6"></script>
 </body>
 </html>

--- a/aquila_web/static/profiles/builder.html
+++ b/aquila_web/static/profiles/builder.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=768, height=1024, initial-scale=1" />
   <title>Create Profile</title>
-  <link rel="stylesheet" href="/static/styles.css?v=220" />
+  <link rel="stylesheet" href="/static/styles.css?v=228" />
 </head>
 <body class="app-body">
   <div class="app-shell">
@@ -96,12 +96,6 @@
           <header class="stage__header">
             <span class="stage__title">Amplification</span>
           </header>
-          <div class="field-grid">
-            <div class="field">
-              <label for="stage-amp-cycles">Cycles</label>
-              <input id="stage-amp-cycles" type="number" inputmode="numeric" value="" />
-            </div>
-          </div>
           <div class="amp-substages">
             <div class="amp-substage" data-sub="0">
               <span class="amp-substage__name" id="stage-amp-sub-0-name">Denaturation</span>
@@ -128,6 +122,15 @@
                   <input id="stage-amp-sub-1-time" type="number" inputmode="numeric" value="" />
                 </div>
               </div>
+            </div>
+          </div>
+          <!-- Add the third (Extension) Sub-stage (issue #202). Hidden once a
+               third exists; the third row carries its own X remove control. -->
+          <button id="amp-add-substage" class="amp-add-tab" type="button">+ Add sub-stage</button>
+          <div class="field-grid">
+            <div class="field">
+              <label for="stage-amp-cycles">Cycles</label>
+              <input id="stage-amp-cycles" type="number" inputmode="numeric" value="" />
             </div>
           </div>
         </section>

--- a/aquila_web/static/profiles/builder.js
+++ b/aquila_web/static/profiles/builder.js
@@ -62,6 +62,17 @@
     };
   }
 
+  // Collect the Sub-stages as currently rendered (2 or 3, in DOM order), so the
+  // payload reflects add/remove state and the two-/three-step names (#202).
+  function collectSubstages() {
+    var rows = document.querySelectorAll(".amp-substage");
+    var list = [];
+    for (var i = 0; i < rows.length; i++) {
+      list.push(subStage(rows[i].getAttribute("data-sub")));
+    }
+    return list;
+  }
+
   function estimatedMinutes() {
     var raw = text("profile-estimated-minutes");
     if (raw === "") return null;
@@ -82,7 +93,7 @@
         denaturation: optionalStage("denaturation"),
         amplification: {
           cycles: num("stage-amp-cycles"),
-          subStages: [subStage(0), subStage(1)],
+          subStages: collectSubstages(),
         },
         finalHold: optionalStage("finalhold"),
       },
@@ -116,6 +127,77 @@
     }
   }
 
+  // ---- Amplification Sub-stages (issue #202) --------------------------------
+
+  // Sub-stage 1's name depends on whether amplification is two- or three-step.
+  var SECOND_NAME_TWO_STEP = "Annealing & Extension";
+  var SECOND_NAME_THREE_STEP = "Annealing";
+  var THIRD_NAME = "Extension";
+  var MIN_SUBSTAGES = 2;
+  var MAX_SUBSTAGES = 3;
+
+  function substageRows() {
+    return document.querySelectorAll(".amp-substage");
+  }
+
+  // The add tab shows only at two Sub-stages; at three the Extension row's own
+  // X is the way back down, so the tab hides.
+  function showAddTab(show) {
+    var tab = document.getElementById("amp-add-substage");
+    if (tab) tab.classList.toggle("is-hidden", !show);
+  }
+
+  // Build the third (Extension) row. It carries its own X remove control in a
+  // header, since removal happens from the row itself, not a persistent button.
+  function buildSubstageRow(index, name) {
+    var row = document.createElement("div");
+    row.className = "amp-substage amp-substage--removable";
+    row.setAttribute("data-sub", String(index));
+    // The name + fields live in a body column; the X is its sibling so it can
+    // centre vertically against the whole row rather than hug the name line.
+    row.innerHTML =
+      '<div class="amp-substage__body">' +
+      '<span class="amp-substage__name" id="stage-amp-sub-' + index + '-name"></span>' +
+      '<div class="field-grid">' +
+      '<div class="field">' +
+      '<label for="stage-amp-sub-' + index + '-temp">Temp (°C)</label>' +
+      '<input id="stage-amp-sub-' + index + '-temp" type="number" inputmode="numeric" value="" />' +
+      '</div>' +
+      '<div class="field">' +
+      '<label for="stage-amp-sub-' + index + '-time">Time (s)</label>' +
+      '<input id="stage-amp-sub-' + index + '-time" type="number" inputmode="numeric" value="" />' +
+      '</div>' +
+      '</div>' +
+      '</div>' +
+      '<button id="amp-remove-substage" class="amp-substage__remove" type="button" aria-label="Remove sub-stage">&times;</button>';
+    // Set the name as text (never innerHTML) so it can't inject markup.
+    row.querySelector(".amp-substage__name").textContent = name;
+    row.querySelector("#amp-remove-substage").addEventListener("click", removeSubstage);
+    return row;
+  }
+
+  // Two-step -> three-step: rename Sub-stage 1, append a blank Extension row, and
+  // hide the add tab.
+  function addSubstage() {
+    if (substageRows().length >= MAX_SUBSTAGES) return;
+    var second = document.getElementById("stage-amp-sub-1-name");
+    if (second) second.textContent = SECOND_NAME_THREE_STEP;
+    var container = document.querySelector(".amp-substages");
+    if (container) container.appendChild(buildSubstageRow(2, THIRD_NAME));
+    showAddTab(false);
+  }
+
+  // Three-step -> two-step: drop the Extension row, revert Sub-stage 1's name,
+  // and bring the add tab back.
+  function removeSubstage() {
+    if (substageRows().length <= MIN_SUBSTAGES) return;
+    var third = document.querySelector('.amp-substage[data-sub="2"]');
+    if (third) third.remove();
+    var second = document.getElementById("stage-amp-sub-1-name");
+    if (second) second.textContent = SECOND_NAME_TWO_STEP;
+    showAddTab(true);
+  }
+
   // ---- Boot -----------------------------------------------------------------
 
   function init() {
@@ -127,6 +209,10 @@
       });
       syncStage(key); // sync initial state on load
     });
+
+    var addBtn = document.getElementById("amp-add-substage");
+    if (addBtn) addBtn.addEventListener("click", addSubstage);
+    showAddTab(substageRows().length < MAX_SUBSTAGES);
 
     var saveButton = document.getElementById("save-profile-button");
     if (saveButton) saveButton.addEventListener("click", saveProfile);

--- a/aquila_web/static/profiles/builder.js
+++ b/aquila_web/static/profiles/builder.js
@@ -116,6 +116,16 @@
   var TIME_MIN = 1, TIME_MAX = 600, EXTENSION_TIME_MIN = 11;
   var CYCLES_MIN = 1, CYCLES_MAX = 50;
 
+  // Standardized error message naming the valid range; derived from the constants
+  // above so the text can never drift out of sync with the actual bounds.
+  function rangeMsg(min, max) {
+    return "Range (" + min + " - " + max + ")";
+  }
+  var MSG_TEMP = rangeMsg(TEMP_MIN, TEMP_MAX);
+  var MSG_TIME = rangeMsg(TIME_MIN, TIME_MAX);
+  var MSG_EXT_TIME = rangeMsg(EXTENSION_TIME_MIN, TIME_MAX);
+  var MSG_CYCLES = rangeMsg(CYCLES_MIN, CYCLES_MAX);
+
   function validTemp(v) {
     return typeof v === "number" && v >= TEMP_MIN && v <= TEMP_MAX;
   }
@@ -126,22 +136,27 @@
     return Number.isInteger(v) && v >= CYCLES_MIN && v <= CYCLES_MAX;
   }
 
-  // Ensure a hidden "Invalid Value" message exists right after the input.
-  function errorEl(input) {
+  // Ensure a hidden range-message element exists right after the input, and keep
+  // its text in sync with the field's range (default for non-range fields).
+  function errorEl(input, message) {
+    var msg = message || "Invalid Value";
     var next = input.nextElementSibling;
-    if (next && next.classList.contains("field-error")) return next;
+    if (next && next.classList.contains("field-error")) {
+      next.textContent = msg;
+      return next;
+    }
     var p = document.createElement("p");
     p.className = "field-error is-hidden";
-    p.textContent = "Invalid Value";
+    p.textContent = msg;
     input.insertAdjacentElement("afterend", p);
     return p;
   }
 
-  function setFieldValid(id, ok) {
+  function setFieldValid(id, ok, message) {
     var input = document.getElementById(id);
     if (!input) return ok;
     input.classList.toggle("is-invalid", !ok);
-    errorEl(input).classList.toggle("is-hidden", ok);
+    errorEl(input, message).classList.toggle("is-hidden", ok);
     return ok;
   }
 
@@ -173,23 +188,24 @@
       var box = document.getElementById("stage-" + key + "-enabled");
       var enabled = !box || box.checked;
       if (!enabled) {
-        setFieldValid("stage-" + key + "-temp", true);
-        setFieldValid("stage-" + key + "-time", true);
+        setFieldValid("stage-" + key + "-temp", true, MSG_TEMP);
+        setFieldValid("stage-" + key + "-time", true, MSG_TIME);
         return;
       }
-      valid = setFieldValid("stage-" + key + "-temp", validTemp(num("stage-" + key + "-temp"))) && valid;
-      valid = setFieldValid("stage-" + key + "-time", validTime(num("stage-" + key + "-time"), TIME_MIN)) && valid;
+      valid = setFieldValid("stage-" + key + "-temp", validTemp(num("stage-" + key + "-temp")), MSG_TEMP) && valid;
+      valid = setFieldValid("stage-" + key + "-time", validTime(num("stage-" + key + "-time"), TIME_MIN), MSG_TIME) && valid;
     });
 
-    valid = setFieldValid("stage-amp-cycles", validCycles(num("stage-amp-cycles"))) && valid;
+    valid = setFieldValid("stage-amp-cycles", validCycles(num("stage-amp-cycles")), MSG_CYCLES) && valid;
 
     var rows = document.querySelectorAll(".amp-substage");
     for (var i = 0; i < rows.length; i++) {
       var idx = rows[i].getAttribute("data-sub");
       var isLast = i === rows.length - 1; // extension-bearing Sub-stage
       var minTime = isLast ? EXTENSION_TIME_MIN : TIME_MIN;
-      valid = setFieldValid("stage-amp-sub-" + idx + "-temp", validTemp(num("stage-amp-sub-" + idx + "-temp"))) && valid;
-      valid = setFieldValid("stage-amp-sub-" + idx + "-time", validTime(num("stage-amp-sub-" + idx + "-time"), minTime)) && valid;
+      var timeMsg = isLast ? MSG_EXT_TIME : MSG_TIME;
+      valid = setFieldValid("stage-amp-sub-" + idx + "-temp", validTemp(num("stage-amp-sub-" + idx + "-temp")), MSG_TEMP) && valid;
+      valid = setFieldValid("stage-amp-sub-" + idx + "-time", validTime(num("stage-amp-sub-" + idx + "-time"), minTime), timeMsg) && valid;
     }
 
     return valid;

--- a/aquila_web/static/profiles/builder.js
+++ b/aquila_web/static/profiles/builder.js
@@ -8,11 +8,10 @@
   // Stages with an enable checkbox. Amplification is always present (no toggle).
   var OPTIONAL_STAGES = ["incubation", "denaturation", "finalhold"];
 
-  // When the URL carries ?id= (or ?profile=) the builder is editing an existing
-  // structured Profile: it repopulates from `stages` and saves in place (#203).
-  var editId =
-    new URLSearchParams(window.location.search).get("id") ||
-    new URLSearchParams(window.location.search).get("profile");
+  // When the URL carries ?id= the builder is editing an existing structured
+  // Profile: it repopulates from `stages` and saves in place (#203). The list
+  // always links with ?id=, and loadForEdit looks up by id, so that's the only key.
+  var editId = new URLSearchParams(window.location.search).get("id");
 
   function valueInputs(card) {
     // Every editable value field in the card (temp/time) — never the checkbox.
@@ -184,6 +183,12 @@
   function validateForm() {
     var valid = setEstimatedValid(validEstimated());
 
+    // Profile name is required — a blank name would otherwise save as "profile.json"
+    // with an empty title (#218 review). Flag it like any other field.
+    var nameInput = document.getElementById("profile-name");
+    var nameOk = !!nameInput && nameInput.value.trim() !== "";
+    valid = setFieldValid("profile-name", nameOk, "Enter a profile name") && valid;
+
     OPTIONAL_STAGES.forEach(function (key) {
       var box = document.getElementById("stage-" + key + "-enabled");
       var enabled = !box || box.checked;
@@ -287,10 +292,11 @@
       '</div>' +
       '</div>' +
       '</div>' +
-      '<button id="amp-remove-substage" class="amp-substage__remove" type="button" aria-label="Remove sub-stage">&times;</button>';
+      '<button class="amp-substage__remove" type="button" aria-label="Remove sub-stage">&times;</button>';
     // Set the name as text (never innerHTML) so it can't inject markup.
     row.querySelector(".amp-substage__name").textContent = name;
-    row.querySelector("#amp-remove-substage").addEventListener("click", removeSubstage);
+    // Query by class (not a per-row id) so additional removable rows can't collide.
+    row.querySelector(".amp-substage__remove").addEventListener("click", removeSubstage);
     return row;
   }
 

--- a/aquila_web/static/profiles/builder.js
+++ b/aquila_web/static/profiles/builder.js
@@ -1,0 +1,140 @@
+// Structured profile builder (issue #200, Structured Profiles B1).
+// The markup lives in builder.html; this script wires behavior: Stage enable
+// toggles (grey/disable while preserving values) and save. Field validation is
+// B3; Amplification Sub-stage add/remove is B2.
+(function () {
+  "use strict";
+
+  // Stages with an enable checkbox. Amplification is always present (no toggle).
+  var OPTIONAL_STAGES = ["incubation", "denaturation", "finalhold"];
+
+  function valueInputs(card) {
+    // Every editable value field in the card (temp/time) — never the checkbox.
+    return card.querySelectorAll("input:not([type=checkbox])");
+  }
+
+  // Reflect a Stage's checkbox into its card: greyed + inputs disabled when off.
+  // Disabling preserves the inputs' typed values, so re-enabling restores them.
+  function syncStage(key) {
+    var box = document.getElementById("stage-" + key + "-enabled");
+    var card = document.getElementById("stage-" + key);
+    if (!box || !card) return;
+    var enabled = box.checked;
+    card.classList.toggle("stage--disabled", !enabled);
+    valueInputs(card).forEach(function (input) {
+      input.disabled = !enabled;
+    });
+  }
+
+  // ---- Save -----------------------------------------------------------------
+
+  function text(id) {
+    var el = document.getElementById(id);
+    return el ? el.value.trim() : "";
+  }
+
+  // A numeric field's value as a Number, or null when blank/non-numeric. #200
+  // does not validate (that is B3) — it just carries whatever was typed.
+  function num(id) {
+    var el = document.getElementById(id);
+    if (!el) return null;
+    var raw = el.value.trim();
+    if (raw === "") return null;
+    var n = Number(raw);
+    return Number.isFinite(n) ? n : null;
+  }
+
+  function optionalStage(domKey) {
+    var box = document.getElementById("stage-" + domKey + "-enabled");
+    return {
+      enabled: box ? box.checked : true,
+      temp: num("stage-" + domKey + "-temp"),
+      time: num("stage-" + domKey + "-time"),
+    };
+  }
+
+  function subStage(index) {
+    var nameEl = document.getElementById("stage-amp-sub-" + index + "-name");
+    return {
+      name: nameEl ? nameEl.textContent.trim() : "",
+      temp: num("stage-amp-sub-" + index + "-temp"),
+      time: num("stage-amp-sub-" + index + "-time"),
+    };
+  }
+
+  function estimatedMinutes() {
+    var raw = text("profile-estimated-minutes");
+    if (raw === "") return null;
+    var parsed = Math.round(Number(raw));
+    return Number.isFinite(parsed) && parsed > 0 ? parsed : null;
+  }
+
+  // Build the POST body. All four stage keys are always present; an unchecked
+  // Stage rides along as enabled:false with its preserved values.
+  function buildPayload() {
+    return {
+      name: text("profile-name"),
+      fam_label: text("profile-fam-label"),
+      rox_label: text("profile-rox-label"),
+      estimated_minutes: estimatedMinutes(),
+      stages: {
+        incubation: optionalStage("incubation"),
+        denaturation: optionalStage("denaturation"),
+        amplification: {
+          cycles: num("stage-amp-cycles"),
+          subStages: [subStage(0), subStage(1)],
+        },
+        finalHold: optionalStage("finalhold"),
+      },
+    };
+  }
+
+  async function saveProfile() {
+    var status = document.getElementById("save-status");
+    if (status) status.textContent = "Saving...";
+    try {
+      var response = await fetch("/profiles", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(buildPayload()),
+      });
+      if (!response.ok) {
+        var err = {};
+        try {
+          err = await response.json();
+        } catch (e) {
+          /* non-JSON error body */
+        }
+        if (status) status.textContent = err.detail || "Failed to save";
+        return;
+      }
+      if (status) status.textContent = "Saved";
+      window.location.href = "/profiles-page";
+    } catch (e) {
+      if (status) status.textContent = "Failed to save";
+      console.error("Save failed", e);
+    }
+  }
+
+  // ---- Boot -----------------------------------------------------------------
+
+  function init() {
+    OPTIONAL_STAGES.forEach(function (key) {
+      var box = document.getElementById("stage-" + key + "-enabled");
+      if (!box) return;
+      box.addEventListener("change", function () {
+        syncStage(key);
+      });
+      syncStage(key); // sync initial state on load
+    });
+
+    var saveButton = document.getElementById("save-profile-button");
+    if (saveButton) saveButton.addEventListener("click", saveProfile);
+  }
+
+  if (document.readyState === "loading") {
+    document.addEventListener("DOMContentLoaded", init);
+  } else {
+    init();
+  }
+})();

--- a/aquila_web/static/profiles/builder.js
+++ b/aquila_web/static/profiles/builder.js
@@ -8,6 +8,12 @@
   // Stages with an enable checkbox. Amplification is always present (no toggle).
   var OPTIONAL_STAGES = ["incubation", "denaturation", "finalhold"];
 
+  // When the URL carries ?id= (or ?profile=) the builder is editing an existing
+  // structured Profile: it repopulates from `stages` and saves in place (#203).
+  var editId =
+    new URLSearchParams(window.location.search).get("id") ||
+    new URLSearchParams(window.location.search).get("profile");
+
   function valueInputs(card) {
     // Every editable value field in the card (temp/time) — never the checkbox.
     return card.querySelectorAll("input:not([type=checkbox])");
@@ -81,9 +87,10 @@
   }
 
   // Build the POST body. All four stage keys are always present; an unchecked
-  // Stage rides along as enabled:false with its preserved values.
+  // Stage rides along as enabled:false with its preserved values. In edit mode
+  // profile_id is included so the backend updates that profile in place.
   function buildPayload() {
-    return {
+    var payload = {
       name: text("profile-name"),
       fam_label: text("profile-fam-label"),
       rox_label: text("profile-rox-label"),
@@ -98,10 +105,105 @@
         finalHold: optionalStage("finalhold"),
       },
     };
+    if (editId) payload.profile_id = editId;
+    return payload;
+  }
+
+  // ---- Validation (issue #203) ----------------------------------------------
+  // Ranges mirror aquila_web/profile_assembly.py::validate_stages so a
+  // client-valid form never trips the server's 400 (which stays the safety net).
+  var TEMP_MIN = 25, TEMP_MAX = 100;
+  var TIME_MIN = 1, TIME_MAX = 600, EXTENSION_TIME_MIN = 11;
+  var CYCLES_MIN = 1, CYCLES_MAX = 50;
+
+  function validTemp(v) {
+    return typeof v === "number" && v >= TEMP_MIN && v <= TEMP_MAX;
+  }
+  function validTime(v, min) {
+    return typeof v === "number" && v >= min && v <= TIME_MAX;
+  }
+  function validCycles(v) {
+    return Number.isInteger(v) && v >= CYCLES_MIN && v <= CYCLES_MAX;
+  }
+
+  // Ensure a hidden "Invalid Value" message exists right after the input.
+  function errorEl(input) {
+    var next = input.nextElementSibling;
+    if (next && next.classList.contains("field-error")) return next;
+    var p = document.createElement("p");
+    p.className = "field-error is-hidden";
+    p.textContent = "Invalid Value";
+    input.insertAdjacentElement("afterend", p);
+    return p;
+  }
+
+  function setFieldValid(id, ok) {
+    var input = document.getElementById(id);
+    if (!input) return ok;
+    input.classList.toggle("is-invalid", !ok);
+    errorEl(input).classList.toggle("is-hidden", ok);
+    return ok;
+  }
+
+  // Est. Time (Min) — optional; blank is fine, otherwise a positive integer.
+  // Mirrors the legacy editor's check (edit.js) so the field behaves the same.
+  function validEstimated() {
+    var el = document.getElementById("profile-estimated-minutes");
+    if (!el) return true;
+    var raw = el.value.trim();
+    if (raw === "") return true;
+    var parsed = Math.round(Number(raw));
+    return Number.isFinite(parsed) && parsed > 0;
+  }
+
+  function setEstimatedValid(ok) {
+    var input = document.getElementById("profile-estimated-minutes");
+    var err = document.getElementById("profile-estimated-error");
+    if (input) input.classList.toggle("is-invalid", !ok);
+    if (err) err.classList.toggle("is-hidden", ok);
+    return ok;
+  }
+
+  // Validate every enabled-Stage field; flag all offenders at once. Disabled
+  // Stages are skipped (and any stale error on them cleared). Returns validity.
+  function validateForm() {
+    var valid = setEstimatedValid(validEstimated());
+
+    OPTIONAL_STAGES.forEach(function (key) {
+      var box = document.getElementById("stage-" + key + "-enabled");
+      var enabled = !box || box.checked;
+      if (!enabled) {
+        setFieldValid("stage-" + key + "-temp", true);
+        setFieldValid("stage-" + key + "-time", true);
+        return;
+      }
+      valid = setFieldValid("stage-" + key + "-temp", validTemp(num("stage-" + key + "-temp"))) && valid;
+      valid = setFieldValid("stage-" + key + "-time", validTime(num("stage-" + key + "-time"), TIME_MIN)) && valid;
+    });
+
+    valid = setFieldValid("stage-amp-cycles", validCycles(num("stage-amp-cycles"))) && valid;
+
+    var rows = document.querySelectorAll(".amp-substage");
+    for (var i = 0; i < rows.length; i++) {
+      var idx = rows[i].getAttribute("data-sub");
+      var isLast = i === rows.length - 1; // extension-bearing Sub-stage
+      var minTime = isLast ? EXTENSION_TIME_MIN : TIME_MIN;
+      valid = setFieldValid("stage-amp-sub-" + idx + "-temp", validTemp(num("stage-amp-sub-" + idx + "-temp"))) && valid;
+      valid = setFieldValid("stage-amp-sub-" + idx + "-time", validTime(num("stage-amp-sub-" + idx + "-time"), minTime)) && valid;
+    }
+
+    return valid;
   }
 
   async function saveProfile() {
     var status = document.getElementById("save-status");
+    // Validate on save only (never on load); block + flag every offender.
+    if (!validateForm()) {
+      var firstBad = document.querySelector(".is-invalid");
+      if (firstBad) firstBad.scrollIntoView({ block: "center", behavior: "smooth" });
+      if (status) status.textContent = "";
+      return;
+    }
     if (status) status.textContent = "Saving...";
     try {
       var response = await fetch("/profiles", {
@@ -198,6 +300,60 @@
     showAddTab(true);
   }
 
+  // ---- Edit round-trip (issue #203) -----------------------------------------
+
+  function setVal(id, value) {
+    var el = document.getElementById(id);
+    if (el && value !== undefined && value !== null) el.value = value;
+  }
+
+  function populateOptionalStage(key, stage) {
+    if (!stage) return;
+    var box = document.getElementById("stage-" + key + "-enabled");
+    if (box) box.checked = !!stage.enabled;
+    setVal("stage-" + key + "-temp", stage.temp);
+    setVal("stage-" + key + "-time", stage.time);
+    syncStage(key); // grey/disable when restored as unchecked
+  }
+
+  // Repopulate the builder from an existing structured Profile's `stages`.
+  async function loadForEdit(id) {
+    try {
+      var resp = await fetch("/profiles/details?id=" + encodeURIComponent(id));
+      if (!resp.ok) return;
+      var data = await resp.json();
+      var stages = data.stages;
+      if (!stages) return; // not a Structured Profile — leave blank defaults
+
+      var titleText = document.getElementById("builder-title-text");
+      if (titleText) titleText.textContent = "Edit Profile";
+
+      setVal("profile-name", data.title);
+      var labels = data.labels || {};
+      setVal("profile-fam-label", labels.fam);
+      setVal("profile-rox-label", labels.rox);
+      var secs = data.estimated_completion_seconds;
+      if (typeof secs === "number" && secs > 0) {
+        setVal("profile-estimated-minutes", Math.round(secs / 60));
+      }
+
+      populateOptionalStage("incubation", stages.incubation);
+      populateOptionalStage("denaturation", stages.denaturation);
+      populateOptionalStage("finalhold", stages.finalHold);
+
+      var amp = stages.amplification || {};
+      setVal("stage-amp-cycles", amp.cycles);
+      var subs = amp.subStages || [];
+      if (subs.length === 3) addSubstage(); // build + name the third row
+      for (var i = 0; i < subs.length; i++) {
+        setVal("stage-amp-sub-" + i + "-temp", subs[i].temp);
+        setVal("stage-amp-sub-" + i + "-time", subs[i].time);
+      }
+    } catch (e) {
+      console.error("Failed to load profile for edit", e);
+    }
+  }
+
   // ---- Boot -----------------------------------------------------------------
 
   function init() {
@@ -216,6 +372,8 @@
 
     var saveButton = document.getElementById("save-profile-button");
     if (saveButton) saveButton.addEventListener("click", saveProfile);
+
+    if (editId) loadForEdit(editId);
   }
 
   if (document.readyState === "loading") {

--- a/aquila_web/static/profiles/edit.html
+++ b/aquila_web/static/profiles/edit.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=768, height=1024, initial-scale=1" />
   <title>Edit Profile</title>
-  <link rel="stylesheet" href="/static/styles.css?v=218" />
+  <link rel="stylesheet" href="/static/styles.css?v=233" />
 </head>
 <body class="app-body">
   <div class="app-shell">

--- a/aquila_web/static/profiles/edit.js
+++ b/aquila_web/static/profiles/edit.js
@@ -230,7 +230,34 @@ const renderSteps = () => {
   renderSummary();
 };
 
+// Read-view header: profile name, FAM/ROX labels, and estimated minutes when set
+// (issue #211). Values come from the loaded form fields.
+const renderSummaryMeta = () => {
+  const meta = document.getElementById("profile-summary-meta");
+  if (!meta) return;
+  const items = [
+    { label: "Profile Name", value: nameInput ? nameInput.value : "" },
+    { label: "FAM Label", value: famLabelInput ? famLabelInput.value : "" },
+    { label: "ROX Label", value: roxLabelInput ? roxLabelInput.value : "" }
+  ];
+  const est = estimatedMinutesInput ? estimatedMinutesInput.value.trim() : "";
+  if (est !== "" && Number(est) > 0) {
+    items.push({ label: "Est. Time (Min)", value: est });
+  }
+  meta.innerHTML = items
+    .map(
+      (item) => `
+      <div>
+        <span class="profile-summary-label">${esc(item.label)}</span>
+        <span class="profile-summary-value">${esc(String(item.value))}</span>
+      </div>
+    `
+    )
+    .join("");
+};
+
 const renderSummary = () => {
+  renderSummaryMeta();
   if (!summaryList) return;
   summaryList.innerHTML = "";
   stages.forEach((stage, stageIndex) => {
@@ -380,6 +407,8 @@ const applyViewMode = () => {
     summarySection.classList.toggle("is-hidden", !isReadView);
   }
   if (toggleReadViewButton) {
+    // Read-only Legacy view has no escape hatch back to editing (issue #211).
+    toggleReadViewButton.classList.toggle("is-hidden", isReadView);
     toggleReadViewButton.textContent = isReadView ? "Edit View" : "Read View";
   }
   if (pageTitle) {

--- a/aquila_web/static/profiles/edit.js
+++ b/aquila_web/static/profiles/edit.js
@@ -33,10 +33,9 @@ const toggleReadViewButton = document.getElementById("toggle-read-view");
 const editSections = document.querySelectorAll(".profile-edit");
 const summarySection = document.getElementById("profile-summary");
 
+// Honour an explicit ?view=1 (or ?mode=view): Legacy Profiles route here to open
+// read-only (issue #203). Without the param the editor opens editable as before.
 let isReadView = viewMode;
-if (isReadView && toggleReadViewButton) {
-  isReadView = false;
-}
 const DEFAULT_DYE_LABELS = { fam: "FAM", rox: "ROX" };
 
 const parseDuration = (value) => {

--- a/aquila_web/static/profiles/edit.js
+++ b/aquila_web/static/profiles/edit.js
@@ -407,8 +407,10 @@ const applyViewMode = () => {
     summarySection.classList.toggle("is-hidden", !isReadView);
   }
   if (toggleReadViewButton) {
-    // Read-only Legacy view has no escape hatch back to editing (issue #211).
-    toggleReadViewButton.classList.toggle("is-hidden", isReadView);
+    // Hide the toggle only for URL-driven read-only entry (?view=1) — a Legacy
+    // Profile has no escape hatch back to editing (issue #211). In normal edit
+    // mode the in-page Read View / Edit View round-trip is preserved.
+    toggleReadViewButton.classList.toggle("is-hidden", viewMode);
     toggleReadViewButton.textContent = isReadView ? "Edit View" : "Read View";
   }
   if (pageTitle) {

--- a/aquila_web/static/profiles/edit_form.html
+++ b/aquila_web/static/profiles/edit_form.html
@@ -102,7 +102,7 @@
     </main>
   </div>
   <script src="/static/nav.js?v=1"></script>
-  <script src="/static/profiles/edit.js?v=19"></script>
+  <script src="/static/profiles/edit.js?v=20"></script>
   <script src="/static/keyboard.js?v=14"></script>
 </body>
 </html>

--- a/aquila_web/static/profiles/edit_form.html
+++ b/aquila_web/static/profiles/edit_form.html
@@ -114,7 +114,7 @@
     </main>
   </div>
   <script src="/static/nav.js?v=1"></script>
-  <script src="/static/profiles/edit.js?v=22"></script>
+  <script src="/static/profiles/edit.js?v=23"></script>
   <script src="/static/keyboard.js?v=14"></script>
 </body>
 </html>

--- a/aquila_web/static/profiles/edit_form.html
+++ b/aquila_web/static/profiles/edit_form.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=768, height=1024, initial-scale=1" />
   <title>Edit Profile</title>
-  <link rel="stylesheet" href="/static/styles.css?v=232" />
+  <link rel="stylesheet" href="/static/styles.css?v=233" />
   <script>
     // Apply read-only before first paint so the editable editor never flashes
     // when a Legacy Profile opens via ?view=1 (issue #211). edit.js still runs

--- a/aquila_web/static/profiles/edit_form.html
+++ b/aquila_web/static/profiles/edit_form.html
@@ -4,7 +4,18 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=768, height=1024, initial-scale=1" />
   <title>Edit Profile</title>
-  <link rel="stylesheet" href="/static/styles.css?v=219" />
+  <link rel="stylesheet" href="/static/styles.css?v=232" />
+  <script>
+    // Apply read-only before first paint so the editable editor never flashes
+    // when a Legacy Profile opens via ?view=1 (issue #211). edit.js still runs
+    // applyViewMode() to populate the summary and disable inputs.
+    (function () {
+      var p = new URLSearchParams(location.search);
+      if (p.get("view") === "1" || p.get("mode") === "view") {
+        document.documentElement.classList.add("view-only");
+      }
+    })();
+  </script>
 </head>
 <body class="app-body">
   <div class="app-shell">
@@ -61,6 +72,7 @@
             <h2>Profile Summary</h2>
             <p>Read-only overview of every stage and step.</p>
           </header>
+          <div id="profile-summary-meta" class="profile-summary-meta"></div>
           <div id="profile-summary-list" class="profile-summary-list"></div>
         </section>
         <section class="card profile-edit" id="profile-edit-steps">
@@ -102,7 +114,7 @@
     </main>
   </div>
   <script src="/static/nav.js?v=1"></script>
-  <script src="/static/profiles/edit.js?v=20"></script>
+  <script src="/static/profiles/edit.js?v=22"></script>
   <script src="/static/keyboard.js?v=14"></script>
 </body>
 </html>

--- a/aquila_web/static/profiles/index.html
+++ b/aquila_web/static/profiles/index.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>Run Profiles</title>
-  <link rel="stylesheet" href="/static/styles.css?v=218" />
+  <link rel="stylesheet" href="/static/styles.css?v=233" />
 </head>
 <body class="app-body">
   <div class="app-shell">

--- a/aquila_web/static/profiles/index.html
+++ b/aquila_web/static/profiles/index.html
@@ -26,7 +26,7 @@
       <div class="profiles-shell">
         <div class="profiles-toolbar profiles-toolbar--minimal">
           <div class="profiles-actions">
-            <a class="run-secondary-btn" href="/profiles/edit-form">New profile</a>
+            <a class="run-secondary-btn" href="/profiles/builder">New profile</a>
             <button class="run-secondary-btn" id="profiles-delete-button" type="button">Delete</button>
           </div>
         </div>
@@ -55,6 +55,6 @@
     </main>
   </div>
   <script src="/static/nav.js?v=1"></script>
-  <script src="/static/profiles/profiles.js?v=6"></script>
+  <script src="/static/profiles/profiles.js?v=7"></script>
 </body>
 </html>

--- a/aquila_web/static/profiles/profiles.js
+++ b/aquila_web/static/profiles/profiles.js
@@ -128,7 +128,13 @@
     const editCell = document.createElement("td");
     if (!isBundled) {
       const idParam = encodeURIComponent(profile.id || "");
-      editCell.appendChild(createActionLink("Edit", `/profiles/edit-form?id=${idParam}`));
+      if (profile.structured) {
+        // Structured Profiles edit in the guided builder.
+        editCell.appendChild(createActionLink("Edit", `/profiles/builder?id=${idParam}`));
+      } else {
+        // Legacy Profiles are read-only in-app — open the viewer (?view=1).
+        editCell.appendChild(createActionLink("View", `/profiles/edit-form?id=${idParam}&view=1`));
+      }
     }
     row.appendChild(editCell);
 

--- a/aquila_web/static/ready.html
+++ b/aquila_web/static/ready.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=768, height=1024, initial-scale=1" />
   <title>Ready Screen</title>
-  <link rel="stylesheet" href="static/styles.css?v=218" />
+  <link rel="stylesheet" href="static/styles.css?v=233" />
 </head>
 <body class="app-body">
   <div class="app-shell">

--- a/aquila_web/static/run.html
+++ b/aquila_web/static/run.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=768, height=1024, initial-scale=1" />
   <title>Run</title>
-  <link rel="stylesheet" href="static/styles.css?v=223" />
+  <link rel="stylesheet" href="static/styles.css?v=233" />
 </head>
 <body class="app-body">
   <div class="app-shell">

--- a/aquila_web/static/settings.html
+++ b/aquila_web/static/settings.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=768, height=1024, initial-scale=1" />
   <title>Settings</title>
-  <link rel="stylesheet" href="/static/styles.css?v=218" />
+  <link rel="stylesheet" href="/static/styles.css?v=233" />
   <link rel="stylesheet" href="/static/icon-colors.css?v=1" />
   <style>
     .settings-sub {

--- a/aquila_web/static/styles.css
+++ b/aquila_web/static/styles.css
@@ -2470,9 +2470,23 @@ a:active {
   gap: 10px;
 }
 
+/* Pre-paint read-only gating for the Legacy viewer (issue #211): hide the
+   editable sections + the Edit View toggle and reveal the summary before edit.js
+   runs, so the editable editor never flashes on a ?view=1 load. */
+html.view-only .profile-edit,
+html.view-only #toggle-read-view {
+  display: none;
+}
+
+html.view-only #profile-summary {
+  display: block;
+}
+
 .profile-summary-step {
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
+  /* Fixed column tracks so every step row aligns regardless of field count —
+     no field-count zig-zag (issue #211). 5 = the max fields any step type has. */
+  grid-template-columns: repeat(5, minmax(0, 1fr));
   gap: 12px;
   padding: 10px 12px;
   border-radius: 10px;

--- a/aquila_web/static/styles.css
+++ b/aquila_web/static/styles.css
@@ -2694,11 +2694,15 @@ a:active {
   align-items: center;
   gap: 10px;
   cursor: pointer;
+  /* Kiosk touch target: keep the tappable label >= 44px tall (issue #202). */
+  min-height: 44px;
 }
 
 .stage__toggle input[type="checkbox"] {
   width: 22px;
   height: 22px;
+  /* Checked fill matches the Save Profile button's green (issue #202 follow-up). */
+  accent-color: var(--icon-acorn-green);
 }
 
 .stage__title {
@@ -2706,8 +2710,13 @@ a:active {
   font-weight: 600;
 }
 
+/* Reserve a right gutter on every Sub-stage row so all temp/time inputs line up,
+   whether or not the row carries an X. The removable (Extension) row drops its X
+   into this gutter via absolute positioning, so it never shrinks the fields. */
 .amp-substage {
+  position: relative;
   margin-top: 12px;
+  padding-right: 39px;
 }
 
 .amp-substage__name {
@@ -2715,6 +2724,58 @@ a:active {
   font-size: 13px;
   font-weight: 600;
   margin-bottom: 8px;
+}
+
+/* Two-/three-step Sub-stage controls (issue #202). */
+
+/* Red X in a square red-outlined box, sitting in the reserved gutter. `top` is
+   tuned so the box centres on the midpoint between the Annealing and Extension
+   time fields. Kept compact (below the 44px kiosk minimum) by design. */
+.amp-substage__remove {
+  position: absolute;
+  top: 4px;
+  right: 0;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 27px;
+  height: 27px;
+  padding: 0;
+  border: 2px solid #dc2626;
+  border-radius: 6px;
+  background: none;
+  color: #dc2626;
+  font-size: 18px;
+  line-height: 1;
+  cursor: pointer;
+}
+
+/* Full-width "+ Add sub-stage" tab; hidden via .is-hidden once a third exists.
+   Kiosk touch target: >= 44px tall. */
+.amp-add-tab {
+  display: block;
+  width: 100%;
+  min-height: 44px;
+  margin-top: 16px;
+  border: 1px dashed #cbd5e1;
+  border-radius: 10px;
+  background: #f8fafc;
+  color: #475569;
+  font-size: 15px;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  cursor: pointer;
+}
+
+/* Override .amp-add-tab's display:block when hidden (same-specificity tie that
+   the later .amp-add-tab rule would otherwise win). */
+.amp-add-tab.is-hidden {
+  display: none;
+}
+
+/* Cycles is the last field in the Amplification card (issue #202). */
+#stage-amplification > .field-grid {
+  margin-top: 16px;
 }
 
 /* An unchecked Stage greys out. Its inputs are also set [disabled] in JS, which

--- a/aquila_web/static/styles.css
+++ b/aquila_web/static/styles.css
@@ -2784,6 +2784,14 @@ a:active {
   opacity: 0.5;
 }
 
+/* A field that failed save-time validation (issue #203). Red border pairs with
+   the "Invalid Value" .field-error text — colour is never the only signal. The
+   `.field input` qualifier beats the base `.field input` border specificity. */
+.field input.is-invalid,
+.is-invalid {
+  border: 2px solid #dc2626;
+}
+
 .field-grid {
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
@@ -2821,10 +2829,12 @@ a:active {
   color: #64748b;
 }
 
+/* `.card .field-error` qualifier beats `.card p`'s grey, so the message is red. */
+.card .field-error,
 .field-error {
   margin: 0;
   font-size: 12px;
-  color: #b91c1c;
+  color: #dc2626;
 }
 
 .profile-steps {

--- a/aquila_web/static/styles.css
+++ b/aquila_web/static/styles.css
@@ -2682,6 +2682,47 @@ a:active {
   gap: 24px;
 }
 
+/* Structured builder Stages (issue #200). */
+.stage__header {
+  display: flex;
+  align-items: center;
+  margin-bottom: 12px;
+}
+
+.stage__toggle {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  cursor: pointer;
+}
+
+.stage__toggle input[type="checkbox"] {
+  width: 22px;
+  height: 22px;
+}
+
+.stage__title {
+  font-size: 16px;
+  font-weight: 600;
+}
+
+.amp-substage {
+  margin-top: 12px;
+}
+
+.amp-substage__name {
+  display: block;
+  font-size: 13px;
+  font-weight: 600;
+  margin-bottom: 8px;
+}
+
+/* An unchecked Stage greys out. Its inputs are also set [disabled] in JS, which
+   keeps their typed values so re-checking the Stage restores them. */
+.stage--disabled {
+  opacity: 0.5;
+}
+
 .field-grid {
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));

--- a/docs/adr/ADR-018-structured-profile-editor-backend-assembled-steps.md
+++ b/docs/adr/ADR-018-structured-profile-editor-backend-assembled-steps.md
@@ -1,0 +1,88 @@
+# ADR-018: Structured Profile Editor — Backend-Assembled Steps with `stages` as Source of Truth
+
+**Status**: Accepted
+**Date**: 2026-06-25
+**Deciders**: Aquila Engineering Team
+
+---
+
+## Context
+
+The current profile editor (`aquila_web/static/profiles/edit_form.html` + `edit.js`) is a fully generic step builder: operators add arbitrary stages and choose raw step types (`setpoint`, `ramp_rate`, `enable`, `disable`, `pcr_fanon`, `pcr_fanoff`). This exposes hardware-level detail that operators get wrong, and every assay must hand-author the same fixed equilibration/fan/optics/cooldown scaffolding (visible identically across all bundled profiles, e.g. `ABBA_ramp1.75_EA30.json`).
+
+We are introducing a guided, structured editor that presents only four domain Stages — Incubation, Initial Denaturation, Amplification, Final Temp Hold — plus the Amplification cycle count. Everything else (equilibration, fan control, optics init, entry/exit ramps, the optics read inside each cycle, cooldown) must be applied automatically and consistently.
+
+Two cross-cutting facts forced the architectural decisions below:
+
+- **The work is split across two engineers** who must proceed concurrently without blocking each other, which demands a clean, agreed contract between the form and the file.
+- **Existing profiles have arbitrary step structures** that do not map cleanly into four fixed Stages, so a rigid editor cannot safely round-trip them.
+
+Per ADR-003, the frontend has no build step — the editor is plain HTML/CSS/JS served by FastAPI.
+
+---
+
+## Decision
+
+**We will add a structured profile editor as new files alongside the existing editor, persist the operator's choices as a `stages` object that is the single editable source of truth, and have the backend assemble the runnable `steps` array from a fixed boilerplate template.**
+
+Concretely:
+
+- **New files, not a rewrite.** The structured editor ships as new artifacts (e.g. `profile_builder.html` / `profile_builder.js`) on a new route. The existing `edit_form.html` / `edit.js` is retained solely to render the read-only Legacy view via its existing `?view=1` mode.
+- **`stages` is the source of truth and the tag.** A Structured Profile's JSON carries a top-level `stages` object (the four Stages with `enabled`/temp/time, plus Amplification's `cycles` and 2–3 `subStages`). Its presence is the *only* marker distinguishing a Structured Profile from a Legacy Profile — no separate version flag.
+- **Backend assembles `steps`.** The frontend POSTs `{title, labels, estimated_minutes, stages}`. The backend validates `stages`, then expands them into the full `steps` array: fixed head (`disable/1s → ramp 1.6 → pcr_fanon → enable/1s → optics → 25°C/1s`), enabled Stages in order, the mid ramp `1.75` before the Amplification `repeat`, the optics read split inside the extension-bearing sub-stage (`(t−10)s → optics → 10s`), the Final Temp Hold before the tail, and the fixed tail (`ramp 1.6 → 40°C/20s → 25°C/10s → disable/5s → pcr_fanoff`). `steps` is regenerated on every save and is **never reverse-parsed** back into `stages`.
+- **`steps` remains the only thing the hardware runner and analytics read.** `stages` is purely additive; the runner ignores it. Re-editing reads `stages`.
+- **Legacy Profiles are read-only in-app.** Any profile without `stages` (everything predating this feature, plus all bundled profiles) opens read-only; it stays runnable and hand-editable as a JSON file on disk. `GET /profiles` returns a `structured` flag so the list routes each row to the builder (structured) or the read-only view (legacy).
+
+This decision is **hard to reverse**: it defines the on-disk JSON contract, what is written to every new profile, and what executes on hardware.
+
+---
+
+## Consequences
+
+### Positive
+- Operators author assays in domain terms; hardware scaffolding can't be mis-entered or forgotten.
+- Boilerplate constants and the optics-split rule live server-side in one place, unit-testable in `unit_tests/` (per CLAUDE.md), not duplicated in browser JS.
+- Lossless round-trip: re-opening reads `stages` directly, sidestepping the unsolved problem of mapping arbitrary `steps` back into four Stages.
+- Clean two-engineer split: the `stages` payload is the contract; frontend and backend build against it independently.
+- Additive `stages` key means zero blast radius for the runner and analytics.
+
+### Negative
+- The JSON carries redundant data (`stages` plus the derived `steps`); a hand-edit to `steps` that isn't mirrored in `stages` will be silently overwritten on the next structured save.
+- Two editor frontends coexist (structured builder + legacy read-only viewer).
+- Boilerplate constants (1.6 / 1.75 / 25°C / 10s optics offset) are hardcoded; changing assay scaffolding requires a code + test change, not a profile edit.
+
+### Neutral / Tradeoffs
+- Local Legacy Profiles lose in-app editability (previously editable); mitigated by the on-disk hand-edit escape hatch and the fact that adding a valid `stages` block promotes a file to Structured.
+- The manual "Est. Time (Min)" field is retained rather than auto-computed — runtime can't be derived accurately from setpoints (machine movement/heat-up), so a manual estimate stays honest.
+
+---
+
+## Alternatives Considered
+
+### Frontend assembles `steps` (status quo pass-through)
+**Why rejected:** buries hardware/domain logic in browser JS, can't be unit-tested server-side, and collapses the clean contract seam the two-engineer split depends on.
+
+### Single editor (rewrite `edit.js` to branch internally)
+**Why rejected:** mixes a rich structured builder and a legacy step-dump in one risky rewrite of working code; new-files-alongside isolates the new UI as an ownable artifact.
+
+### Reverse-parse `steps` into `stages` on edit (no stored `stages`)
+**Why rejected:** arbitrary thermal programs don't map cleanly into four fixed Stages; reverse-parsing is lossy and could silently drop steps a scientist relied on.
+
+### Optics read placed after a single hold (no split)
+**Why rejected:** every shipped assay reads mid-hold; a single-hold read diverges from validated profiles. The `(t−10)s → optics → 10s` split reproduces current behavior.
+
+---
+
+## Revisit Conditions
+
+- If a third assay shape emerges that the four-Stage model can't express, revisit whether `stages` should become a more general schema.
+- If boilerplate constants need to vary per assay, revisit hardcoding them (promote to config or per-profile fields).
+- If maintaining two editor frontends becomes a burden, revisit folding the Legacy read-only view into the builder.
+
+---
+
+## References
+
+- Related ADRs: ADR-003 (plain HTML/CSS/JS, no build step), ADR-006 (JSON state-machine UI screens)
+- Glossary: `CONTEXT.md` — Stage, Sub-stage, Step, Boilerplate, Structured Profile, Legacy Profile
+- Code: `aquila_web/main.py` (`POST /profiles`, `GET /profiles`, `GET /profiles/details`), `aquila_web/static/profiles/`

--- a/specs/backend/spec_integration_promotion.md
+++ b/specs/backend/spec_integration_promotion.md
@@ -1,0 +1,57 @@
+# Spec: Structured Profile Editor — Integration & Promotion (C) — issue #204
+
+**Status:** Draft
+**Author:** Aquila Engineering Team
+**Last updated:** 2026-06-26
+**GitHub issue:** #204
+**Type:** Integration / verification + promotion (HITL) — not a red-green feature build
+**Umbrella PRD:** `specs/prd/structured-profile-editor-prd.md` · **Decision:** ADR-018
+
+---
+
+## 1. Overview
+
+The convergence step. A1–A4 (backend) and B1–B4 (frontend) were built and tested **in isolation** — the backend against hand-written `stages` payloads, the frontend against the #197 stub. C is the first time they run **together** against the real endpoints on `updated-profiles`: it verifies the assembled whole end-to-end, resolves any contract drift, then promotes the entire feature to `main` in one reviewed PR that closes the whole epic.
+
+No new feature code is expected. C's "tests" are the **already-written** e2e suites (from B1–B4), now pointed at the real backend for the first time; C makes the integrated system pass them and fixes any integration-only gaps it surfaces.
+
+---
+
+## 2. Scope of merged work being integrated
+
+- **Backend:** A1 #198 (`assemble_steps`), A2 #199 (`validate_stages`), A3 #201 (POST/GET wiring + `structured` flag), A4 #213 (canonical key order).
+- **Frontend:** B1 #200 (builder shell), B2 #202 (sub-stages), B3 #203 (validation UX + edit round-trip + list routing), B4 #211 (legacy read-only view).
+
+---
+
+## 3. Verification steps
+
+1. **Backend/unit/contract suite:** `venv/Scripts/python -m pytest unit_tests tests/contract -q`. Expect green except the known pre-existing environmental failures (button/ready-screen state-bleed, device-filtering/results fixtures, profile-dir-state tests). These are identical on `main` (verified during A3) — not introduced here.
+2. **e2e against the real backend** (the deferred convergence): with a simulate-mode server running (`AQ_DEV_SIMULATE=1 … uvicorn aquila_web.main:app --port 8090`), run
+   `venv/Scripts/python -m pytest tests/e2e/test_profile_builder.py tests/e2e/test_legacy_view.py -q`
+   (requires `playwright install chromium`). These exercise: structured create → real validate/assemble → save → reopen → repopulate from `stages`; save-time validation display; sub-stage add/remove; list routing (structured → builder, legacy → read-only view).
+3. **Resolve integration drift** if any surfaces — most likely the stylesheet cache-buster uniformity check (`test_settings_nav`) now that `builder.html` is a live page, or any field-id/payload mismatch between what the builder POSTs and what the backend expects.
+
+## 4. Promotion
+
+- Open a single PR **`updated-profiles` → `main`**.
+- Body must list: `Closes #197, #198, #199, #200, #201, #202, #203, #211, #213` so merging to the default branch auto-closes the whole epic.
+- Reviewed + merged as one unit. (#204 itself closed manually or via the PR.)
+
+---
+
+## 5. Acceptance criteria
+
+- [ ] Full `pytest unit_tests tests/contract` run reviewed; only known pre-existing environmental failures remain.
+- [ ] e2e `test_profile_builder` + `test_legacy_view` pass against the real backend.
+- [ ] Any integration drift fixed (or explicitly deferred with a tracked issue).
+- [ ] Promotion PR `updated-profiles` → `main` opened with the full `Closes …` list.
+
+## 6. Out of scope
+
+- New feature behavior — owned by A1–A4 / B1–B4.
+- Rewriting already-saved profile files (A4 normalizes on next save only).
+
+## 7. Open Questions
+
+- [ ] If the cache-buster uniformity test fails, fix here (align `?v=` across pages) or split into its own follow-up issue? (Lean: quick fix here if trivial.)

--- a/specs/backend/spec_profile_endpoints_wiring.md
+++ b/specs/backend/spec_profile_endpoints_wiring.md
@@ -1,0 +1,70 @@
+# Backend Spec: Structured Profile Endpoint Wiring — issue #201 (A3)
+
+**Status:** Draft
+**Author:** Aquila Engineering Team
+**Last updated:** 2026-06-25
+**GitHub issue:** #201
+**Source file(s):** `aquila_web/main.py`, `tests/contract/test_profile_endpoints.py`
+**Umbrella PRD:** `specs/prd/structured-profile-editor-prd.md` · **Decision:** ADR-018
+**Builds on:** `spec_stages_contract_foundation.md` (#197), `spec_profile_step_assembly.md` (#198), `spec_stages_validation.md` (#199)
+
+---
+
+## 1. Overview
+
+Wire the pure `validate_stages` (A2) and `assemble_steps` (A1) into the live profile endpoints. This is the only A-issue that modifies `main.py`. It turns a structured-profile save into: validate → (reject with 4xx, or) assemble `steps` and persist; and exposes a `structured` flag on the profile list so the UI can route rows.
+
+---
+
+## 2. Endpoints
+
+### `POST /profiles` (extended)
+
+When `payload.stages` is present:
+1. Call `validate_stages(stages)` **first**.
+2. If it returns any errors → `HTTPException(status_code=400, detail={"errors": [...]})`; **nothing is written**.
+3. Otherwise set `base_profile["steps"] = assemble_steps(stages)` (regenerate from stages — any client-sent `steps` is ignored for structured saves) and persist both `stages` and `steps`.
+
+When `payload.stages` is absent: unchanged legacy behavior (client `steps` saved as-is, no validation).
+
+**Order guarantee:** `validate_stages` is always called before `assemble_steps`, so the assembler only ever runs on validated input (it assumes well-formed data — A1).
+
+| Code | Condition | Body |
+|------|-----------|------|
+| 200 | valid `stages` (or legacy save) | `{"ok": true, "id": "..."}` |
+| 400 | `stages` present and invalid | `{"detail": {"errors": ["<field>: Invalid Value", ...]}}` |
+| 403 | target inside `profiles/bundled/` | (unchanged) |
+
+### `GET /profiles` (extended)
+
+Each profile entry gains `structured: bool` — `true` iff the profile's JSON contains a `stages` key. Lets the list route: structured → builder, legacy → read-only view. All other fields unchanged.
+
+---
+
+## 5. Persistence
+
+A structured save writes a JSON carrying both `stages` (source of truth) and the regenerated `steps` (what the runner reads). `steps` is never reverse-parsed; on every structured save it is rebuilt from `stages`.
+
+---
+
+## 8. Contract Tests
+
+`tests/contract/test_profile_endpoints.py` (marked `contract`):
+- POST valid `stages` → 200; written JSON has `stages` **and** an assembled `steps` (fixed head/tail + amplification repeat present).
+- POST out-of-range `stages` (e.g. temp 200) → 400; nothing written.
+- POST malformed `stages` (missing sub-stage `name`) → **400, not 500** (validate guards before assemble).
+- `GET /profiles` → a structured profile has `structured: true`; a legacy profile has `structured: false`.
+
+Run: `pytest tests/contract/test_profile_endpoints.py -v`
+
+---
+
+## Out of Scope
+
+- The pure assembler/validator themselves — A1 (#198) / A2 (#199), already merged.
+- The builder UI, validation display, list routing in the browser — B1/B2/B3.
+- `GET /profiles/details` returning `stages` — already shipped in #197.
+
+## 9. Open Questions
+
+- [ ] Error body shape chosen: `detail={"errors": [...]}`. Revisit if the frontend wants a different envelope (B-side validates independently, so no hard dependency).

--- a/specs/backend/spec_profile_key_order.md
+++ b/specs/backend/spec_profile_key_order.md
@@ -1,0 +1,67 @@
+# Backend Spec: Canonical Profile JSON Key Order — issue #213 (A4)
+
+**Status:** Draft
+**Author:** Aquila Engineering Team
+**Last updated:** 2026-06-26
+**GitHub issue:** #213
+**Source file(s):** `aquila_web/main.py`, `tests/contract/test_profile_endpoints.py`
+**Umbrella PRD:** `specs/prd/structured-profile-editor-prd.md` · **Decision:** ADR-018
+**Supersedes helper:** `_order_time_fields()` (the targeted 2-key reorder this generalizes)
+
+---
+
+## 1. Overview
+
+Structured Profiles save their top-level JSON keys in an inconsistent order vs Legacy Profiles (`steps` floats to the top, `post_in_gui`/`stages`/`labels` land in the wrong spots) because `save_profile` builds the dict by insertion order. This issue enforces one canonical key order on every saved profile. Purely a serialization/ordering change — **no values or semantics change**.
+
+---
+
+## 2. Canonical order
+
+Order the keys that are present into this sequence; any other/unknown top-level keys are preserved and appended after, in their original relative order (never dropped):
+
+1. `output_dir`
+2. `post_in_gui`
+3. `title`
+4. `rox_unavailable` *(when present)*
+5. `time_unavailable`
+6. `estimated_completion_seconds`
+7. `labels`
+8. `stages` *(structured profiles only)*
+9. `steps`
+
+Rationale: metadata first (matches legacy), then the human-authored `stages`, then the large machine-facing `steps` last. `stages` immediately precedes `steps`.
+
+**Decisions (resolved):**
+- **`labels` placement:** with the metadata, after `estimated_completion_seconds`, before `stages`. ✔
+- **Scope:** **structured saves only** (a profile whose `base_profile` has a `stages` key). Legacy/`steps`-based saves keep the existing `_order_time_fields` behavior unchanged. ✔
+
+---
+
+## 3. Implementation
+
+- Add `_order_profile_keys(profile: dict) -> dict` in `main.py`: build a new dict by walking the canonical list and copying present keys, then append any leftover keys. Pure dict→dict.
+- `save_profile` calls `_order_profile_keys(base_profile)` immediately before writing **when `base_profile` has a `stages` key** (structured); otherwise it keeps the existing `_order_time_fields(base_profile)` call. The countdown keys are already set on `base_profile` before this point, so ordering need not inject them.
+- Keep the existing "both countdown fields always present, positioned after the anchor" guarantee intact (canonical order keeps `time_unavailable` → `estimated_completion_seconds` right after `title`/`rox_unavailable`).
+
+---
+
+## 8. Tests
+
+`tests/contract/test_profile_endpoints.py` (marked `contract`; prior art: `test_saved_file_always_carries_both_fields_after_anchor`, which reads the written file from disk):
+- A saved **structured** profile's top-level keys equal the canonical order (filtered to present keys); `stages` immediately precedes `steps`; `steps` is last. (`tests/contract/test_profile_endpoints.py::test_structured_profile_keys_in_canonical_order`)
+- Unit tests for the pure `_order_profile_keys`: canonical order regardless of input order; only-present keys emitted; `rox_unavailable` placement; **unknown keys preserved, never dropped** (`unit_tests/test_profile_key_order.py`).
+- **Legacy/steps-based saves are unchanged** — the existing countdown-field ordering test (`test_saved_file_always_carries_both_fields_after_anchor`) still passes.
+
+Run: `pytest tests/contract/test_profile_endpoints.py -v`
+
+---
+
+## Out of Scope
+
+- Re-ordering already-saved profile files on disk (this only affects writes; existing files normalize on their next save).
+- Any change to `stages`/`steps` content — A1/A2/A3 own those.
+
+## 9. Open Questions
+
+- None — `labels` placement and structured-only scope both resolved above.

--- a/specs/backend/spec_profile_step_assembly.md
+++ b/specs/backend/spec_profile_step_assembly.md
@@ -1,0 +1,83 @@
+# Backend Spec: Profile Step Assembly (`stages → steps`) — issue #198 (A1)
+
+**Status:** Draft
+**Author:** Aquila Engineering Team
+**Last updated:** 2026-06-25
+**GitHub issue:** #198
+**Source file(s):** `aquila_web/profile_assembly.py` (new), `unit_tests/test_profile_assembly.py` (new)
+**Umbrella PRD:** `specs/prd/structured-profile-editor-prd.md` · **Decision:** ADR-018
+**Builds on:** `specs/backend/spec_stages_contract_foundation.md` (#197 — the `stages` contract)
+
+---
+
+## 1. Overview
+
+A pure function that expands a structured `stages` object (the #197 contract) into the complete runnable `steps` array, weaving the fixed Boilerplate together with the user's Stages. No HTTP, no disk, no hardware imports — pure `dict → list`.
+
+```python
+def assemble_steps(stages: dict) -> list[dict]: ...
+```
+
+Lives in a standalone module so it is unit-testable without importing the FastAPI app (no RPi/serial stubbing). Wiring into `POST /profiles` is **A3 (#201)**; range validation is **A2 (#199)**. A1 assumes well-formed input and does not validate.
+
+---
+
+## 2. Input
+
+The `stages` object (canonical fixture `tests/fixtures/sample_stages.json`):
+`incubation`/`denaturation`/`finalHold` = `{enabled, temp, time}` (optional Stages); `amplification` = `{cycles, subStages:[{name,temp,time}]}` (always present, 2–3 sub-stages). `temp` °C, `time` seconds.
+
+---
+
+## 3. Output: assembled `steps`, in order
+
+1. **Head (always):**
+   - `{"disable": 0, "duration": 1, "description": "Record equilibration without power."}`
+   - `{"ramp_rate": 1.6}`
+   - `{"pcr_fanon": 1}`
+   - `{"enable": 0, "duration": 1, "description": "Turn on and record temperature for a little bit"}`
+   - `{"optics": ""}`
+   - `{"setpoint": 25, "duration": 1, "description": "Presetting temperature"}`
+2. **Incubation** (only if `enabled`): `{"setpoint": temp, "duration": time, "description": "Incubation"}`
+3. **Initial Denaturation** (only if `enabled`): `{"setpoint": temp, "duration": time, "description": "Initial Denaturation"}`
+4. **Amplification** (always):
+   - `{"ramp_rate": 1.75}`
+   - `{"repeat": [ <sub-stage steps> ], "cycles": <cycles>}`
+   - Each sub-stage → `{"setpoint": temp, "duration": time, "description": <name>}`.
+   - The **extension-bearing** sub-stage (the 2nd when there are 2, the 3rd when there are 3) is split around the optics read:
+     `{"setpoint": temp, "duration": time-10, "description": <name>}`, `{"optics": ""}`, `{"setpoint": temp, "duration": 10, "description": <name>}`.
+5. **Final Temp Hold** (only if `enabled`): `{"setpoint": temp, "duration": time, "description": "Final Temp Hold"}` — after Amplification, before tail.
+6. **Tail (always):**
+   - `{"ramp_rate": 1.6}`
+   - `{"setpoint": 40, "duration": 20, "description": "Initial cooling"}`
+   - `{"setpoint": 25, "duration": 10, "description": "Restoring setpoint to RT"}`
+   - `{"disable": 0, "duration": 5, "description": "Turn off and record temperature for a little bit"}`
+   - `{"pcr_fanoff": 0}`
+
+Disabled Stages emit nothing. Constants (1.6 / 1.75 / 25 °C / 10 s offset) are fixed per ADR-018.
+
+---
+
+## 7. Validation Rules
+
+None here — A1 assumes valid input. Range/shape validation is A2 (#199), enforced on `POST` in A3 (#201).
+
+---
+
+## 8. Unit Tests
+
+`unit_tests/test_profile_assembly.py` (marked `unit`), importing `aquila_web.profile_assembly` directly. Behaviors: head emitted; tail emitted; amplification ramp 1.75 + repeat with cycles; sub-stage → setpoint with name description; optics split on extension sub-stage (2- and 3-sub-stage cases); incubation/denaturation/final-hold emitted when enabled; disabled stages omitted; full end-to-end ordering.
+
+Run: `pytest unit_tests/test_profile_assembly.py -v`
+
+---
+
+## Out of Scope (other issues)
+
+- Validation — A2 (#199). Wiring into `POST /profiles` + `structured` list flag — A3 (#201). UI — B1/B2/B3.
+
+---
+
+## 9. Open Questions
+
+- [ ] None — assembly rules fixed in ADR-018 / the PRD.

--- a/specs/backend/spec_stages_contract_foundation.md
+++ b/specs/backend/spec_stages_contract_foundation.md
@@ -1,0 +1,115 @@
+# Backend / API Spec: `stages` Contract Foundation (issue #197)
+
+**Status:** Active
+**Author:** Aquila Engineering Team
+**Last updated:** 2026-06-25
+**GitHub issue:** #197
+**Source file(s):** `aquila_web/main.py`, `aquila_web/static/profiles/builder.html`, `tests/fixtures/sample_stages.json`
+**Umbrella PRD:** `specs/prd/structured-profile-editor-prd.md` · **Decision:** `docs/adr/ADR-018-structured-profile-editor-backend-assembled-steps.md`
+
+---
+
+## 1. Overview
+
+The shared prerequisite for the Structured Profile Editor: make the backend accept, persist, and return a structured `stages` object, and serve the editor's HTML shell. This establishes the `stages` contract both routes build against. It deliberately does **not** assemble `steps`, validate ranges, add the list `structured` flag, or build any UI — those are separate issues (A1 #198, A2 #199, A3 #201, B1–B3) with their own specs.
+
+---
+
+## 2. Endpoints
+
+### `POST /profiles` (extended)
+
+**Purpose:** Accept an optional structured `stages` object and persist it verbatim alongside the existing fields.
+
+**Request body (relevant addition):**
+```json
+{
+  "name": "My Assay",     // required (unchanged)
+  "stages": { ... }       // optional; persisted verbatim (see §4)
+}
+```
+
+**Response (200 OK):** `{ "ok": true, "id": "local/my_assay.json" }` (unchanged).
+
+**Behavior for #197:**
+- When `stages` is present, it is written into the saved JSON unchanged.
+- When `stages` is absent, behavior is exactly as before (Legacy/`steps`-based saves unaffected).
+- No validation of `stages` contents in #197 (deferred to A2/A3). No `steps` regeneration (deferred to A1/A3).
+
+**Error responses:** unchanged from current `POST /profiles` (e.g. 403 on bundled, 500 on write failure).
+
+### `GET /profiles/details` (extended)
+
+Returns the `stages` object **only when the file contains it**; Legacy Profiles omit the key entirely so the presence of `stages` is the Structured-Profile marker. All other returned fields unchanged.
+
+### `GET /profiles/builder` (new)
+
+Serves `static/profiles/builder.html` with `Cache-Control: no-store`. A static shell only — Stage UI, validation, and save wiring are the frontend issues (B1/B2/B3).
+
+---
+
+## 4. Data Models
+
+### `ProfileSave.stages` (request field) — the contract
+
+Optional `dict`. Canonical fixture committed at `tests/fixtures/sample_stages.json`:
+
+```json
+{
+  "incubation":   { "enabled": true,  "temp": 37, "time": 600 },
+  "denaturation": { "enabled": true,  "temp": 95, "time": 120 },
+  "amplification": {
+    "cycles": 40,
+    "subStages": [
+      { "name": "Denaturation",          "temp": 95,   "time": 11 },
+      { "name": "Annealing & Extension", "temp": 60.5, "time": 38 }
+    ]
+  },
+  "finalHold":    { "enabled": false, "temp": 25, "time": 60 }
+}
+```
+
+- `incubation` / `denaturation` / `finalHold`: `{enabled: bool, temp: °C, time: seconds}` — optional Stages.
+- `amplification`: always present (no `enabled`); `cycles` integer; `subStages` length 2–3, each `{name, temp, time}`.
+
+#197 treats this object as opaque — it stores and returns it without interpreting it.
+
+---
+
+## 5. Persistence
+
+- The `stages` object is written verbatim into the Profile JSON (under `profiles/local/` for new profiles).
+- A file containing `stages` is a Structured Profile; its presence is the only marker (ADR-018).
+- `steps` remains the only artifact the hardware runner/analytics read. In #197 a structured-only save does not yet regenerate `steps` (that is A1/A3); the field is carried for the contract.
+
+---
+
+## 7. Validation Rules
+
+None in #197. Range/shape validation of `stages` is specified separately for A2 (#199) and enforced on `POST` in A3 (#201).
+
+---
+
+## 8. Contract Tests
+
+`tests/contract/test_profile_endpoints.py` (marked `contract`):
+- `test_post_profile_persists_and_returns_stages` — a `stages` payload round-trips through `POST` → `GET /profiles/details`.
+- `test_profiles_builder_route_serves_html` — `GET /profiles/builder` returns 200 + HTML.
+- `test_sample_stages_fixture_matches_contract` — the committed fixture matches the canonical shape.
+
+Run: `pytest tests/contract/test_profile_endpoints.py -v`
+
+---
+
+## Out of Scope (other issues, other specs)
+
+- Assembling `stages → steps` and the Boilerplate constants — A1 (#198).
+- Validating `stages` ranges/shape — A2 (#199).
+- Enforcing validation on `POST` and adding the `structured` flag to `GET /profiles` — A3 (#201).
+- The builder UI, validation display, and list routing — B1/B2/B3 (#200/#202/#203).
+
+---
+
+## 9. Open Questions
+
+- [ ] None — contract decisions resolved in ADR-018 and the PRD.

--- a/specs/backend/spec_stages_validation.md
+++ b/specs/backend/spec_stages_validation.md
@@ -38,6 +38,8 @@ Validated only for **enabled** Stages (Amplification is always enabled). Disable
 
 Constants per ADR-018. Non-numeric or missing values for enabled fields are errors (not exceptions).
 
+**Non-finite guard (#219):** `_is_number` rejects `NaN`/`Infinity`, and `save_profile` serializes with `allow_nan=False` *before* writing — so a non-finite value anywhere (including a disabled stage that validation skips) fails as a 400 with nothing written, rather than persisting literal `NaN`/`Infinity` that 500s on every later read.
+
 ---
 
 ## 8. Unit Tests

--- a/specs/backend/spec_stages_validation.md
+++ b/specs/backend/spec_stages_validation.md
@@ -1,0 +1,62 @@
+# Backend Spec: Stages Validation (`validate_stages`) — issue #199 (A2)
+
+**Status:** Draft
+**Author:** Aquila Engineering Team
+**Last updated:** 2026-06-25
+**GitHub issue:** #199
+**Source file(s):** `aquila_web/profile_assembly.py`, `unit_tests/test_profile_assembly.py`
+**Umbrella PRD:** `specs/prd/structured-profile-editor-prd.md` · **Decision:** ADR-018
+**Builds on:** `spec_stages_contract_foundation.md` (#197), `spec_profile_step_assembly.md` (#198)
+
+---
+
+## 1. Overview
+
+A pure function that checks a structured `stages` object against the instrument's valid ranges and shape, returning the list of problems found. Lives in `aquila_web/profile_assembly.py` alongside `assemble_steps` (same bounded concern). No HTTP/disk/hardware imports.
+
+```python
+def validate_stages(stages: dict) -> list[str]: ...
+```
+
+Returns a list of human-readable error strings, each naming the offending field (e.g. `"incubation.temp: Invalid Value"`). **Empty list means valid.** Enforcement on `POST /profiles` (return 4xx; call `validate_stages` *before* `assemble_steps`) is **A3 (#201)**; the frontend does its own save-time display (B3). A2 is the backend defense-in-depth check only.
+
+---
+
+## 2. Rules
+
+Validated only for **enabled** Stages (Amplification is always enabled). Disabled optional Stages are skipped entirely — their values never produce errors.
+
+| Field | Rule | On failure |
+|-------|------|-----------|
+| any temp (incubation/denaturation/finalHold/each sub-stage) | numeric, `25 ≤ temp ≤ 100` | error |
+| incubation/denaturation/finalHold time | numeric, `1 ≤ time ≤ 600` | error |
+| extension-bearing sub-stage time (last sub-stage) | numeric, `11 ≤ time ≤ 600` | error — keeps the `assemble_steps` `(time-10)` split ≥ 1s |
+| non-extension sub-stage time | numeric, `1 ≤ time ≤ 600` | error |
+| `amplification.cycles` | integer, `1 ≤ cycles ≤ 50` | error |
+| `amplification.subStages` | length 2 or 3 | error |
+| any required numeric field | present and numeric (not blank / non-numeric) | error |
+
+Constants per ADR-018. Non-numeric or missing values for enabled fields are errors (not exceptions).
+
+---
+
+## 8. Unit Tests
+
+`unit_tests/test_profile_assembly.py` (marked `unit`), importing `validate_stages` directly. Behaviors, one RED→GREEN each: valid stages → no errors; temp above 100 / below 25 → error; time above 600 / below 1 → error; extension sub-stage time < 11 → error (while a non-extension time of e.g. 5 is fine); cycles 0 / 51 / non-int → error; sub-stage count 1 or 4 → error; disabled stage with bad values → no error (skipped); non-numeric / missing value → error.
+
+Run: `pytest unit_tests/test_profile_assembly.py -v`
+
+---
+
+## Also in this issue (carried from A1 review, PR #206)
+
+- Tighten `assemble_steps`'s return annotation from `-> list` to `-> list[dict]` (same file, cosmetic).
+
+## Out of Scope
+
+- Enforcing validation on `POST` + returning 4xx, and calling `validate_stages` before `assemble_steps` — A3 (#201).
+- Frontend save-time validation display — B3 (#203).
+
+## 9. Open Questions
+
+- [ ] Return shape chosen: `list[str]` of field-named messages — simplest for A3's 4xx; the frontend doesn't depend on it (B3 validates independently). Revisit if A3 wants structured `{field, message}` entries.

--- a/specs/frontend/spec_amplification_substages.md
+++ b/specs/frontend/spec_amplification_substages.md
@@ -1,0 +1,148 @@
+# Frontend / UI Spec: Amplification Sub-stages — add/remove + rename + cycles (issue #202)
+
+**Status:** Active
+**Author:** Aquila Engineering Team
+**Last updated:** 2026-06-25
+**GitHub issue:** #202 (Structured Profiles B2)
+**Affected screens:** Create Profile (`/profiles/builder`)
+**Source file(s):** `aquila_web/static/profiles/builder.html`, `aquila_web/static/profiles/builder.js`, `aquila_web/static/styles.css`, `tests/e2e/test_profile_builder.py`
+**Umbrella PRD:** `specs/prd/structured-profile-editor-prd.md` · **Decision:** ADR-018, ADR-003 (plain HTML/JS, no build)
+**Depends on:** #200 (the builder shell — merged into `updated-profiles`)
+
+---
+
+## 1. Overview
+
+B2 makes the Amplification Stage's Sub-stages interactive. B1 (#200) shipped two static Sub-stage rows; this issue lets the operator switch between a two-step and three-step amplification by adding/removing the third Sub-stage, with the name transitions the domain requires, bounded to 2–3 Sub-stages. The Amplification cycle count (the `#stage-amp-cycles` field shipped in B1) and the now-dynamic Sub-stage list both feed the posted `stages.amplification` object.
+
+It deliberately does **not** validate field ranges or enforce the extension-bearing Sub-stage's 11 s minimum (B3 / A2), assemble `steps` or place the optics split (A1), or repopulate from a saved Profile on edit (later issue).
+
+**Carry-over cleanups from the B1 PR review (#207), folded in because B2 edits these same files:**
+- Fix the misleading `_goto_builder` comment in `test_profile_builder.py` that claims the Stages are JS-rendered (they are static HTML; `builder.js` only wires behavior).
+- Bring tap targets to the spec's **≥44×44px** kiosk rule (§6): the new add/remove controls, and the existing B1 Stage enable checkbox whose 22px box + unpadded label currently misses it.
+
+Context: plain HTML/CSS/JS, no build step (ADR-003); Chromium kiosk on the 768×1024 Pi touch display (ADR-005).
+
+---
+
+## 2. Screen Inventory
+
+| Screen ID | Name | Entry condition | Exit conditions |
+|-----------|------|----------------|-----------------|
+| `builder` | Create Profile | Navigate to `/profiles/builder` | Save → Profiles list; Back/Cancel → Profiles list |
+
+No new screens — this extends the Amplification card on the existing builder.
+
+---
+
+## 3. State Machine Transitions
+
+Sub-stage count is a small local state machine inside the Amplification card:
+
+```
+[2 sub-stages] --[+ Add sub-stage tab]----> [3 sub-stages]
+[3 sub-stages] --[Extension row's X]-------> [2 sub-stages]
+```
+
+- At `[2]`: add tab visible, no `X` present. At `[3]`: add tab hidden, Extension row carries the `X`. Count never leaves {2, 3}.
+
+---
+
+## 4. Screen Designs
+
+### Amplification card (`#stage-amplification`)
+
+**Sub-stage names are display labels driven by the count, not editable inputs:**
+
+| Count | Sub-stage 0 | Sub-stage 1 | Sub-stage 2 |
+|-------|-------------|-------------|-------------|
+| 2 (two-step) | `Denaturation` | `Annealing & Extension` | — |
+| 3 (three-step) | `Denaturation` | `Annealing` | `Extension` |
+
+Each Sub-stage row keeps its B1 DOM shape: a name label `#stage-amp-sub-{i}-name` and temp/time inputs `#stage-amp-sub-{i}-temp` / `#stage-amp-sub-{i}-time` (`i` = 0,1,2).
+
+**Card layout (top → bottom):** Amplification header → the Sub-stage rows → the add-tab (when at two) → **Cycles** (`#stage-amp-cycles`) as the last field. Cycles sits at the bottom of the card, below the last Sub-stage.
+
+**Controls:**
+- Add: `#amp-add-substage` — a **full-width "+ Add sub-stage" tab** rendered below the Sub-stage rows. Visible **only at two Sub-stages**; hidden once a third exists.
+- Remove: `#amp-remove-substage` — an **`X` button on the right of the Extension row's header**. It exists **only while the third Sub-stage exists** (created with that row), not a persistent control.
+
+**Interactions:**
+- **Add (count 2 → 3):** rename Sub-stage 1's label `Annealing & Extension` → `Annealing`; append a third row `#stage-amp-sub-2-*` named `Extension` (blank temp/time) carrying its `X` remove button; **hide the add tab**.
+- **Remove via the Extension row's `X` (count 3 → 2):** delete the third row; rename Sub-stage 1's label back to `Annealing & Extension`; **show the add tab** again.
+- A fresh builder opens at count 2 (two-step) with the add tab visible and no `X`, matching B1.
+
+**Touch targets:** the add tab and the Stage enable checkbox (B1, via its `.stage__toggle` label) guarantee a ≥44×44px hit area. The Extension row's `X` is a deliberate exception — kept compact (red, no 44px minimum) so the Extension header is the same height as a plain Sub-stage name and the spacing between Sub-stages stays uniform; it trades the touch minimum for visual rhythm on this one rarely-used control.
+
+**Error states:** none in B2 (validation is B3). The 2–3 bound is enforced structurally by the disabled controls, not by an error message.
+
+---
+
+## 5. Data Binding
+
+### Save payload — `stages.amplification`
+
+The amplification object in the POST body becomes **dynamic** over the rendered Sub-stage rows (B1 hardcoded exactly two):
+
+```json
+"amplification": {
+  "cycles": <number|null>,
+  "subStages": [
+    { "name": "<row 0 label>", "temp": <number|null>, "time": <number|null> },
+    { "name": "<row 1 label>", "temp": <number|null>, "time": <number|null> }
+    // ...plus row 2 when present (three-step)
+  ]
+}
+```
+
+Binding rules:
+- `subStages` is built by iterating the rendered `.amp-substage` rows in DOM order — length 2 or 3 — reading each row's name label and its temp/time inputs. Names reflect the current two-/three-step state.
+- `cycles` = `#stage-amp-cycles` (blank ⇒ `null`, else `Number`). No validation in B2 (B3).
+- All other payload fields (`name`, `fam_label`, `rox_label`, `estimated_minutes`, and the other three Stages) are unchanged from B1.
+
+---
+
+## 6. Accessibility / Kiosk Constraints
+
+- All interactive controls ≥ 44×44px (frontend spec §6; 768×1024 Pi kiosk). This is a hard criterion B2 must satisfy for its add/remove controls **and** retroactively for the B1 Stage checkbox.
+- No hover-only affordances; disabled controls visibly non-interactive.
+
+---
+
+## 7. Assets
+
+| Asset | Path | Notes |
+|-------|------|-------|
+| Builder markup | `aquila_web/static/profiles/builder.html` | Add the add/remove controls; the third Sub-stage row is created in JS on demand. |
+| Builder script | `aquila_web/static/profiles/builder.js` | Sub-stage add/remove + rename + bound enforcement; dynamic `subStages` in `buildPayload`. |
+| Styles | `aquila_web/static/styles.css` | Add/remove control sizing; checkbox ≥44px hit area. |
+
+---
+
+## 8. Acceptance Criteria
+
+- [ ] Amplification starts with exactly two Sub-stages named `Denaturation` and `Annealing & Extension`.
+- [ ] The full-width add tab shows at two Sub-stages; adding a third renames Sub-stage 1 to `Annealing`, appends a blank `Extension` row, and hides the add tab.
+- [ ] The Extension row carries an `X` (right of its header); clicking it removes the third Sub-stage, reverts Sub-stage 1's name to `Annealing & Extension`, and brings the add tab back.
+- [ ] Count is bounded to {2, 3}: no `X` at two, no add tab at three.
+- [ ] Cycles is the last field in the Amplification card (below the Sub-stages).
+- [ ] The posted `stages.amplification` reflects the current Sub-stages (2 or 3, with correct names) and `cycles`.
+- [ ] The add tab and the B1 Stage enable checkbox meet the ≥44×44px touch-target rule (the Extension `X` is intentionally exempt, kept compact for uniform spacing).
+- [ ] The Extension `X` is red and small enough that the gap between Sub-stages 2 and 3 matches the gap between 1 and 2.
+- [ ] `_goto_builder`'s comment in `test_profile_builder.py` no longer claims the Stages are JS-rendered.
+- [ ] e2e in `tests/e2e/test_profile_builder.py` covers add/remove + the rename transitions and the 2–3 bound; existing B1 tests still pass.
+
+---
+
+## Out of Scope (other issues, other specs)
+
+- Field validation, "Invalid Value" highlighting, the extension-bearing Sub-stage's 11 s minimum, save-blocking — B3 (#203) / A2 (#199).
+- Assembling `stages → steps` and placing the optics split inside the extension Sub-stage — A1 (#198).
+- Repopulating the builder (including 3-Sub-stage state) from a saved Profile on edit, and Profiles-list routing — B3 (#203).
+- Making Sub-stage names free-text editable — they remain count-driven labels.
+
+---
+
+## 9. Open Questions
+
+- [ ] None — Sub-stage transitions and the 2–3 bound are fixed by PRD user stories 13–18 and ADR-018.

--- a/specs/frontend/spec_legacy_readonly_view.md
+++ b/specs/frontend/spec_legacy_readonly_view.md
@@ -1,0 +1,107 @@
+# Frontend / UI Spec: Legacy Read-only View — lock, summary header, aligned layout, no flash (issue #211)
+
+**Status:** Active
+**Author:** Aquila Engineering Team
+**Last updated:** 2026-06-26
+**GitHub issue:** #211 (Structured Profiles B4)
+**Affected screens:** Legacy Profile read-only view (`/profiles/edit-form?id=<id>&view=1`)
+**Source file(s):** `aquila_web/static/profiles/edit_form.html`, `aquila_web/static/profiles/edit.js`, `aquila_web/static/styles.css`, `tests/e2e/`
+**Umbrella PRD:** `specs/prd/structured-profile-editor-prd.md` · **Decision:** ADR-018
+**Depends on:** #203 (B3 routes Legacy Profiles to `?view=1` and made `edit.js` honour read-only) — merged.
+
+---
+
+## 1. Overview
+
+B3 routes Legacy Profiles to the existing viewer (`edit_form.html` / `edit.js`) via `?view=1` and made the param actually open read-only. B4 makes that viewer **truly read-only and presentable**, in four parts:
+
+1. **Lock it** — no "Edit View" toggle in read-only mode, so a Legacy Profile has no in-app path back to editing.
+2. **Summary header** — name, FAM/ROX labels, and estimated minutes (when set) at the top of the read view.
+3. **Aligned step layout** — fix the field-count-driven zig-zag so steps line up.
+4. **No flash** — the read-only view renders from first paint; the editable editor never flashes.
+
+Out of scope: any change to the structured builder; re-deriving Legacy `steps`; the integration convergence (C / #204, which has been told about these changes).
+
+Context: plain HTML/CSS/JS, no build step (ADR-003); 768×1024 Pi kiosk (ADR-005). The viewer is reached only from the Profiles list's Legacy "View" affordance (B3).
+
+---
+
+## 2. Screen Inventory
+
+| Screen ID | Name | Entry condition | Exit conditions |
+|-----------|------|----------------|-----------------|
+| `legacy-view` | Profile Details (read-only) | `/profiles/edit-form?id=<id>&view=1` (Legacy row "View") | Back ‹ → Profiles list |
+| `legacy-edit` | Edit Run Profile (unchanged) | `/profiles/edit-form?id=<id>` (no `view` param) | Save / Cancel |
+
+`?view=1` ⇒ `legacy-view` (locked); no param ⇒ `legacy-edit` (editable, toggle present — unchanged).
+
+---
+
+## 3. Behaviour
+
+### 3.1 Lock the read-only view (no escape hatch)
+
+- In read-only mode the **"Edit View" toggle (`#toggle-read-view`) is not shown** — there is no control to flip a Legacy Profile into the editable legacy editor.
+- The toggle remains present and functional in normal edit-mode entry (no `view` param).
+
+### 3.2 Summary header
+
+At the top of the Profile Summary (read view), above the per-stage step list, render a header block showing:
+- **Profile name**
+- **FAM** label and **ROX** label (the values entered on the Profile)
+- **Estimated time (minutes)** — shown **only when an estimate is set**; the row is omitted entirely when there is no estimate.
+
+Values come from the already-loaded Profile (the same data `edit.js` populates into the form fields). The estimate is present iff `estimated_completion_seconds` is a positive number (→ minutes).
+
+### 3.3 Aligned step layout
+
+The summary step rows currently use `grid-template-columns: repeat(auto-fit, minmax(120px, 1fr))`, so a row's column count tracks its field count (setpoint ≈ 5 fields, ramp/enable ≈ 3–4) and the columns don't line up across rows — the zig-zag. Replace with a **fixed column grid** (every step row uses the same column tracks regardless of how many fields it has), so labels/values align top-to-bottom. Rows with fewer fields simply leave trailing tracks empty.
+
+### 3.4 No flash of the editable view
+
+Today `edit_form.html` paints the editable form first; `edit.js` then runs `applyViewMode()` and hides the edit sections — a brief flash of the editor. The read-only state must be applied **before first paint**:
+- A tiny synchronous script (in `<head>`/top of `<body>`) reads the `view`/`mode` param and adds a `view-only` class to `<html>` before the body renders.
+- CSS keyed on `html.view-only` immediately hides the editable sections (`.profile-edit`) and the toggle, and reveals `#profile-summary` — so the editor never paints.
+- `edit.js`'s existing `applyViewMode()` still runs (it populates the summary and disables inputs); the pre-paint CSS only removes the visual flash. The two must agree (same end state).
+
+---
+
+## 4. Data Binding
+
+| UI element | Source | Trigger |
+|------------|--------|---------|
+| Summary header: name / FAM / ROX | loaded Profile (`title`, `labels.fam`, `labels.rox`) | On read-view render |
+| Summary header: est. minutes (if set) | `estimated_completion_seconds` → minutes | On read-view render; omitted when unset |
+| Editable vs read-only at first paint | `?view=1` / `?mode=view` → `html.view-only` | Synchronously before paint |
+
+---
+
+## 5. Accessibility / Kiosk Constraints
+
+- Read view is for inspection only — no editable affordances, no toggle.
+- Summary remains legible on the 768×1024 kiosk; aligned columns improve scanability.
+
+---
+
+## 6. Acceptance Criteria
+
+- [ ] Entering a Legacy Profile (`?view=1`) shows **no "Edit View" toggle**; no in-app path from read view to editing.
+- [ ] The read view shows **name + FAM + ROX** at the top of the summary; the **estimated-minutes row appears only when an estimate is set** and is absent otherwise.
+- [ ] Step rows are **column-aligned** (no zig-zag) whether a row has 2 or 5 fields.
+- [ ] Clicking **View** lands directly on the read-only view with **no momentary flash** of the editable editor (read-only applied before first paint).
+- [ ] Normal (non-`view`) edit entry is **unchanged** — toggle present, sections editable.
+- [ ] e2e tests in `tests/e2e/` for the locked view, the summary header (estimate present/absent), the aligned layout, and the no-flash behaviour.
+
+---
+
+## 7. Out of Scope (other issues)
+
+- Structured builder, validation, round-trip, list routing — B1–B3 (#200/#202/#203), merged.
+- Integration convergence and PR to `main` — C (#204), updated to expect this viewer's new behaviour.
+- Re-authoring the legacy step editor itself (edit mode) — only the read-only presentation changes here.
+
+---
+
+## 8. Open Questions
+
+- [ ] None — scope and decisions resolved in #211 and ADR-018.

--- a/specs/frontend/spec_structured_builder_shell.md
+++ b/specs/frontend/spec_structured_builder_shell.md
@@ -1,0 +1,166 @@
+# Frontend / UI Spec: Structured Builder Shell — Stages, Checkboxes, Save (issue #200)
+
+**Status:** Active
+**Author:** Aquila Engineering Team
+**Last updated:** 2026-06-25
+**GitHub issue:** #200 (Structured Profiles B1)
+**Affected screens:** Create Profile (`/profiles/builder`)
+**Source file(s):** `aquila_web/static/profiles/builder.html`, `aquila_web/static/profiles/builder.js` (new), `aquila_web/static/styles.css`
+**Umbrella PRD:** `specs/prd/structured-profile-editor-prd.md` · **Decisions:** ADR-018, ADR-003 (plain HTML/JS, no build)
+**Depends on:** #197 (the `stages` contract + `/profiles/builder` route — merged)
+
+---
+
+## 1. Overview
+
+The structured profile builder's first vertical slice: render the fixed top fields and the four domain Stages into the editor shell (`#profile-builder-root`, served by `/profiles/builder` from #197), let the operator toggle the three optional Stages with checkboxes, and POST a `stages` payload that redirects to the Profiles list.
+
+This is the **shell only**. It deliberately does **not** validate fields, display "Invalid Value" errors, drive Amplification Sub-stage add/remove, or repopulate from an existing Profile — those are B3 (#202), B2 (#201/#199 area), and the edit/list-routing issues. The backend stores `stages` verbatim (#197); assembly into `steps` and `POST` validation are A1/A2/A3 and are not exercised here.
+
+Context: plain HTML/CSS/JS, no build step (ADR-003); Chromium kiosk on the Pi display, 768×1024 touch viewport (ADR-005).
+
+---
+
+## 2. Screen Inventory
+
+| Screen ID | Name | Entry condition | Exit conditions |
+|-----------|------|----------------|-----------------|
+| `builder` | Create Profile | Navigate to `/profiles/builder` (from Profiles list "Create" — wired later) | Save success → Profiles list; Back/Cancel → Profiles list |
+
+---
+
+## 3. State Machine Transitions
+
+```
+profiles-page --[Create]--> builder
+builder       --[Save success (POST /profiles 200)]--> profiles-page
+builder       --[Back ‹ / Cancel]--> profiles-page
+```
+
+No in-page screen states in B1 (validation error state is B3).
+
+---
+
+## 4. Screen Designs
+
+### Screen: `builder`
+
+Renders inside the existing shell's `<div class="profile-form" id="profile-builder-root">`. Reuses the existing form CSS vocabulary (`card`, `field-grid`, `field`, `form-action-btn`, `button-row`, `is-hidden`).
+
+**Layout (top → bottom):**
+
+1. **Details card** (`#builder-details`) — fixed top fields, mirroring `edit_form.html`:
+   - Profile name — `#profile-name` (text).
+   - FAM Label — `#profile-fam-label` (text, pre-filled `"FAM"`). ROX Label — `#profile-rox-label` (text, pre-filled `"ROX"`). *(Mirrors `edit_form.html`'s defaults — decided over a fully-blank form so a quick save still carries sensible channel labels. The "every field blank" rule in #200 applies to the thermal value fields below.)*
+   - Est. Time (Min) — `#profile-estimated-minutes` (number, `min="1"`, `placeholder="(Optional)"`). Retains the existing estimated-minutes behavior (blank ⇒ `null`).
+
+2. **Four Stage cards**, in order. Each optional Stage is a `card stage` with an enable checkbox in its header; Amplification has no checkbox.
+
+   | Stage | DOM id | Checkbox | Fields (all blank on fresh form) |
+   |-------|--------|----------|----------------------------------|
+   | Incubation | `#stage-incubation` | `#stage-incubation-enabled` (checked) | temp `#stage-incubation-temp`, time `#stage-incubation-time` |
+   | Initial Denaturation | `#stage-denaturation` | `#stage-denaturation-enabled` (checked) | temp `#stage-denaturation-temp`, time `#stage-denaturation-time` |
+   | Amplification | `#stage-amplification` | *(none — always present)* | cycles `#stage-amp-cycles`; 2 fixed Sub-stage rows (see below) |
+   | Final Temp Hold | `#stage-finalhold` | `#stage-finalhold-enabled` (checked) | temp `#stage-finalhold-temp`, time `#stage-finalhold-time` |
+
+   Temp/time/cycles inputs are `type="number"` `inputmode="numeric"`. Temp inputs carry the existing `keyboard-ignore`-style touch conventions as used elsewhere on the form (match `edit_form.html`).
+
+   **Amplification Sub-stages (B1 = static).** Two rows are rendered with fixed name **labels** "Denaturation" and "Annealing & Extension", each with a temp and a time input (`#stage-amp-sub-0-temp/-time`, `#stage-amp-sub-1-temp/-time`), blank on a fresh form. **No add/remove controls and no rename transitions in B1** (that is B2). Sub-stage names are display labels, not editable inputs.
+
+3. **Action row** (`button-row`): Save (`#save-profile-button`, primary) and Cancel (`<a href="/profiles-page">`). A `#save-status` line mirrors `edit_form.html`.
+
+**Fresh-form initial state:**
+- All three optional Stage checkboxes **checked (ON)**.
+- Name and estimate blank; FAM/ROX pre-filled `"FAM"`/`"ROX"`; all temps, all times, **and cycles** blank.
+- No error styling anywhere (no `field-error` shown; no red borders).
+
+**User interactions:**
+- Toggle a Stage checkbox OFF → the Stage card greys out (`.stage--disabled`) and **all its inputs get `disabled`**. The typed values are **kept in the DOM** (not cleared).
+- Toggle it back ON → card un-greys, inputs re-enabled, previously typed values intact.
+- Tap Save → build the `stages` payload (§5), `POST /profiles`, and on `200` redirect to `/profiles-page`.
+
+**Error states (B1):** none rendered. A non-200 from `POST /profiles` sets `#save-status` to the response `detail` (or "Failed to save") and does **not** navigate — same failure handling as `edit.js`. Field-level "Invalid Value" highlighting is B3.
+
+---
+
+## 5. Data Binding
+
+### Save payload — `POST /profiles`
+
+Body (no `steps` — backend assembles those in A1/A3):
+
+```json
+{
+  "name": "<#profile-name>",
+  "fam_label": "<#profile-fam-label>",
+  "rox_label": "<#profile-rox-label>",
+  "estimated_minutes": <int|null>,
+  "stages": {
+    "incubation":   { "enabled": <bool>, "temp": <number|null>, "time": <number|null> },
+    "denaturation": { "enabled": <bool>, "temp": <number|null>, "time": <number|null> },
+    "amplification": {
+      "cycles": <number|null>,
+      "subStages": [
+        { "name": "Denaturation",          "temp": <number|null>, "time": <number|null> },
+        { "name": "Annealing & Extension", "temp": <number|null>, "time": <number|null> }
+      ]
+    },
+    "finalHold":    { "enabled": <bool>, "temp": <number|null>, "time": <number|null> }
+  }
+}
+```
+
+Binding rules:
+- `enabled` = the Stage checkbox's `checked` state. **All four stage keys are always present**; an unchecked Stage is sent with `enabled: false` (its preserved temp/time still ride along).
+- Numeric fields: read `input.value`; an empty string ⇒ `null`, otherwise `Number(value)`. **No range/NaN validation in B1** (B3). The happy-path save uses in-range numeric values.
+- `estimated_minutes`: reuse the existing rule — blank ⇒ `null`, else a positive integer (`Math.round(Number(...))`).
+- `amplification.subStages` is always length 2 in B1 with the fixed names above.
+
+### Redirect
+On `response.ok`, `window.location.href = "/profiles-page"` (matches `edit.js`).
+
+---
+
+## 6. Accessibility / Kiosk Constraints
+
+- Touch targets ≥ 44×44px; checkboxes sized for touch.
+- No hover-only affordances.
+- Disabled-Stage state must be visually obvious (greyed) and the inputs non-interactive (`disabled`), readable at arm's length on the 768×1024 display.
+
+---
+
+## 7. Assets
+
+| Asset | Path | Notes |
+|-------|------|-------|
+| Builder shell | `aquila_web/static/profiles/builder.html` | Exists (#197); B1 fills `#profile-builder-root` and adds the `builder.js` script tag. |
+| Builder script | `aquila_web/static/profiles/builder.js` | New. |
+| Stage-disabled styling | `aquila_web/static/styles.css` | New `.stage--disabled` rule (grey + dim). |
+
+---
+
+## 8. Acceptance Criteria
+
+- [ ] `GET /profiles/builder` renders the four Stage cards and the top fields into `#profile-builder-root`.
+- [ ] Fresh form: all three optional Stages checked ON, thermal value fields (temps/times/cycles) blank, FAM/ROX pre-filled, no error styling shown.
+- [ ] Unchecking a Stage greys it and disables its inputs; re-checking restores the previously typed values.
+- [ ] An unchecked Stage is sent as `enabled: false` in the `stages` payload; all four stage keys always present.
+- [ ] A valid Save POSTs the `stages` shape in §5 and redirects to `/profiles-page`.
+- [ ] Plain HTML/CSS/JS, no build step (ADR-003); no change to `aquila_web/main.py`.
+- [ ] e2e test `tests/e2e/test_profile_builder.py` (marked `e2e`) covers: default state, toggle/preserve, happy-path save. Prior art: `test_countdown_timer.py`, `test_run_dropdowns.py`.
+
+---
+
+## Out of Scope (other issues, other specs)
+
+- Field validation, "Invalid Value" red highlighting, save-blocking — B3 (#202).
+- Amplification Sub-stage add/remove, the 2↔3 rename transitions, and the 2–3 bound — B2.
+- Repopulating the builder from an existing structured Profile on edit — later frontend issue.
+- Profiles-list routing by the `structured` flag and the Legacy read-only view — later frontend issue.
+- Backend `stages → steps` assembly and `POST` validation — A1 (#198) / A2 (#199) / A3 (#201).
+
+---
+
+## 9. Open Questions
+
+- [ ] None — contract and scope resolved in ADR-018 and the PRD.

--- a/specs/frontend/spec_validation_roundtrip_routing.md
+++ b/specs/frontend/spec_validation_roundtrip_routing.md
@@ -1,0 +1,140 @@
+# Frontend / UI Spec: Validation UX + Edit Round-trip + List Routing (issue #203)
+
+**Status:** Active
+**Author:** Aquila Engineering Team
+**Last updated:** 2026-06-26
+**GitHub issue:** #203 (Structured Profiles B3)
+**Affected screens:** Create/Edit Profile (`/profiles/builder`), Profiles list (`/profiles-page`)
+**Source file(s):** `aquila_web/static/profiles/builder.html`, `aquila_web/static/profiles/builder.js`, `aquila_web/static/profiles/profiles.js`, `aquila_web/static/profiles/index.html`, `aquila_web/static/styles.css`, `tests/e2e/test_profile_builder.py`
+**Umbrella PRD:** `specs/prd/structured-profile-editor-prd.md` · **Decision:** ADR-018, ADR-003 (plain HTML/JS, no build)
+**Depends on:** #200 (builder shell), #202 (Sub-stages), #201 (A3 — endpoints now validate, assemble `steps`, and return the `structured` flag) — all merged into `updated-profiles`.
+
+---
+
+## 1. Overview
+
+B3 is the final frontend slice: it makes the structured builder **trustworthy** (can't save an invalid program), **complete** (can edit existing profiles, not just create), and **wired into the app** (the Profiles list and the New button send each profile to the right editor). It builds against the real merged backend (A3), not a stub.
+
+Three capabilities:
+1. **Validation on save** — client-side, mirroring the server's `validate_stages` ranges so a client-valid form never trips the server 400 (which remains the safety net).
+2. **Edit round-trip** — opening a structured Profile repopulates every Stage/Sub-stage/value from its `stages` object; saving updates that profile in place.
+3. **List routing** — structured Profiles → the builder; Legacy → the existing read-only view; bundled stay read-only. "New profile" → the builder.
+
+Out of scope: changing the assembled `steps`, ranges, or any backend logic (A-side, done); the Legacy editor's internals.
+
+Context: plain HTML/CSS/JS, no build step (ADR-003); 768×1024 Pi kiosk (ADR-005).
+
+---
+
+## 2. Screen Inventory
+
+| Screen ID | Name | Entry condition | Exit conditions |
+|-----------|------|----------------|-----------------|
+| `builder-new` | Create Profile | `/profiles/builder` (from "New profile") | Valid Save → list; Cancel → list |
+| `builder-edit` | Edit Profile | `/profiles/builder?id=<id>` (from a structured row's "Edit") | Valid Save → list; Cancel → list |
+| `legacy-view` | View Profile (read-only) | `/profiles/edit-form?id=<id>&view=1` (from a Legacy row's "View") | Back → list |
+
+---
+
+## 3. State Machine Transitions
+
+```
+profiles-page --[New profile]----------------> builder-new
+profiles-page --[structured row · Edit]-------> builder-edit
+profiles-page --[legacy row · View]-----------> legacy-view (read-only)
+builder-* --[Save · all enabled fields valid]-> profiles-page
+builder-* --[Save · any invalid]--------------> builder-* (errors shown, no navigation)
+```
+
+---
+
+## 4. Screen Designs
+
+### 4.1 Validation on save (`builder-*`)
+
+Each validatable numeric field (Stage temp/time, each Sub-stage temp/time, cycles) gets an adjacent error element `<p class="field-error is-hidden">Invalid Value</p>` and, when invalid, the input gets an `is-invalid` red-border class.
+
+**Trigger:** validation runs **only on Save attempt** — never on initial load, so a pristine blank form shows no errors (PRD story 28).
+
+**On Save:**
+- Validate every field in **enabled** Stages plus Amplification (always enabled). **Disabled (unchecked) Stages are skipped entirely** — their blanks never block save.
+- A field is invalid if blank, non-numeric, or out of range. Ranges (mirroring `validate_stages`):
+  - temp: **25–100** °C
+  - time: **1–600** s
+  - **last (extension-bearing) Sub-stage** time: **11–600** s — the last Sub-stage row, i.e. "Annealing & Extension" (2-step) or "Extension" (3-step)
+  - cycles: integer **1–50**
+- **All** offending fields flag at once (red border + "Invalid Value"); the first invalid field scrolls into view.
+- If anything is invalid: **do not POST, do not navigate**.
+- If all valid: clear any error styling and POST as today (B1/B2). The server still re-validates; a 400 `{detail:{errors:[…]}}` surfaces in `#save-status` (defense in depth — should not normally happen given client parity).
+
+**Est. Time (Min):** the optional estimate field is validated on save exactly like the legacy editor (`edit.js`) — blank is fine; a value must be a positive integer, else the field flags `is-invalid` with its "Invalid Estimated Time" message (`#profile-estimated-error`) and blocks the save.
+
+### 4.2 Edit round-trip (`builder-edit`)
+
+On load, if the URL carries `?id=<id>` (or `?profile=`):
+- `GET /profiles/details?id=<id>`; read the returned `stages` object.
+- Repopulate: `#profile-name` (title), FAM/ROX labels, estimated minutes; each optional Stage's checkbox (`enabled`) + temp/time (triggering the B1 grey/disable sync); Amplification `cycles`; and the Sub-stages — **including adding the third row** when `subStages.length === 3` (reusing B2's add path so names/X/controls are correct), then filling each temp/time.
+- Title affordance: the header reads "Edit Profile" in edit mode (vs "Create Profile" for new).
+- **Save updates in place:** the payload includes `profile_id: <id>` so the backend overwrites the existing profile rather than creating a copy. (`save_profile` already keys off `profile_id`.)
+- A profile with no `stages` should not normally reach here (the list routes Legacy → the read-only view); if `?id` resolves to one, fall back gracefully (leave the form at its blank defaults).
+
+### 4.3 List routing (`profiles.js`)
+
+Replace the single "Edit → `/profiles/edit-form`" affordance with per-row routing keyed on the `structured` and `bundled` flags from `GET /profiles`:
+
+| Row type | Flag | Affordance | Target |
+|----------|------|-----------|--------|
+| Structured | `structured === true`, not bundled | **Edit** | `/profiles/builder?id=<id>` |
+| Legacy | `structured` falsy, not bundled | **View** | `/profiles/edit-form?id=<id>&view=1` |
+| Bundled | `bundled === true` | read-only (unchanged — lock icon, no edit affordance) | — |
+
+"New profile" (`index.html`) → `/profiles/builder`.
+
+**`edit.js` read-only fix:** `?view=1` previously got reset back to editable whenever the "Edit View" toggle existed, so the legacy viewer opened editable. That reset is removed so `?view=1` honours read-only. (Fully locking the viewer + the summary header + aligned step layout are **B4 / #211**, deliberately deferred — this issue only guarantees Legacy *opens* read-only.)
+
+---
+
+## 5. Data Binding
+
+| UI element | Source | Trigger |
+|------------|--------|---------|
+| Builder fields (edit mode) | `GET /profiles/details?id=` → `stages`, title, labels, `estimated_completion_seconds` | On load when `?id` present |
+| Row Edit/View affordance | `GET /profiles` → `structured`, `bundled` | On list render |
+| Save (create) | `POST /profiles` `{name, fam_label, rox_label, estimated_minutes, stages}` | Save, all valid |
+| Save (edit) | as above **plus** `profile_id` | Save, all valid, `?id` present |
+
+Client validation ranges must equal `aquila_web/profile_assembly.py::validate_stages`. If those constants change server-side, the client values here must change too (documented coupling).
+
+---
+
+## 6. Accessibility / Kiosk Constraints
+
+- Error state must be unmistakable on the kiosk: red border **and** the "Invalid Value" text (not colour alone).
+- No new tap targets below 44px; existing controls unchanged.
+
+---
+
+## 7. Acceptance Criteria
+
+- [ ] Save with blanks/invalid flags **every** offending enabled field red with "Invalid Value" and does **not** navigate.
+- [ ] A pristine blank form shows no errors until a Save is attempted.
+- [ ] Disabled Stages never block save (their blank/invalid fields are skipped).
+- [ ] The last Sub-stage enforces the 11 s minimum; other times enforce 1 s.
+- [ ] Opening a structured Profile (`?id`) repopulates all Stages, Sub-stages (incl. a 3rd when present), and values from `stages`; Save updates it in place (`profile_id`).
+- [ ] Profiles list routes structured → builder (Edit), Legacy → read-only view (View); bundled stay read-only.
+- [ ] "New profile" opens the builder.
+- [ ] e2e tests in `tests/e2e/` for validation display, round-trip repopulation, and list routing; existing B1/B2 tests still pass.
+
+---
+
+## 8. Out of Scope (other issues)
+
+- Backend assembly/validation/ranges and the `structured` flag — A1/A2/A3 (#198/#199/#201), merged.
+- The integration issue's real-backend convergence checklist — C (#204).
+- Re-authoring the Legacy read-only viewer — it is reused as-is via `?view=1`.
+
+---
+
+## 9. Open Questions
+
+- [ ] None — backend contract is merged (A3) and routing/validation decisions are resolved in ADR-018 and the PRD.

--- a/specs/prd/structured-profile-editor-prd.md
+++ b/specs/prd/structured-profile-editor-prd.md
@@ -40,7 +40,7 @@ Replace the generic builder — for new and structured Profiles — with a guide
 24. As an operator, I want a time outside 1–600 s to be rejected with an "Invalid Value" error highlighted in red, so that I can't save an out-of-range duration.
 25. As an operator, I want the extension-bearing Sub-stage to require at least 11 s, so that the automatic optics split is always valid.
 26. As an operator, I want a non-numeric entry in any field to be rejected with an "Invalid Value" error, so that garbage values never reach a run.
-27. As an operator, I want a cycle count outside 1–99 to be rejected with an "Invalid Value" error, so that the cycle count stays valid.
+27. As an operator, I want a cycle count outside 1–50 to be rejected with an "Invalid Value" error, so that the cycle count stays valid.
 28. As an operator, I want validation errors to appear only when I try to save (not while the form is still blank on first load), so that a fresh form doesn't look broken.
 29. As an operator, I want every offending field flagged red simultaneously on a failed save, so that I can see all the problems at once.
 30. As an operator, I want save blocked until every enabled field is valid, so that I can't persist an invalid Profile.
@@ -87,7 +87,7 @@ stages: {
 - Unchecked Stages emit no steps.
 - Top-level keys preserved: `output_dir` ("pcr_data"), `post_in_gui` ("True"), `title`, `labels` {fam, rox}.
 
-**Backend validation.** A pure validation function re-checks the submitted `stages`: temp 25–100 °C; time 1–600 s; extension-bearing Sub-stage time 11–600 s; cycles integer 1–99; Sub-stage count 2 or 3. Disabled Stages are skipped. Invalid input returns an error response (existing 4xx convention on `POST /profiles`), not a written file.
+**Backend validation.** A pure validation function re-checks the submitted `stages`: temp 25–100 °C; time 1–600 s; extension-bearing Sub-stage time 11–600 s; cycles integer 1–50; Sub-stage count 2 or 3. Disabled Stages are skipped. Invalid input returns an error response (existing 4xx convention on `POST /profiles`), not a written file.
 
 **List & detail endpoints.** `GET /profiles` returns a `structured` boolean per Profile (true iff its JSON has `stages`) so the list can route rows. `GET /profiles/details` returns the `stages` object when present so the editor can repopulate.
 
@@ -103,7 +103,7 @@ stages: {
 
 Good tests assert external behavior at the highest available seam — the shape of the written Profile JSON, the HTTP response, and observable DOM behavior — not internal function structure. Three seams, matching the split:
 
-**Seam 1 — Backend assembly (unit).** New `unit_tests/test_profile_assembly.py` exercising the pure `stages → steps` assembly and the validation function directly: head/tail constants and ordering; mid ramp 1.75 before the `repeat`; optics split `(time−10) / 10` on the correct Sub-stage for both 2- and 3-Sub-stage cases; unchecked Stages omitted; Sub-stage names in descriptions; cycles wrapping; Final Temp Hold placement; every validation boundary (25/100 °C, 1/600 s, extension 11 s, cycles 1/99, Sub-stage count). Prior art: `unit_tests/test_estimated_completion.py` (stubs hardware deps, imports `aquila_web.main`, marked `unit`).
+**Seam 1 — Backend assembly (unit).** New `unit_tests/test_profile_assembly.py` exercising the pure `stages → steps` assembly and the validation function directly: head/tail constants and ordering; mid ramp 1.75 before the `repeat`; optics split `(time−10) / 10` on the correct Sub-stage for both 2- and 3-Sub-stage cases; unchecked Stages omitted; Sub-stage names in descriptions; cycles wrapping; Final Temp Hold placement; every validation boundary (25/100 °C, 1/600 s, extension 11 s, cycles 1/50, Sub-stage count). Prior art: `unit_tests/test_estimated_completion.py` (stubs hardware deps, imports `aquila_web.main`, marked `unit`).
 
 **Seam 2 — Backend HTTP contract (contract).** Extend `tests/contract/test_profile_endpoints.py` (FastAPI TestClient, marked `contract`): POST a `stages` payload → 200, written JSON has correct `steps` and a round-trippable `stages`; out-of-range / blank / wrong Sub-stage count → error, nothing written; `GET /profiles` returns `structured` true for a structured Profile and false for a legacy one; `GET /profiles/details` returns `stages` for a structured Profile and omits it for a legacy one. Prior art: existing `test_profile_endpoints.py`, `test_bundled_profiles.py`.
 

--- a/specs/prd/structured-profile-editor-prd.md
+++ b/specs/prd/structured-profile-editor-prd.md
@@ -1,0 +1,129 @@
+# PRD: Structured Profile Editor
+
+> Status: Ready for agent
+> Related: ADR-018 (Structured Profile Editor — Backend-Assembled Steps with `stages` as Source of Truth), ADR-003 (plain HTML/CSS/JS, no build step)
+> Glossary: `CONTEXT.md` — Stage, Sub-stage, Step, Boilerplate, Structured Profile, Legacy Profile
+
+## Problem Statement
+
+Operators creating a PCR Profile today face a fully generic step builder that exposes raw hardware steps (`setpoint`, `ramp_rate`, `enable`/`disable`, fan on/off) and forces them to hand-author the same fixed equilibration, fan, optics, and cooldown scaffolding on every Profile. This is error-prone (an operator can omit or misconfigure scaffolding that every valid assay needs) and presents the assay in hardware terms rather than the domain terms a scientist thinks in (Incubation, Denaturation, Amplification, Final Hold). There is no guardrail against out-of-range temperatures or durations.
+
+## Solution
+
+Replace the generic builder — for new and structured Profiles — with a guided editor that presents only the four domain Stages the operator actually controls (Incubation, Initial Denaturation, Amplification, Final Temp Hold) plus the Amplification cycle count. Each optional Stage is toggled by a checkbox; Amplification is always present and supports 2–3 Sub-stages. All fixed scaffolding (Boilerplate) — equilibration, fan control, optics init, entry/exit ramps, the per-cycle optics read, and cooldown — is applied automatically by the backend and never shown to the operator. Field-level validation keeps temperatures and durations in the instrument's safe range. The operator's selections are saved as a `stages` object that is the editable source of truth; the backend regenerates the runnable `steps` from it on every save. Profiles created before this feature (Legacy Profiles) open read-only in the app and remain hand-editable on disk.
+
+## User Stories
+
+1. As an operator, I want to name a new Profile, so that I can identify it later in the Profiles list.
+2. As an operator, I want to set the FAM and ROX channel labels on a Profile, so that results are reported against my biological targets.
+3. As an operator, I want to optionally record an estimated completion time in minutes, so that the run screen can show a countdown.
+4. As an operator, I want a fresh Profile to open with all four Stages enabled but every field blank, so that I explicitly enter every value rather than trusting hidden defaults.
+5. As an operator, I want to enable or disable the Incubation Stage with a checkbox, so that I only include it when my assay needs it.
+6. As an operator, I want to enable or disable the Initial Denaturation Stage with a checkbox, so that I only include it when my assay needs it.
+7. As an operator, I want to enable or disable the Final Temp Hold Stage with a checkbox, so that I only include it when my assay needs it.
+8. As an operator, I want the Amplification Stage to always be present, so that every Profile produces an amplification program.
+9. As an operator, I want to set a temperature and time for each enabled Stage, so that I define the thermal program.
+10. As an operator, I want disabled (unchecked) Stages to grey out and become uneditable, so that I can clearly see which Stages are inactive.
+11. As an operator, I want the values in a Stage I just unchecked to be preserved, so that if I re-check it I get my original entries back instead of having to retype them.
+12. As an operator, I want an unchecked Stage to produce no entries in the saved Profile, so that disabled Stages have zero effect on the run.
+13. As an operator, I want the Amplification Stage to start with two Sub-stages (Denaturation and "Annealing & Extension"), so that I have the common two-step amplification by default.
+14. As an operator, I want to add a third Amplification Sub-stage, so that I can run a three-step amplification.
+15. As an operator, when I add a third Sub-stage, I want the second Sub-stage to be renamed from "Annealing & Extension" to "Annealing" and the new third to be named "Extension", so that the naming reflects a three-step program.
+16. As an operator, I want to remove the third Sub-stage, so that I can revert to a two-step amplification.
+17. As an operator, when I remove the third Sub-stage, I want the second Sub-stage's name reverted to "Annealing & Extension", so that the naming reflects a two-step program again.
+18. As an operator, I want to be prevented from having fewer than two or more than three Amplification Sub-stages, so that I can't build an invalid amplification.
+19. As an operator, I want to set a temperature and time for each Amplification Sub-stage, so that I define each step of the cycle.
+20. As an operator, I want to set the Amplification cycle count, so that the amplification repeats the right number of times.
+21. As an operator, I want the optics read to be taken automatically during the extension portion of each cycle, so that fluorescence is measured without my having to place a read step.
+22. As an operator, I want all the fixed instrument scaffolding (equilibration, fan, ramps, cooldown) handled automatically, so that I don't have to author it and can't get it wrong.
+23. As an operator, I want a temperature outside 25–100 °C to be rejected with an "Invalid Value" error highlighted in red, so that I can't save a Profile the instrument can't run.
+24. As an operator, I want a time outside 1–600 s to be rejected with an "Invalid Value" error highlighted in red, so that I can't save an out-of-range duration.
+25. As an operator, I want the extension-bearing Sub-stage to require at least 11 s, so that the automatic optics split is always valid.
+26. As an operator, I want a non-numeric entry in any field to be rejected with an "Invalid Value" error, so that garbage values never reach a run.
+27. As an operator, I want a cycle count outside 1–99 to be rejected with an "Invalid Value" error, so that the cycle count stays valid.
+28. As an operator, I want validation errors to appear only when I try to save (not while the form is still blank on first load), so that a fresh form doesn't look broken.
+29. As an operator, I want every offending field flagged red simultaneously on a failed save, so that I can see all the problems at once.
+30. As an operator, I want save blocked until every enabled field is valid, so that I can't persist an invalid Profile.
+31. As an operator, I want fields in disabled Stages to be skipped by validation, so that blanks in inactive Stages don't block my save.
+32. As an operator, I want to save my Profile and return to the Profiles list, so that I can run or manage it.
+33. As an operator, I want to re-open a Profile I created in the structured editor and see all my Stages, Sub-stages, and values restored, so that I can edit it.
+34. As an operator, I want my edits to a structured Profile to regenerate the run program correctly, so that the saved Profile reflects my changes.
+35. As an operator, I want Legacy Profiles (created before this feature) to open in a read-only view, so that I can inspect them without risking accidental edits.
+36. As an operator, I want bundled Profiles to remain read-only, so that shipped assays can't be altered in the app.
+37. As an operator, I want the Profiles list to take me to the structured editor for structured Profiles and the read-only view for Legacy Profiles, so that each Profile opens in the right place.
+38. As an operator, I want to start a run from any Profile regardless of how it was authored, so that older Profiles keep working.
+39. As a developer, I want to hand-edit a Legacy Profile's JSON file on disk, so that I can still maintain old Profiles outside the app.
+40. As a developer, I want adding a valid `stages` block to a Profile file to promote it to a Structured Profile, so that there's a manual upgrade path.
+41. As a developer, I want the backend to re-validate the submitted Stages, so that an out-of-range value can't bypass the form and reach disk.
+42. As a developer, I want the boilerplate assembly logic to live server-side in one place, so that it's unit-testable and not duplicated in the browser.
+
+## Implementation Decisions
+
+**Contract (shared, built first).** `ProfileSave` gains an optional `stages` field. The structured editor POSTs `{ name, fam_label, rox_label, estimated_minutes, stages }` (no `steps`). The `stages` object shape:
+
+```
+stages: {
+  incubation:    { enabled: bool, temp: number, time: number },   // seconds
+  denaturation:  { enabled: bool, temp: number, time: number },
+  amplification: {
+    cycles: number,
+    subStages: [ { name: string, temp: number, time: number }, ... ]  // length 2 or 3
+  },
+  finalHold:     { enabled: bool, temp: number, time: number }
+}
+```
+
+`amplification` has no `enabled` (always present). A committed sample fixture of this object is the contract artifact both routes build against.
+
+**Storage & tagging.** A Structured Profile's JSON carries the `stages` object (editable source of truth) plus the backend-generated `steps`. The presence of `stages` is the only marker that a Profile is structured — no separate version flag. `steps` is regenerated from `stages` on every save and is never reverse-parsed.
+
+**Backend step assembly.** A pure function expands `stages` into `steps`, in order:
+- Head (always): `disable`/1s ("Record equilibration without power.") → `ramp_rate` 1.6 → `pcr_fanon` 1 → `enable`/1s → `optics` → `setpoint` 25 °C/1s ("Presetting temperature").
+- Incubation (if enabled): one `setpoint` (temp/time, description "Incubation").
+- Initial Denaturation (if enabled): one `setpoint` (temp/time, description "Initial Denaturation").
+- Amplification (always): `ramp_rate` 1.75, then a `repeat` block over the Sub-stages with `cycles` = cycle count. Each Sub-stage is one `setpoint` (description = current Sub-stage name). The extension-bearing Sub-stage (the 2nd of two, or the 3rd of three) is split so the optics read fires inside it: `setpoint`(temp, time−10) → `optics` → `setpoint`(temp, 10).
+- Final Temp Hold (if enabled): one `setpoint` (temp/time, description "Final Temp Hold"), placed after Amplification and before the tail.
+- Tail (always): `ramp_rate` 1.6 → `setpoint` 40 °C/20s ("Initial cooling") → `setpoint` 25 °C/10s ("Restoring setpoint to RT") → `disable`/5s → `pcr_fanoff` 0.
+- Unchecked Stages emit no steps.
+- Top-level keys preserved: `output_dir` ("pcr_data"), `post_in_gui` ("True"), `title`, `labels` {fam, rox}.
+
+**Backend validation.** A pure validation function re-checks the submitted `stages`: temp 25–100 °C; time 1–600 s; extension-bearing Sub-stage time 11–600 s; cycles integer 1–99; Sub-stage count 2 or 3. Disabled Stages are skipped. Invalid input returns an error response (existing 4xx convention on `POST /profiles`), not a written file.
+
+**List & detail endpoints.** `GET /profiles` returns a `structured` boolean per Profile (true iff its JSON has `stages`) so the list can route rows. `GET /profiles/details` returns the `stages` object when present so the editor can repopulate.
+
+**Estimated time.** The manual optional "Est. Time (Min)" field and its existing `estimated_minutes` → `estimated_completion_seconds` / `time_unavailable` handling are retained unchanged. It is not auto-computed (true runtime depends on machine movement/heat-up and can't be derived from setpoints).
+
+**Frontend editor (new files).** A new structured editor (e.g. `profile_builder.html` + `profile_builder.js`) on a new route, served by a single backend route added in the shared upfront task. Plain HTML/CSS/JS, no build step (ADR-003). Responsibilities: render the four Stages with checkboxes; grey/disable unchecked Stages while preserving their values; Amplification Sub-stage add/remove with the rename transitions and the 2–3 bound; save-triggered validation that flags every blank/non-numeric/out-of-range enabled field red with "Invalid Value" and blocks save; POST the `stages` payload; repopulate from `stages` on edit.
+
+**List routing & legacy view (frontend).** The Profiles list routes a row by its `structured` flag: structured → the new editor; Legacy → the existing `edit_form.html` in its read-only `?view=1` mode (Legacy rows get a "View" affordance, not "Edit"). Bundled Profiles stay read-only as today.
+
+**Branching.** Integration branch `feature/structured-profiles` off `main`; `…-backend` and `…-frontend` branch off it and PR back into it; integration merges to `main` as one reviewed PR. The only `main.py` region both routes would touch — the route that serves the new editor HTML — is done in the shared upfront task so the two route branches stay disjoint.
+
+## Testing Decisions
+
+Good tests assert external behavior at the highest available seam — the shape of the written Profile JSON, the HTTP response, and observable DOM behavior — not internal function structure. Three seams, matching the split:
+
+**Seam 1 — Backend assembly (unit).** New `unit_tests/test_profile_assembly.py` exercising the pure `stages → steps` assembly and the validation function directly: head/tail constants and ordering; mid ramp 1.75 before the `repeat`; optics split `(time−10) / 10` on the correct Sub-stage for both 2- and 3-Sub-stage cases; unchecked Stages omitted; Sub-stage names in descriptions; cycles wrapping; Final Temp Hold placement; every validation boundary (25/100 °C, 1/600 s, extension 11 s, cycles 1/99, Sub-stage count). Prior art: `unit_tests/test_estimated_completion.py` (stubs hardware deps, imports `aquila_web.main`, marked `unit`).
+
+**Seam 2 — Backend HTTP contract (contract).** Extend `tests/contract/test_profile_endpoints.py` (FastAPI TestClient, marked `contract`): POST a `stages` payload → 200, written JSON has correct `steps` and a round-trippable `stages`; out-of-range / blank / wrong Sub-stage count → error, nothing written; `GET /profiles` returns `structured` true for a structured Profile and false for a legacy one; `GET /profiles/details` returns `stages` for a structured Profile and omits it for a legacy one. Prior art: existing `test_profile_endpoints.py`, `test_bundled_profiles.py`.
+
+**Seam 3 — Frontend builder (e2e).** New `tests/e2e/test_profile_builder.py` (Playwright, marked `e2e`): fresh form opens with all Stages on and fields blank, no errors shown; unchecking greys a Stage and preserves its values on re-check; adding/removing the third Sub-stage applies the rename transitions and enforces the 2–3 bound; Save with blanks/invalid flags the offending fields red with "Invalid Value" and does not navigate; a valid Save POSTs the expected `stages` payload and redirects to the Profiles list; a structured Profile re-opens repopulated; a Legacy Profile opens read-only. Prior art: `tests/e2e/test_countdown_timer.py`, `tests/e2e/test_run_dropdowns.py`.
+
+The full suite (`pytest tests unit_tests -v`) must pass, including existing profile/bundled tests, per CLAUDE.md.
+
+## Out of Scope
+
+- Reverse-parsing arbitrary Legacy `steps` into the structured model — Legacy Profiles are read-only in-app by design (ADR-018).
+- In-app editing of Legacy or bundled Profiles (hand-editing the JSON on disk remains the path).
+- Auto-computing estimated completion time.
+- Exposing ramp rates, fan control, optics placement, or equilibration/cooldown as operator-editable fields — these are fixed Boilerplate.
+- Per-Sub-stage configurable optics offset (the 10 s tail is a fixed constant).
+- Changes to the run flow, analytics, Sync, or the `run_complete` event payload.
+- Profile name uniqueness / filename-collision policy beyond the existing sanitization behavior.
+
+## Further Notes
+
+- The optics split tail (10 s) and ramp constants (head/tail 1.6, mid 1.75) and preset temp (25 °C) are hardcoded per ADR-018; changing them is a code + test change, not a Profile edit.
+- The `steps` array remains the only artifact the hardware runner and analytics read; `stages` is additive and ignored by the runner.
+- A hand-edit to a structured Profile's `steps` that isn't mirrored in `stages` will be overwritten on the next structured save — `stages` wins.
+- The 25 °C floor on Final Temp Hold (and all temps) matches the instrument's cooldown floor; sub-ambient holds are not supported.

--- a/tests/contract/test_profile_endpoints.py
+++ b/tests/contract/test_profile_endpoints.py
@@ -534,6 +534,27 @@ def test_nonfinite_in_disabled_stage_rejected_not_persisted(client):
 
 
 @pytest.mark.contract
+def test_edit_rename_keeps_structured_profile_in_local(client):
+    """Renaming a structured profile on edit keeps it under local/, not the
+    profiles root (concern #2 from the #218 review)."""
+    created = client.post("/profiles", json={
+        "name": "Rename Me", "fam_label": "FAM", "rox_label": "ROX", "stages": SAMPLE_STAGES,
+    }).json()["id"]
+    assert created.replace("\\", "/").startswith("local/")
+    resp = client.post("/profiles", json={
+        "name": "Renamed Profile", "profile_id": created,
+        "fam_label": "FAM", "rox_label": "ROX", "stages": SAMPLE_STAGES,
+    })
+    assert resp.status_code == 200, resp.text
+    new_id = resp.json()["id"]
+    try:
+        assert new_id.replace("\\", "/").startswith("local/"), f"renamed left local/: {new_id}"
+    finally:
+        _delete_profile(client, new_id)
+        _delete_profile(client, created)
+
+
+@pytest.mark.contract
 def test_structured_profile_keys_in_canonical_order(client):
     """A saved structured profile writes its top-level keys in canonical order:
     output_dir, post_in_gui, title, countdown fields, labels, stages, steps."""

--- a/tests/contract/test_profile_endpoints.py
+++ b/tests/contract/test_profile_endpoints.py
@@ -503,6 +503,37 @@ def test_list_profiles_includes_structured_flag(client):
 
 
 @pytest.mark.contract
+def test_nonfinite_in_disabled_stage_rejected_not_persisted(client):
+    """A non-finite value (NaN/Infinity) anywhere — even in a DISABLED stage that
+    validation skips — must be rejected with 400 and never written to disk.
+
+    Regression for the trust-boundary blocker: such a value used to pass
+    validation, persist as literal NaN/Infinity, and 500 every later read.
+    """
+    from aquila_web import main as web_main
+
+    bad = json.loads(json.dumps(SAMPLE_STAGES))  # deep copy
+    bad["incubation"] = {"enabled": False, "temp": "__NAN__", "time": "__INF__"}
+    # Build a raw body with literal NaN/Infinity tokens — a crafted client can send
+    # these (Starlette's json.loads accepts them); httpx's json= encoder cannot.
+    body = json.dumps({"name": "NonFinite Poison", "fam_label": "FAM",
+                       "rox_label": "ROX", "stages": bad})
+    body = body.replace('"__NAN__"', "NaN").replace('"__INF__"', "Infinity")
+    resp = client.post("/profiles", content=body,
+                       headers={"Content-Type": "application/json"})
+    try:
+        assert resp.status_code == 400, f"expected 400, got {resp.status_code}"
+        # nothing written: the poison profile must not appear in the listing
+        ids = [p["id"] for p in client.get("/profiles").json()]
+        assert not any("NonFinite_Poison" in i for i in ids)
+    finally:
+        # defensive: remove any poison file a failing (pre-fix) run may have written,
+        # since it would 500 every subsequent read of the listing/details
+        for p in (web_main.resolve_profile_dir() / "local").glob("NonFinite_Poison*.json"):
+            p.unlink(missing_ok=True)
+
+
+@pytest.mark.contract
 def test_structured_profile_keys_in_canonical_order(client):
     """A saved structured profile writes its top-level keys in canonical order:
     output_dir, post_in_gui, title, countdown fields, labels, stages, steps."""

--- a/tests/contract/test_profile_endpoints.py
+++ b/tests/contract/test_profile_endpoints.py
@@ -436,3 +436,62 @@ def test_sample_stages_fixture_matches_contract():
     assert 2 <= len(amp["subStages"]) <= 3
     for sub in amp["subStages"]:
         assert set(sub) == {"name", "temp", "time"}
+
+
+# ---------------------------------------------------------------------------
+# Structured profiles — endpoint wiring (issue #201 / A3)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.contract
+def test_post_structured_profile_assembles_steps(client):
+    """A valid stages payload is validated, assembled into steps, and persisted."""
+    resp = client.post("/profiles", json={"name": "A3 Assembled", "stages": SAMPLE_STAGES})
+    assert resp.status_code == 200, resp.text
+    pid = resp.json()["id"]
+    try:
+        data = client.get(f"/profiles/details?id={pid}").json()
+        steps = data["steps"]
+        # head, amplification repeat, and tail are all present
+        assert steps[0] == {"disable": 0, "duration": 1, "description": "Record equilibration without power."}
+        assert any("repeat" in s for s in steps)
+        assert steps[-1] == {"pcr_fanoff": 0}
+        # source of truth round-trips too
+        assert data["stages"] == SAMPLE_STAGES
+    finally:
+        _delete_profile(client, pid)
+
+
+@pytest.mark.contract
+def test_post_invalid_stages_returns_400(client):
+    """An out-of-range stages payload is rejected with 400 (validated before assembly)."""
+    bad = json.loads(json.dumps(SAMPLE_STAGES))  # deep copy
+    bad["incubation"]["temp"] = 200  # above the 100 C max
+    resp = client.post("/profiles", json={"name": "A3 Invalid Temp", "stages": bad})
+    assert resp.status_code == 400
+
+
+@pytest.mark.contract
+def test_post_malformed_stages_returns_400_not_500(client):
+    """Malformed structure (missing sub-stage name) is rejected cleanly, never a 500
+    (validate guards before assemble — the trust-boundary payoff)."""
+    bad = json.loads(json.dumps(SAMPLE_STAGES))  # deep copy
+    del bad["amplification"]["subStages"][0]["name"]
+    resp = client.post("/profiles", json={"name": "A3 Malformed", "stages": bad})
+    assert resp.status_code == 400
+
+
+@pytest.mark.contract
+def test_list_profiles_includes_structured_flag(client):
+    """GET /profiles flags structured profiles (have `stages`) vs legacy ones."""
+    structured_id = client.post(
+        "/profiles", json={"name": "A3 Structured Flag", "stages": SAMPLE_STAGES}
+    ).json()["id"]
+    legacy_id = _create_profile(client, name="A3 Legacy Flag")  # steps-based, no stages
+    try:
+        by_id = {p["id"]: p for p in client.get("/profiles").json()}
+        assert by_id[structured_id]["structured"] is True
+        assert by_id[legacy_id]["structured"] is False
+    finally:
+        _delete_profile(client, structured_id)
+        _delete_profile(client, legacy_id)

--- a/tests/contract/test_profile_endpoints.py
+++ b/tests/contract/test_profile_endpoints.py
@@ -365,3 +365,74 @@ def test_saved_file_always_carries_both_fields_after_anchor(client):
         assert keys[keys.index("time_unavailable") + 1] == "estimated_completion_seconds"
     finally:
         _delete_profile(client, pid)
+
+
+# ---------------------------------------------------------------------------
+# Structured profiles — `stages` contract foundation (issue #197)
+# ---------------------------------------------------------------------------
+
+# The canonical structured-profile payload both routes build and test against.
+SAMPLE_STAGES = {
+    "incubation": {"enabled": True, "temp": 37, "time": 600},
+    "denaturation": {"enabled": True, "temp": 95, "time": 120},
+    "amplification": {
+        "cycles": 40,
+        "subStages": [
+            {"name": "Denaturation", "temp": 95, "time": 11},
+            {"name": "Annealing & Extension", "temp": 60.5, "time": 38},
+        ],
+    },
+    "finalHold": {"enabled": False, "temp": 25, "time": 60},
+}
+
+
+@pytest.mark.contract
+def test_post_profile_persists_and_returns_stages(client):
+    """A `stages` payload is accepted, persisted, and read back unchanged.
+
+    #197 only carries the contract surface — it does not assemble steps or
+    validate ranges (those are A1/A2/A3). It must, however, round-trip the
+    structured object so both routes can build against a real contract.
+    """
+    resp = client.post(
+        "/profiles",
+        json={"name": "Contract Stages Profile", "stages": SAMPLE_STAGES},
+    )
+    assert resp.status_code == 200, resp.text
+    pid = resp.json()["id"]
+    try:
+        details = client.get(f"/profiles/details?id={pid}")
+        assert details.status_code == 200
+        assert details.json()["stages"] == SAMPLE_STAGES
+    finally:
+        _delete_profile(client, pid)
+
+
+@pytest.mark.contract
+def test_profiles_builder_route_serves_html(client):
+    """GET /profiles/builder serves the structured-editor HTML shell (issue #197)."""
+    resp = client.get("/profiles/builder")
+    assert resp.status_code == 200
+    assert "text/html" in resp.headers.get("content-type", "")
+
+
+@pytest.mark.contract
+def test_sample_stages_fixture_matches_contract():
+    """The committed sample fixture is the canonical `stages` shape (issue #197).
+
+    Both routes build against this file, so it must match the agreed contract:
+    incubation/denaturation/finalHold carry enabled+temp+time; amplification is
+    always present (no `enabled`) with cycles and 2-3 sub-stages.
+    """
+    fixture = Path(__file__).parent.parent / "fixtures" / "sample_stages.json"
+    data = json.loads(fixture.read_text())
+    assert data == SAMPLE_STAGES
+
+    for key in ("incubation", "denaturation", "finalHold"):
+        assert set(data[key]) == {"enabled", "temp", "time"}, key
+    amp = data["amplification"]
+    assert "enabled" not in amp
+    assert "cycles" in amp
+    assert 2 <= len(amp["subStages"]) <= 3
+    for sub in amp["subStages"]:
+        assert set(sub) == {"name", "temp", "time"}

--- a/tests/contract/test_profile_endpoints.py
+++ b/tests/contract/test_profile_endpoints.py
@@ -495,3 +495,33 @@ def test_list_profiles_includes_structured_flag(client):
     finally:
         _delete_profile(client, structured_id)
         _delete_profile(client, legacy_id)
+
+
+# ---------------------------------------------------------------------------
+# Structured profiles — canonical JSON key order (issue #213 / A4)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.contract
+def test_structured_profile_keys_in_canonical_order(client):
+    """A saved structured profile writes its top-level keys in canonical order:
+    output_dir, post_in_gui, title, countdown fields, labels, stages, steps."""
+    from aquila_web import main as web_main
+
+    resp = client.post("/profiles", json={
+        "name": "A4 Key Order",
+        "fam_label": "FAM",
+        "rox_label": "ROX",
+        "stages": SAMPLE_STAGES,
+    })
+    assert resp.status_code == 200, resp.text
+    pid = resp.json()["id"]
+    try:
+        keys = list(json.loads((web_main.resolve_profile_dir() / pid).read_text()).keys())
+        assert keys == [
+            "output_dir", "post_in_gui", "title",
+            "time_unavailable", "estimated_completion_seconds",
+            "labels", "stages", "steps",
+        ]
+    finally:
+        _delete_profile(client, pid)

--- a/tests/contract/test_settings_nav.py
+++ b/tests/contract/test_settings_nav.py
@@ -276,6 +276,7 @@ LIVE_NAV_PAGE_FILES = [
     "history_detail.html",
     "profiles/index.html",
     "profiles/edit_form.html",
+    "profiles/builder.html",
     "complete.html",
     "help.html",
     "settings.html",

--- a/tests/e2e/test_legacy_view.py
+++ b/tests/e2e/test_legacy_view.py
@@ -1,0 +1,143 @@
+"""
+E2E tests for the Legacy Profile read-only view (issue #211, Structured Profiles B4).
+
+The Legacy viewer is the existing `edit_form.html` / `edit.js`, which B3 (#203)
+routes Legacy Profiles to via `?view=1`. B4 locks it (no Edit View toggle), adds a
+summary header (name/FAM/ROX/estimate), aligns the step layout, and removes the
+flash of the editable editor before read-only applies.
+
+Requires a running backend at base_url (default http://localhost:8090; override
+with AQUILA_TEST_URL). Run with: pytest -m e2e tests/e2e/test_legacy_view.py
+"""
+from urllib.parse import quote
+
+import pytest
+
+pytestmark = pytest.mark.e2e
+
+
+def _seed_legacy(page, base_url, name, **fields):
+    """Create a Legacy Profile (no `stages`) and return its id."""
+    body = {"name": name, "steps": [{"setpoint": 95, "duration": 30}], **fields}
+    resp = page.request.post(f"{base_url}/profiles", data=body)
+    assert resp.status == 200, resp.text()
+    return resp.json()["id"]
+
+
+def _delete(page, base_url, pid):
+    page.request.post(f"{base_url}/profiles/delete", data={"profiles": [pid]})
+
+
+def _goto(page, base_url, path):
+    try:
+        page.goto(f"{base_url}{path}", timeout=10_000)
+    except Exception as exc:
+        pytest.skip(f"Backend not reachable at {base_url}: {exc}")
+    page.wait_for_load_state("networkidle")
+
+
+def _view_url(pid, view=True):
+    return f"/profiles/edit-form?id={quote(pid)}" + ("&view=1" if view else "")
+
+
+def test_read_view_hides_edit_toggle_edit_mode_shows_it(page, base_url):
+    """Read-only entry hides the Edit View toggle (no escape to editing); normal
+    edit entry keeps it."""
+    pid = _seed_legacy(page, base_url, "B4 Lock")
+    try:
+        _goto(page, base_url, _view_url(pid, view=True))
+        assert not page.locator("#toggle-read-view").is_visible(), (
+            "Edit View toggle must be hidden in the read-only view"
+        )
+
+        _goto(page, base_url, _view_url(pid, view=False))
+        assert page.locator("#toggle-read-view").is_visible(), (
+            "toggle stays available in normal edit mode"
+        )
+    finally:
+        _delete(page, base_url, pid)
+
+
+def test_summary_header_shows_name_labels_and_estimate(page, base_url):
+    """The read view's summary header shows the profile name, FAM/ROX labels and
+    the estimated minutes when one is set."""
+    pid = _seed_legacy(
+        page, base_url, "B4 Header",
+        fam_label="MyFAM", rox_label="MyROX", estimated_minutes=42,
+    )
+    try:
+        _goto(page, base_url, _view_url(pid, view=True))
+        meta = page.locator("#profile-summary-meta")
+        page.wait_for_selector("#profile-summary-meta", state="attached", timeout=5_000)
+        text = meta.inner_text()
+        assert "B4 Header" in text
+        assert "MyFAM" in text
+        assert "MyROX" in text
+        assert "42" in text  # estimated minutes
+    finally:
+        _delete(page, base_url, pid)
+
+
+def test_summary_header_omits_estimate_when_unset(page, base_url):
+    """With no estimate set, the summary header has no estimated-minutes row."""
+    pid = _seed_legacy(page, base_url, "B4 NoEst", fam_label="FAM", rox_label="ROX")
+    try:
+        _goto(page, base_url, _view_url(pid, view=True))
+        page.wait_for_selector("#profile-summary-meta", state="attached", timeout=5_000)
+        text = page.locator("#profile-summary-meta").inner_text()
+        assert "B4 NoEst" in text
+        assert "Est. Time" not in text and "Estimated" not in text
+    finally:
+        _delete(page, base_url, pid)
+
+
+def test_summary_step_rows_share_one_column_layout(page, base_url):
+    """Step rows align: every row uses the same column tracks regardless of how
+    many fields it has (no field-count zig-zag)."""
+    pid = _seed_legacy(
+        page, base_url, "B4 Align",
+        steps=[
+            {"setpoint": 95, "duration": 30, "description": "Hold"},  # 5 fields
+            {"ramp_rate": 1.6},                                        # 3 fields
+            {"enable": 0, "duration": 1},                              # 4 fields
+        ],
+    )
+    try:
+        _goto(page, base_url, _view_url(pid, view=True))
+        page.wait_for_selector(".profile-summary-step", state="attached", timeout=5_000)
+        cols = page.eval_on_selector_all(
+            ".profile-summary-step",
+            "els => els.map(e => getComputedStyle(e).gridTemplateColumns)",
+        )
+        assert len(cols) >= 2, f"need multiple step rows, got {len(cols)}"
+        # Aligned == every row has the same number of grid tracks regardless of
+        # field count (auto-fit gave 5/3/4; fixed columns give the same count).
+        # Exact px can differ by sub-pixel fr rounding, so compare track counts.
+        track_counts = [len(c.split()) for c in cols]
+        assert len(set(track_counts)) == 1, f"rows must share track count, got {track_counts}"
+    finally:
+        _delete(page, base_url, pid)
+
+
+def test_no_flash_read_only_applied_before_paint(page, base_url):
+    """`?view=1` gets the pre-paint `view-only` class on <html> (so the editable
+    sections never paint); a normal edit load does not."""
+    pid = _seed_legacy(page, base_url, "B4 Flash")
+    try:
+        _goto(page, base_url, _view_url(pid, view=True))
+        assert "view-only" in (page.eval_on_selector("html", "el => el.className") or ""), (
+            "read-only view must set html.view-only before paint"
+        )
+        assert page.locator(".profile-edit").first.is_visible() is False, (
+            "editable sections must not show in the read-only view"
+        )
+
+        _goto(page, base_url, _view_url(pid, view=False))
+        assert "view-only" not in (page.eval_on_selector("html", "el => el.className") or ""), (
+            "edit mode must not be view-only"
+        )
+        assert page.locator("#profile-edit-details").is_visible(), (
+            "edit mode shows the editable sections"
+        )
+    finally:
+        _delete(page, base_url, pid)

--- a/tests/e2e/test_profile_builder.py
+++ b/tests/e2e/test_profile_builder.py
@@ -228,6 +228,10 @@ def test_three_step_save_posts_three_substages(page, base_url):
     _goto_builder(page, base_url)
 
     page.locator("#profile-name").fill("B2 Three Step")
+    # Focus on amplification: disable the other Stages so save-time validation
+    # (B3) doesn't flag their blank fields.
+    for stage in ("incubation", "denaturation", "finalhold"):
+        page.locator(f"#stage-{stage}-enabled").uncheck()
     page.locator("#stage-amp-cycles").fill("35")
     page.locator("#amp-add-substage").click()  # -> three Sub-stages
 
@@ -280,3 +284,297 @@ def test_touch_targets_meet_kiosk_minimum(page, base_url):
     for i in range(toggles.count()):
         box = toggles.nth(i).bounding_box()
         assert box["height"] >= MIN, f"stage toggle {i} too short: {box['height']}px"
+
+
+# ---------------------------------------------------------------------------
+# Validation on save (issue #203, B3)
+# ---------------------------------------------------------------------------
+
+# Every validatable field on a fresh (two-Sub-stage) form, all Stages enabled.
+ENABLED_FIELDS = [
+    "#stage-incubation-temp", "#stage-incubation-time",
+    "#stage-denaturation-temp", "#stage-denaturation-time",
+    "#stage-finalhold-temp", "#stage-finalhold-time",
+    "#stage-amp-cycles",
+    "#stage-amp-sub-0-temp", "#stage-amp-sub-0-time",
+    "#stage-amp-sub-1-temp", "#stage-amp-sub-1-time",
+]
+
+
+def _is_invalid(page, sel):
+    return "is-invalid" in (page.locator(sel).get_attribute("class") or "")
+
+
+def test_pristine_form_has_no_validation_errors(page, base_url):
+    """A freshly loaded builder shows no error styling until a Save is tried."""
+    _goto_builder(page, base_url)
+    assert page.locator(".is-invalid").count() == 0
+    assert page.locator(".field-error:visible").count() == 0
+
+
+def test_blank_save_flags_every_enabled_field_and_blocks(page, base_url):
+    """Saving an all-blank form flags every enabled field red with 'Invalid
+    Value' and does not navigate away."""
+    _goto_builder(page, base_url)
+    page.locator("#profile-name").fill("B3 Blank")
+
+    page.locator("#save-profile-button").click()
+
+    for sel in ENABLED_FIELDS:
+        assert _is_invalid(page, sel), f"{sel} should be flagged invalid"
+    errors = page.locator(".field-error:visible")
+    assert errors.count() >= 1
+    assert "Invalid Value" in errors.first.inner_text()
+
+    # Blocked: still on the builder, no redirect to the Profiles list.
+    assert page.url.rstrip("/").endswith("/profiles/builder")
+
+
+def test_disabled_stage_does_not_block_save(page, base_url):
+    """A disabled (unchecked) Stage's blank fields are skipped by validation, so
+    an otherwise-valid form still saves."""
+    _goto_builder(page, base_url)
+
+    page.locator("#profile-name").fill("B3 Disabled Skip")
+    page.locator("#stage-incubation-enabled").uncheck()  # left blank, must not block
+
+    page.locator("#stage-denaturation-temp").fill("95")
+    page.locator("#stage-denaturation-time").fill("120")
+    page.locator("#stage-finalhold-temp").fill("25")
+    page.locator("#stage-finalhold-time").fill("60")
+    page.locator("#stage-amp-cycles").fill("40")
+    page.locator("#stage-amp-sub-0-temp").fill("95")
+    page.locator("#stage-amp-sub-0-time").fill("11")
+    page.locator("#stage-amp-sub-1-temp").fill("60")
+    page.locator("#stage-amp-sub-1-time").fill("38")
+
+    def is_save_post(req):
+        return req.url.rstrip("/").endswith("/profiles") and req.method == "POST"
+
+    with page.expect_response(lambda r: is_save_post(r.request)) as resp_info:
+        page.locator("#save-profile-button").click()
+
+    assert resp_info.value.status == 200
+    page.wait_for_url("**/profiles-page", timeout=5_000)
+
+    listing = page.request.get(f"{base_url}/profiles").json()
+    stale = [p["id"] for p in listing if "B3_Disabled_Skip" in p.get("id", "")]
+    if stale:
+        page.request.post(f"{base_url}/profiles/delete", data={"profiles": stale})
+
+
+def _fill_valid_two_step(page):
+    """Fill a fully valid two-Sub-stage form (caller tweaks one field to test edges)."""
+    page.locator("#profile-name").fill("B3 Ranges")
+    page.locator("#stage-incubation-temp").fill("37")
+    page.locator("#stage-incubation-time").fill("600")
+    page.locator("#stage-denaturation-temp").fill("95")
+    page.locator("#stage-denaturation-time").fill("120")
+    page.locator("#stage-finalhold-temp").fill("25")
+    page.locator("#stage-finalhold-time").fill("60")
+    page.locator("#stage-amp-cycles").fill("40")
+    page.locator("#stage-amp-sub-0-temp").fill("95")
+    page.locator("#stage-amp-sub-0-time").fill("11")
+    page.locator("#stage-amp-sub-1-temp").fill("60")
+    page.locator("#stage-amp-sub-1-time").fill("38")
+
+
+def test_extension_min_applies_only_to_last_substage(page, base_url):
+    """The 11s minimum applies to the last (extension-bearing) Sub-stage only:
+    a 5s first Sub-stage is fine, a 10s last Sub-stage is rejected."""
+    _goto_builder(page, base_url)
+    _fill_valid_two_step(page)
+    page.locator("#stage-amp-sub-0-time").fill("5")   # not last -> min 1, OK
+    page.locator("#stage-amp-sub-1-time").fill("10")  # last -> min 11, invalid
+
+    page.locator("#save-profile-button").click()
+
+    assert _is_invalid(page, "#stage-amp-sub-1-time"), "last sub-stage <11s must flag"
+    assert not _is_invalid(page, "#stage-amp-sub-0-time"), "first sub-stage 5s is valid"
+    assert page.url.rstrip("/").endswith("/profiles/builder")  # blocked
+
+
+def test_out_of_range_temp_and_cycles_block_then_pass(page, base_url):
+    """Out-of-range temp (24) and cycles (51) are flagged and block; fixing them
+    to the valid edges (25 / 50) lets the save through."""
+    _goto_builder(page, base_url)
+    _fill_valid_two_step(page)
+    page.locator("#stage-incubation-temp").fill("24")  # below 25
+    page.locator("#stage-amp-cycles").fill("51")       # above 50
+
+    page.locator("#save-profile-button").click()
+    assert _is_invalid(page, "#stage-incubation-temp")
+    assert _is_invalid(page, "#stage-amp-cycles")
+    assert page.url.rstrip("/").endswith("/profiles/builder")
+
+    # Fix to the valid boundary values; save now succeeds.
+    page.locator("#stage-incubation-temp").fill("25")
+    page.locator("#stage-amp-cycles").fill("50")
+
+    def is_save_post(req):
+        return req.url.rstrip("/").endswith("/profiles") and req.method == "POST"
+
+    with page.expect_response(lambda r: is_save_post(r.request)) as resp_info:
+        page.locator("#save-profile-button").click()
+    assert resp_info.value.status == 200
+    page.wait_for_url("**/profiles-page", timeout=5_000)
+
+    listing = page.request.get(f"{base_url}/profiles").json()
+    stale = [p["id"] for p in listing if "B3_Ranges" in p.get("id", "")]
+    if stale:
+        page.request.post(f"{base_url}/profiles/delete", data={"profiles": stale})
+
+
+# ---------------------------------------------------------------------------
+# Edit round-trip (issue #203, B3)
+# ---------------------------------------------------------------------------
+
+ROUNDTRIP_STAGES = {
+    "incubation": {"enabled": True, "temp": 37, "time": 600},
+    "denaturation": {"enabled": True, "temp": 95, "time": 120},
+    "amplification": {
+        "cycles": 40,
+        "subStages": [
+            {"name": "Denaturation", "temp": 95, "time": 11},
+            {"name": "Annealing", "temp": 60, "time": 30},
+            {"name": "Extension", "temp": 72, "time": 20},
+        ],
+    },
+    "finalHold": {"enabled": False, "temp": 25, "time": 60},
+}
+
+
+def test_edit_roundtrip_repopulates_and_updates_in_place(page, base_url):
+    """Opening a structured Profile by id repopulates every Stage/Sub-stage/value
+    from its `stages`, and saving updates that same profile (carries profile_id)."""
+    # Seed a structured profile straight through the API.
+    created = page.request.post(
+        f"{base_url}/profiles",
+        data={"name": "B3 Roundtrip", "stages": ROUNDTRIP_STAGES},
+    )
+    assert created.status == 200, created.text()
+    pid = created.json()["id"]
+
+    try:
+        page.goto(f"{base_url}/profiles/builder?id={pid}", timeout=10_000)
+        page.wait_for_load_state("domcontentloaded")
+        # Repopulation is async (fetch /details); wait for a known value to land.
+        page.wait_for_function(
+            "() => document.getElementById('stage-amp-cycles')?.value === '40'",
+            timeout=5_000,
+        )
+
+        assert page.locator("#profile-name").input_value() == "B3 Roundtrip"
+        # Enabled Stage values restored.
+        assert page.locator("#stage-incubation-enabled").is_checked()
+        assert page.locator("#stage-incubation-temp").input_value() == "37"
+        assert page.locator("#stage-incubation-time").input_value() == "600"
+        # Disabled Stage restored as unchecked + greyed.
+        assert not page.locator("#stage-finalhold-enabled").is_checked()
+        assert "stage--disabled" in (page.locator("#stage-finalhold").get_attribute("class") or "")
+        # Three Sub-stages with their three-step names and values.
+        assert page.locator(".amp-substage").count() == 3
+        assert _substage_names(page) == THREE_STEP_NAMES
+        assert page.locator("#stage-amp-sub-2-temp").input_value() == "72"
+        assert page.locator("#stage-amp-sub-2-time").input_value() == "20"
+
+        # Saving updates in place: the POST carries profile_id.
+        def is_save_post(req):
+            return req.url.rstrip("/").endswith("/profiles") and req.method == "POST"
+
+        with page.expect_request(is_save_post) as req_info:
+            page.locator("#save-profile-button").click()
+        assert req_info.value.post_data_json.get("profile_id") == pid
+        page.wait_for_url("**/profiles-page", timeout=5_000)
+    finally:
+        _delete_profile_by_fragment(page, base_url, "B3_Roundtrip")
+
+
+def _delete_profile_by_fragment(page, base_url, fragment):
+    listing = page.request.get(f"{base_url}/profiles").json()
+    stale = [p["id"] for p in listing if fragment in p.get("id", "")]
+    if stale:
+        page.request.post(f"{base_url}/profiles/delete", data={"profiles": stale})
+
+
+# ---------------------------------------------------------------------------
+# Profiles-list routing (issue #203, B3)
+# ---------------------------------------------------------------------------
+
+def test_list_routes_structured_legacy_and_bundled(page, base_url):
+    """The list routes structured rows to the builder (Edit), Legacy rows to the
+    read-only view (View), and never gives bundled rows an edit affordance."""
+    page.request.post(f"{base_url}/profiles", data={"name": "B3 Routing Structured", "stages": ROUNDTRIP_STAGES})
+    page.request.post(f"{base_url}/profiles", data={"name": "B3 Routing Legacy", "steps": [{"setpoint": 95, "duration": 30}]})
+
+    try:
+        page.goto(f"{base_url}/profiles-page", timeout=10_000)
+        page.wait_for_selector("a.profiles-action-btn[href*='B3_Routing']", timeout=5_000)
+
+        edit = page.locator("a.profiles-action-btn[href*='B3_Routing_Structured']")
+        assert edit.count() == 1
+        assert "edit" in edit.inner_text().lower()  # CSS uppercases the label
+        assert "/profiles/builder" in edit.get_attribute("href")
+
+        view = page.locator("a.profiles-action-btn[href*='B3_Routing_Legacy']")
+        assert view.count() == 1
+        assert "view" in view.inner_text().lower()
+        href = view.get_attribute("href")
+        assert "/profiles/edit-form" in href and "view=1" in href
+
+        # Bundled rows (lock icon) carry no Edit/View action link.
+        assert page.locator("tr:has(.profile-lock-icon) a.profiles-action-btn").count() == 0
+    finally:
+        _delete_profile_by_fragment(page, base_url, "B3_Routing")
+
+
+def test_new_profile_button_opens_builder(page, base_url):
+    """The Profiles list 'New profile' button opens the structured builder."""
+    try:
+        page.goto(f"{base_url}/profiles-page", timeout=10_000)
+    except Exception as exc:
+        pytest.skip(f"Backend not reachable: {exc}")
+    new_btn = page.locator("a", has_text="New profile").first
+    assert new_btn.get_attribute("href") == "/profiles/builder"
+
+
+# ---------------------------------------------------------------------------
+# B3 follow-ups: Est Time validation, legacy read-only, red error text
+# ---------------------------------------------------------------------------
+
+def test_invalid_estimated_time_blocks_save(page, base_url):
+    """A non-positive / non-numeric Est. Time is flagged and blocks save, like
+    the legacy editor on main."""
+    _goto_builder(page, base_url)
+    _fill_valid_two_step(page)
+    page.locator("#profile-estimated-minutes").fill("-5")
+
+    page.locator("#save-profile-button").click()
+
+    assert _is_invalid(page, "#profile-estimated-minutes")
+    assert page.locator("#profile-estimated-error").is_visible()
+    assert page.url.rstrip("/").endswith("/profiles/builder")  # blocked
+
+
+def test_legacy_profile_opens_read_only(page, base_url):
+    """Routing a Legacy Profile to ?view=1 opens the viewer read-only (inputs
+    disabled), not the editable legacy editor."""
+    from urllib.parse import quote
+    leg = page.request.post(
+        f"{base_url}/profiles",
+        data={"name": "B3 ReadOnly", "steps": [{"setpoint": 95, "duration": 30}]},
+    ).json()["id"]
+    try:
+        page.goto(f"{base_url}/profiles/edit-form?id={quote(leg)}&view=1", timeout=10_000)
+        page.wait_for_load_state("networkidle")
+        assert page.locator("#profile-name").is_disabled(), "legacy view must be read-only"
+    finally:
+        page.request.post(f"{base_url}/profiles/delete", data={"profiles": [leg]})
+
+
+def test_invalid_value_message_is_red(page, base_url):
+    """The 'Invalid Value' message renders red, not the muted card-text grey."""
+    _goto_builder(page, base_url)
+    page.locator("#save-profile-button").click()  # all-blank -> errors shown
+    color = page.eval_on_selector(".field-error:visible", "el => getComputedStyle(el).color")
+    assert color == "rgb(220, 38, 38)", f"expected red #dc2626, got {color}"

--- a/tests/e2e/test_profile_builder.py
+++ b/tests/e2e/test_profile_builder.py
@@ -313,8 +313,8 @@ def test_pristine_form_has_no_validation_errors(page, base_url):
 
 
 def test_blank_save_flags_every_enabled_field_and_blocks(page, base_url):
-    """Saving an all-blank form flags every enabled field red with 'Invalid
-    Value' and does not navigate away."""
+    """Saving an all-blank form flags every enabled field red with a range
+    message naming the valid bounds, and does not navigate away."""
     _goto_builder(page, base_url)
     page.locator("#profile-name").fill("B3 Blank")
 
@@ -324,7 +324,12 @@ def test_blank_save_flags_every_enabled_field_and_blocks(page, base_url):
         assert _is_invalid(page, sel), f"{sel} should be flagged invalid"
     errors = page.locator(".field-error:visible")
     assert errors.count() >= 1
-    assert "Invalid Value" in errors.first.inner_text()
+    texts = errors.all_inner_texts()
+    assert any("Range (25 - 100)" in t for t in texts), "temp range message"
+    assert any("Range (1 - 600)" in t for t in texts), "time range message"
+    assert any("Range (11 - 600)" in t for t in texts), "extension time range message"
+    assert any("Range (1 - 50)" in t for t in texts), "cycles range message"
+    assert not any("Invalid Value" in t for t in texts), "generic message replaced"
 
     # Blocked: still on the builder, no redirect to the Profiles list.
     assert page.url.rstrip("/").endswith("/profiles/builder")
@@ -573,7 +578,7 @@ def test_legacy_profile_opens_read_only(page, base_url):
 
 
 def test_invalid_value_message_is_red(page, base_url):
-    """The 'Invalid Value' message renders red, not the muted card-text grey."""
+    """The range error message renders red, not the muted card-text grey."""
     _goto_builder(page, base_url)
     page.locator("#save-profile-button").click()  # all-blank -> errors shown
     color = page.eval_on_selector(".field-error:visible", "el => getComputedStyle(el).color")

--- a/tests/e2e/test_profile_builder.py
+++ b/tests/e2e/test_profile_builder.py
@@ -160,6 +160,36 @@ def test_valid_save_posts_stages_and_redirects(page, base_url):
         page.request.post(f"{base_url}/profiles/delete", data={"profiles": stale})
 
 
+def test_blank_name_blocks_save_and_flags_field(page, base_url):
+    """A blank profile name is required: it's flagged and blocks save even when
+    every Stage field is valid (concern #1 from the #218 review)."""
+    _goto_builder(page, base_url)
+    # All stage fields valid; name left blank.
+    page.locator("#stage-incubation-temp").fill("37")
+    page.locator("#stage-incubation-time").fill("600")
+    page.locator("#stage-denaturation-temp").fill("95")
+    page.locator("#stage-denaturation-time").fill("120")
+    page.locator("#stage-amp-cycles").fill("40")
+    page.locator("#stage-amp-sub-0-temp").fill("95")
+    page.locator("#stage-amp-sub-0-time").fill("11")
+    page.locator("#stage-amp-sub-1-temp").fill("60")
+    page.locator("#stage-amp-sub-1-time").fill("38")
+    page.locator("#stage-finalhold-temp").fill("25")
+    page.locator("#stage-finalhold-time").fill("60")
+
+    page.locator("#save-profile-button").click()
+    try:
+        # Blocked: still on the builder, name field flagged invalid.
+        assert page.url.rstrip("/").endswith("/profiles/builder")
+        assert "is-invalid" in (page.locator("#profile-name").get_attribute("class") or "")
+    finally:
+        # Defensive: a pre-fix run would have saved a blank-name profile.
+        listing = page.request.get(f"{base_url}/profiles").json()
+        stale = [p["id"] for p in listing if (p.get("id", "").replace("\\", "/") in ("local/profile.json",))]
+        if stale:
+            page.request.post(f"{base_url}/profiles/delete", data={"profiles": stale})
+
+
 # ---------------------------------------------------------------------------
 # Amplification Sub-stages — add/remove + rename + cycles (issue #202, B2)
 # ---------------------------------------------------------------------------
@@ -181,7 +211,7 @@ def test_amplification_starts_two_step_with_add_tab(page, base_url):
 
     # The add tab is shown; there is no remove control until a third exists.
     assert page.locator("#amp-add-substage").is_visible(), "add tab should show at two"
-    assert page.locator("#amp-remove-substage").count() == 0, "no X at two Sub-stages"
+    assert page.locator(".amp-substage__remove").count() == 0, "no X at two Sub-stages"
 
 
 def test_adding_third_substage_renames_appends_and_hides_add_tab(page, base_url):
@@ -200,7 +230,7 @@ def test_adding_third_substage_renames_appends_and_hides_add_tab(page, base_url)
 
     # At three: the add tab is hidden and the Extension row carries the X.
     assert not page.locator("#amp-add-substage").is_visible(), "add tab hidden at three"
-    assert page.locator("#amp-remove-substage").is_visible(), "Extension X should show"
+    assert page.locator(".amp-substage__remove").is_visible(), "Extension X should show"
 
 
 def test_removing_third_substage_via_x_reverts_to_two_step(page, base_url):
@@ -211,7 +241,7 @@ def test_removing_third_substage_via_x_reverts_to_two_step(page, base_url):
     page.locator("#amp-add-substage").click()      # 2 -> 3
     assert page.locator(".amp-substage").count() == 3
 
-    page.locator("#amp-remove-substage").click()   # X on the Extension row, 3 -> 2
+    page.locator(".amp-substage__remove").click()   # X on the Extension row, 3 -> 2
 
     assert page.locator(".amp-substage").count() == 2
     assert page.locator("#stage-amp-sub-2-name").count() == 0, "third row should be gone"
@@ -219,7 +249,7 @@ def test_removing_third_substage_via_x_reverts_to_two_step(page, base_url):
 
     # Back at two: the add tab returns and the X is gone.
     assert page.locator("#amp-add-substage").is_visible(), "add tab should return"
-    assert page.locator("#amp-remove-substage").count() == 0, "X should be gone at two"
+    assert page.locator(".amp-substage__remove").count() == 0, "X should be gone at two"
 
 
 def test_three_step_save_posts_three_substages(page, base_url):

--- a/tests/e2e/test_profile_builder.py
+++ b/tests/e2e/test_profile_builder.py
@@ -27,7 +27,8 @@ def _goto_builder(page, base_url):
     except Exception as exc:
         pytest.skip(f"Backend not reachable at {base_url}: {exc}")
     page.wait_for_load_state("domcontentloaded")
-    # The builder renders its Stages from JS; wait for the first card to attach.
+    # The Stage cards are static HTML in builder.html (builder.js only wires
+    # behavior); wait for the shell to attach before driving it.
     page.wait_for_selector("#stage-incubation", state="attached", timeout=5_000)
 
 
@@ -157,3 +158,125 @@ def test_valid_save_posts_stages_and_redirects(page, base_url):
     stale = [p["id"] for p in listing if "B1_Happy_Path" in p.get("id", "")]
     if stale:
         page.request.post(f"{base_url}/profiles/delete", data={"profiles": stale})
+
+
+# ---------------------------------------------------------------------------
+# Amplification Sub-stages — add/remove + rename + cycles (issue #202, B2)
+# ---------------------------------------------------------------------------
+
+TWO_STEP_NAMES = ["Denaturation", "Annealing & Extension"]
+THREE_STEP_NAMES = ["Denaturation", "Annealing", "Extension"]
+
+
+def _substage_names(page):
+    return page.locator(".amp-substage .amp-substage__name").all_inner_texts()
+
+
+def test_amplification_starts_two_step_with_add_tab(page, base_url):
+    """A fresh builder shows two Sub-stages and the add tab, with no remove X."""
+    _goto_builder(page, base_url)
+
+    assert page.locator(".amp-substage").count() == 2
+    assert _substage_names(page) == TWO_STEP_NAMES
+
+    # The add tab is shown; there is no remove control until a third exists.
+    assert page.locator("#amp-add-substage").is_visible(), "add tab should show at two"
+    assert page.locator("#amp-remove-substage").count() == 0, "no X at two Sub-stages"
+
+
+def test_adding_third_substage_renames_appends_and_hides_add_tab(page, base_url):
+    """Adding a third Sub-stage renames the 2nd to 'Annealing', appends a blank
+    'Extension' carrying its X, and hides the add tab."""
+    _goto_builder(page, base_url)
+
+    page.locator("#amp-add-substage").click()
+
+    assert page.locator(".amp-substage").count() == 3
+    assert _substage_names(page) == THREE_STEP_NAMES
+
+    # The appended Extension Sub-stage starts blank.
+    assert page.locator("#stage-amp-sub-2-temp").input_value() == ""
+    assert page.locator("#stage-amp-sub-2-time").input_value() == ""
+
+    # At three: the add tab is hidden and the Extension row carries the X.
+    assert not page.locator("#amp-add-substage").is_visible(), "add tab hidden at three"
+    assert page.locator("#amp-remove-substage").is_visible(), "Extension X should show"
+
+
+def test_removing_third_substage_via_x_reverts_to_two_step(page, base_url):
+    """The Extension row's X removes the third Sub-stage, reverts the 2nd's name,
+    and brings the add tab back."""
+    _goto_builder(page, base_url)
+
+    page.locator("#amp-add-substage").click()      # 2 -> 3
+    assert page.locator(".amp-substage").count() == 3
+
+    page.locator("#amp-remove-substage").click()   # X on the Extension row, 3 -> 2
+
+    assert page.locator(".amp-substage").count() == 2
+    assert page.locator("#stage-amp-sub-2-name").count() == 0, "third row should be gone"
+    assert _substage_names(page) == TWO_STEP_NAMES
+
+    # Back at two: the add tab returns and the X is gone.
+    assert page.locator("#amp-add-substage").is_visible(), "add tab should return"
+    assert page.locator("#amp-remove-substage").count() == 0, "X should be gone at two"
+
+
+def test_three_step_save_posts_three_substages(page, base_url):
+    """With a third Sub-stage added, Save POSTs all three in order with their
+    three-step names and the cycle count."""
+    _goto_builder(page, base_url)
+
+    page.locator("#profile-name").fill("B2 Three Step")
+    page.locator("#stage-amp-cycles").fill("35")
+    page.locator("#amp-add-substage").click()  # -> three Sub-stages
+
+    page.locator("#stage-amp-sub-0-temp").fill("95")
+    page.locator("#stage-amp-sub-0-time").fill("10")
+    page.locator("#stage-amp-sub-1-temp").fill("60")
+    page.locator("#stage-amp-sub-1-time").fill("30")
+    page.locator("#stage-amp-sub-2-temp").fill("72")
+    page.locator("#stage-amp-sub-2-time").fill("20")
+
+    def is_save_post(req):
+        return req.url.rstrip("/").endswith("/profiles") and req.method == "POST"
+
+    with page.expect_request(is_save_post) as req_info, \
+            page.expect_response(lambda r: is_save_post(r.request)) as resp_info:
+        page.locator("#save-profile-button").click()
+
+    amp = req_info.value.post_data_json["stages"]["amplification"]
+    assert amp["cycles"] == 35
+    assert [s["name"] for s in amp["subStages"]] == THREE_STEP_NAMES
+    assert amp["subStages"][0] == {"name": "Denaturation", "temp": 95, "time": 10}
+    assert amp["subStages"][1] == {"name": "Annealing", "temp": 60, "time": 30}
+    assert amp["subStages"][2] == {"name": "Extension", "temp": 72, "time": 20}
+
+    assert resp_info.value.status == 200
+    page.wait_for_url("**/profiles-page", timeout=5_000)
+
+    listing = page.request.get(f"{base_url}/profiles").json()
+    stale = [p["id"] for p in listing if "B2_Three_Step" in p.get("id", "")]
+    if stale:
+        page.request.post(f"{base_url}/profiles/delete", data={"profiles": stale})
+
+
+def test_touch_targets_meet_kiosk_minimum(page, base_url):
+    """The add tab and each Stage enable toggle meet the >=44x44px kiosk
+    touch-target rule (spec §6).
+
+    The Extension row's X is intentionally exempt: it is kept compact so the
+    Sub-stage spacing stays uniform (issue #202 follow-up), accepting a smaller
+    hit area for that one rarely-used control.
+    """
+    _goto_builder(page, base_url)
+    MIN = 44
+
+    add_box = page.locator("#amp-add-substage").bounding_box()
+    assert add_box["width"] >= MIN and add_box["height"] >= MIN, f"add tab small: {add_box}"
+
+    toggles = page.locator(".stage__toggle")
+    assert toggles.count() == 3
+    for i in range(toggles.count()):
+        box = toggles.nth(i).bounding_box()
+        assert box["height"] >= MIN, f"stage toggle {i} too short: {box['height']}px"

--- a/tests/e2e/test_profile_builder.py
+++ b/tests/e2e/test_profile_builder.py
@@ -1,0 +1,159 @@
+"""
+E2E tests for the structured profile builder shell (issue #200, Structured Profiles B1).
+
+Covers the builder's observable DOM behavior at the page seam: the fresh-form
+default state, the checkbox toggle that greys/disables a Stage while preserving
+its values, and the happy-path save that POSTs a `stages` payload and redirects.
+Field-level validation (B3) and Amplification Sub-stage add/remove (B2) are out
+of scope here.
+
+Requires a running backend at base_url (default http://localhost:8090; override
+with AQUILA_TEST_URL). Run with: pytest -m e2e tests/e2e/test_profile_builder.py
+Prior art: tests/e2e/test_countdown_timer.py, tests/e2e/test_run_dropdowns.py
+"""
+import pytest
+
+pytestmark = pytest.mark.e2e
+
+# Optional Stages carry an enable checkbox; Amplification is always present.
+OPTIONAL_STAGES = ("incubation", "denaturation", "finalhold")
+ALL_STAGES = ("incubation", "denaturation", "amplification", "finalhold")
+
+
+def _goto_builder(page, base_url):
+    """Navigate to the builder; skip if the backend isn't reachable."""
+    try:
+        page.goto(f"{base_url}/profiles/builder", timeout=10_000)
+    except Exception as exc:
+        pytest.skip(f"Backend not reachable at {base_url}: {exc}")
+    page.wait_for_load_state("domcontentloaded")
+    # The builder renders its Stages from JS; wait for the first card to attach.
+    page.wait_for_selector("#stage-incubation", state="attached", timeout=5_000)
+
+
+def test_fresh_builder_default_state(page, base_url):
+    """A fresh builder shows all four Stages, optional ones checked ON, every
+    thermal field blank, and no validation error styling."""
+    _goto_builder(page, base_url)
+
+    # All four Stage cards are rendered.
+    for stage in ALL_STAGES:
+        assert page.locator(f"#stage-{stage}").count() == 1, f"#stage-{stage} missing"
+
+    # The three optional Stages open checked ON; Amplification has no checkbox.
+    for stage in OPTIONAL_STAGES:
+        assert page.locator(f"#stage-{stage}-enabled").is_checked(), (
+            f"{stage} should default checked ON"
+        )
+    assert page.locator("#stage-amplification-enabled").count() == 0, (
+        "Amplification must not have an enable checkbox"
+    )
+
+    # Every thermal value field is blank on a fresh form, including cycles.
+    blank_fields = [
+        "#stage-incubation-temp", "#stage-incubation-time",
+        "#stage-denaturation-temp", "#stage-denaturation-time",
+        "#stage-amp-cycles",
+        "#stage-amp-sub-0-temp", "#stage-amp-sub-0-time",
+        "#stage-amp-sub-1-temp", "#stage-amp-sub-1-time",
+        "#stage-finalhold-temp", "#stage-finalhold-time",
+    ]
+    for sel in blank_fields:
+        assert page.locator(sel).input_value() == "", f"{sel} should start blank"
+
+    # No error styling shown on a fresh form.
+    assert page.locator(".field-error:visible").count() == 0, "no errors on fresh form"
+
+
+def test_unchecking_stage_greys_and_disables_its_fields(page, base_url):
+    """Unchecking a Stage greys its card and disables its inputs."""
+    _goto_builder(page, base_url)
+
+    card = page.locator("#stage-incubation")
+    temp = page.locator("#stage-incubation-temp")
+    time = page.locator("#stage-incubation-time")
+
+    # Starts enabled: not greyed, inputs editable.
+    assert "stage--disabled" not in (card.get_attribute("class") or "")
+    assert temp.is_enabled() and time.is_enabled()
+
+    page.locator("#stage-incubation-enabled").uncheck()
+
+    assert "stage--disabled" in (card.get_attribute("class") or ""), (
+        "unchecked Stage card should be greyed via .stage--disabled"
+    )
+    assert temp.is_disabled() and time.is_disabled(), (
+        "unchecked Stage inputs should be disabled"
+    )
+
+
+def test_rechecking_stage_preserves_typed_values(page, base_url):
+    """Values typed into a Stage survive an uncheck/re-check round trip."""
+    _goto_builder(page, base_url)
+
+    page.locator("#stage-incubation-temp").fill("37")
+    page.locator("#stage-incubation-time").fill("600")
+
+    page.locator("#stage-incubation-enabled").uncheck()
+    page.locator("#stage-incubation-enabled").check()
+
+    # Re-enabled inputs keep what was typed before the toggle.
+    assert page.locator("#stage-incubation-temp").input_value() == "37"
+    assert page.locator("#stage-incubation-time").input_value() == "600"
+    assert page.locator("#stage-incubation-temp").is_enabled()
+
+
+def test_valid_save_posts_stages_and_redirects(page, base_url):
+    """A valid Save POSTs the expected `stages` shape and redirects to the list.
+
+    Final Temp Hold is unchecked, so it must ride along as enabled:false while
+    the other Stages carry their typed temps/times. All four stage keys are
+    always present.
+    """
+    _goto_builder(page, base_url)
+
+    page.locator("#profile-name").fill("B1 Happy Path")
+
+    page.locator("#stage-incubation-temp").fill("37")
+    page.locator("#stage-incubation-time").fill("600")
+    page.locator("#stage-denaturation-temp").fill("95")
+    page.locator("#stage-denaturation-time").fill("120")
+    page.locator("#stage-amp-cycles").fill("40")
+    page.locator("#stage-amp-sub-0-temp").fill("95")
+    page.locator("#stage-amp-sub-0-time").fill("11")
+    page.locator("#stage-amp-sub-1-temp").fill("60")
+    page.locator("#stage-amp-sub-1-time").fill("38")
+    page.locator("#stage-finalhold-temp").fill("25")
+    page.locator("#stage-finalhold-time").fill("60")
+    page.locator("#stage-finalhold-enabled").uncheck()
+
+    def is_save_post(req):
+        return req.url.rstrip("/").endswith("/profiles") and req.method == "POST"
+
+    with page.expect_request(is_save_post) as req_info, \
+            page.expect_response(lambda r: is_save_post(r.request)) as resp_info:
+        page.locator("#save-profile-button").click()
+
+    payload = req_info.value.post_data_json
+    stages = payload["stages"]
+
+    assert payload["name"] == "B1 Happy Path"
+    assert stages["incubation"] == {"enabled": True, "temp": 37, "time": 600}
+    assert stages["denaturation"] == {"enabled": True, "temp": 95, "time": 120}
+    assert stages["finalHold"]["enabled"] is False
+    amp = stages["amplification"]
+    assert amp["cycles"] == 40
+    assert [s["name"] for s in amp["subStages"]] == ["Denaturation", "Annealing & Extension"]
+    assert amp["subStages"][0] == {"name": "Denaturation", "temp": 95, "time": 11}
+    assert amp["subStages"][1] == {"name": "Annealing & Extension", "temp": 60, "time": 38}
+
+    # Save succeeded and the browser returned to the Profiles list.
+    assert resp_info.value.status == 200
+    page.wait_for_url("**/profiles-page", timeout=5_000)
+
+    # Clean up: the redirect discards the response body, so find the created
+    # profile by its sanitized id in the listing and delete it.
+    listing = page.request.get(f"{base_url}/profiles").json()
+    stale = [p["id"] for p in listing if "B1_Happy_Path" in p.get("id", "")]
+    if stale:
+        page.request.post(f"{base_url}/profiles/delete", data={"profiles": stale})

--- a/tests/fixtures/sample_stages.json
+++ b/tests/fixtures/sample_stages.json
@@ -1,0 +1,12 @@
+{
+  "incubation": { "enabled": true, "temp": 37, "time": 600 },
+  "denaturation": { "enabled": true, "temp": 95, "time": 120 },
+  "amplification": {
+    "cycles": 40,
+    "subStages": [
+      { "name": "Denaturation", "temp": 95, "time": 11 },
+      { "name": "Annealing & Extension", "temp": 60.5, "time": 38 }
+    ]
+  },
+  "finalHold": { "enabled": false, "temp": 25, "time": 60 }
+}

--- a/unit_tests/test_profile_assembly.py
+++ b/unit_tests/test_profile_assembly.py
@@ -1,0 +1,169 @@
+"""
+Unit tests for aquila_web/profile_assembly.py — assemble_steps(stages) -> steps.
+
+Pure logic, no hardware or network (the module has no hardware imports, so unlike
+test_estimated_completion.py this needs no RPi/serial stubbing). Marked ``unit``.
+Spec: specs/backend/spec_profile_step_assembly.md (issue #198).
+"""
+import pytest
+
+from aquila_web.profile_assembly import assemble_steps
+
+pytestmark = pytest.mark.unit
+
+
+def _stages(*, incubation=None, denaturation=None, final_hold=None,
+            cycles=40, sub_stages=None):
+    """Build a valid stages dict. Optional stages default to disabled;
+    amplification defaults to the 2-sub-stage shape."""
+    if sub_stages is None:
+        sub_stages = [
+            {"name": "Denaturation", "temp": 95, "time": 11},
+            {"name": "Annealing & Extension", "temp": 60.5, "time": 38},
+        ]
+    return {
+        "incubation": incubation or {"enabled": False, "temp": 37, "time": 600},
+        "denaturation": denaturation or {"enabled": False, "temp": 95, "time": 120},
+        "amplification": {"cycles": cycles, "subStages": sub_stages},
+        "finalHold": final_hold or {"enabled": False, "temp": 25, "time": 60},
+    }
+
+
+HEAD = [
+    {"disable": 0, "duration": 1, "description": "Record equilibration without power."},
+    {"ramp_rate": 1.6},
+    {"pcr_fanon": 1},
+    {"enable": 0, "duration": 1, "description": "Turn on and record temperature for a little bit"},
+    {"optics": ""},
+    {"setpoint": 25, "duration": 1, "description": "Presetting temperature"},
+]
+
+
+TAIL = [
+    {"ramp_rate": 1.6},
+    {"setpoint": 40, "duration": 20, "description": "Initial cooling"},
+    {"setpoint": 25, "duration": 10, "description": "Restoring setpoint to RT"},
+    {"disable": 0, "duration": 5, "description": "Turn off and record temperature for a little bit"},
+    {"pcr_fanoff": 0},
+]
+
+
+def test_emits_fixed_head_first():
+    """Every assembled profile begins with the fixed equilibration/fan/optics head."""
+    steps = assemble_steps(_stages())
+    assert steps[:len(HEAD)] == HEAD
+
+
+def test_emits_fixed_tail_last():
+    """Every assembled profile ends with the fixed cooldown/fan-off tail."""
+    steps = assemble_steps(_stages())
+    assert steps[-len(TAIL):] == TAIL
+
+
+def test_amplification_emits_ramp_then_repeat_with_cycles():
+    """Amplification is always present: a 1.75 ramp followed by a repeat block
+    carrying the user's cycle count. With no optional stages enabled it sits
+    immediately after the head."""
+    steps = assemble_steps(_stages(cycles=42))
+    assert steps[len(HEAD)] == {"ramp_rate": 1.75}
+    repeat_step = steps[len(HEAD) + 1]
+    assert "repeat" in repeat_step
+    assert repeat_step["cycles"] == 42
+
+
+def _repeat_of(steps):
+    """The repeat block's inner step list (amplification sits after the head when
+    no optional stages are enabled)."""
+    return steps[len(HEAD) + 1]["repeat"]
+
+
+def test_substage_maps_to_setpoint_with_name_description():
+    """A (non-extension) sub-stage becomes one setpoint whose description is its name."""
+    steps = assemble_steps(_stages())
+    repeat = _repeat_of(steps)
+    assert repeat[0] == {"setpoint": 95, "duration": 11, "description": "Denaturation"}
+
+
+def test_optics_split_on_extension_substage_two_substage_case():
+    """With 2 sub-stages, the 2nd (Annealing & Extension) carries the optics read,
+    split as (time-10) -> optics -> 10."""
+    steps = assemble_steps(_stages())  # extension sub-stage time = 38
+    assert _repeat_of(steps) == [
+        {"setpoint": 95, "duration": 11, "description": "Denaturation"},
+        {"setpoint": 60.5, "duration": 28, "description": "Annealing & Extension"},
+        {"optics": ""},
+        {"setpoint": 60.5, "duration": 10, "description": "Annealing & Extension"},
+    ]
+
+
+def test_optics_split_on_extension_substage_three_substage_case():
+    """With 3 sub-stages, the 3rd (Extension) carries the optics read; the 2nd
+    (Annealing) is a plain hold."""
+    three = [
+        {"name": "Denaturation", "temp": 95, "time": 11},
+        {"name": "Annealing", "temp": 60, "time": 20},
+        {"name": "Extension", "temp": 72, "time": 30},
+    ]
+    steps = assemble_steps(_stages(sub_stages=three))
+    assert _repeat_of(steps) == [
+        {"setpoint": 95, "duration": 11, "description": "Denaturation"},
+        {"setpoint": 60, "duration": 20, "description": "Annealing"},
+        {"setpoint": 72, "duration": 20, "description": "Extension"},
+        {"optics": ""},
+        {"setpoint": 72, "duration": 10, "description": "Extension"},
+    ]
+
+
+def test_incubation_emitted_after_head_when_enabled():
+    """An enabled Incubation Stage is one setpoint, right after the head."""
+    steps = assemble_steps(_stages(incubation={"enabled": True, "temp": 37, "time": 600}))
+    assert steps[len(HEAD)] == {"setpoint": 37, "duration": 600, "description": "Incubation"}
+
+
+def test_initial_denaturation_emitted_when_enabled():
+    """An enabled Initial Denaturation Stage is one setpoint with that description."""
+    steps = assemble_steps(_stages(denaturation={"enabled": True, "temp": 95, "time": 120}))
+    assert steps[len(HEAD)] == {"setpoint": 95, "duration": 120, "description": "Initial Denaturation"}
+
+
+def test_final_temp_hold_emitted_before_tail_when_enabled():
+    """An enabled Final Temp Hold is one setpoint placed after amplification,
+    immediately before the cooldown tail."""
+    steps = assemble_steps(_stages(final_hold={"enabled": True, "temp": 25, "time": 60}))
+    assert steps[-len(TAIL) - 1] == {"setpoint": 25, "duration": 60, "description": "Final Temp Hold"}
+
+
+def test_disabled_optional_stages_emit_nothing():
+    """With Incubation/Denaturation/Final Hold all off, only head + amplification + tail remain."""
+    steps = assemble_steps(_stages(cycles=40))
+    assert steps == HEAD + [
+        {"ramp_rate": 1.75},
+        {"repeat": [
+            {"setpoint": 95, "duration": 11, "description": "Denaturation"},
+            {"setpoint": 60.5, "duration": 28, "description": "Annealing & Extension"},
+            {"optics": ""},
+            {"setpoint": 60.5, "duration": 10, "description": "Annealing & Extension"},
+        ], "cycles": 40},
+    ] + TAIL
+
+
+def test_full_profile_ordering_all_stages_enabled():
+    """End-to-end: head -> incubation -> denaturation -> amplification -> final hold -> tail."""
+    steps = assemble_steps(_stages(
+        incubation={"enabled": True, "temp": 37, "time": 600},
+        denaturation={"enabled": True, "temp": 95, "time": 120},
+        final_hold={"enabled": True, "temp": 25, "time": 60},
+        cycles=40,
+    ))
+    assert steps == HEAD + [
+        {"setpoint": 37, "duration": 600, "description": "Incubation"},
+        {"setpoint": 95, "duration": 120, "description": "Initial Denaturation"},
+        {"ramp_rate": 1.75},
+        {"repeat": [
+            {"setpoint": 95, "duration": 11, "description": "Denaturation"},
+            {"setpoint": 60.5, "duration": 28, "description": "Annealing & Extension"},
+            {"optics": ""},
+            {"setpoint": 60.5, "duration": 10, "description": "Annealing & Extension"},
+        ], "cycles": 40},
+        {"setpoint": 25, "duration": 60, "description": "Final Temp Hold"},
+    ] + TAIL

--- a/unit_tests/test_profile_assembly.py
+++ b/unit_tests/test_profile_assembly.py
@@ -7,7 +7,7 @@ Spec: specs/backend/spec_profile_step_assembly.md (issue #198).
 """
 import pytest
 
-from aquila_web.profile_assembly import assemble_steps
+from aquila_web.profile_assembly import assemble_steps, validate_stages
 
 pytestmark = pytest.mark.unit
 
@@ -145,6 +145,74 @@ def test_disabled_optional_stages_emit_nothing():
             {"setpoint": 60.5, "duration": 10, "description": "Annealing & Extension"},
         ], "cycles": 40},
     ] + TAIL
+
+
+# ---------------------------------------------------------------------------
+# validate_stages (A2 / #199)
+# ---------------------------------------------------------------------------
+
+
+def test_valid_stages_has_no_errors():
+    """A fully valid, all-stages-enabled profile produces no validation errors."""
+    stages = _stages(
+        incubation={"enabled": True, "temp": 37, "time": 600},
+        denaturation={"enabled": True, "temp": 95, "time": 120},
+        final_hold={"enabled": True, "temp": 25, "time": 60},
+        cycles=40,
+    )
+    assert validate_stages(stages) == []
+
+
+def test_temp_above_max_is_error():
+    """A temperature above 100 °C on an enabled stage is flagged."""
+    stages = _stages(incubation={"enabled": True, "temp": 150, "time": 600})
+    errors = validate_stages(stages)
+    assert any("incubation" in e for e in errors)
+
+
+def test_time_above_max_is_error():
+    """A duration above 600 s on an enabled stage is flagged."""
+    stages = _stages(incubation={"enabled": True, "temp": 37, "time": 999})
+    errors = validate_stages(stages)
+    assert any("incubation.time" in e for e in errors)
+
+
+def test_extension_substage_has_11s_floor_others_dont():
+    """The extension-bearing (last) sub-stage needs time >= 11 so the optics split
+    stays valid; a non-extension sub-stage may go as low as 1 s."""
+    subs = [
+        {"name": "Denaturation", "temp": 95, "time": 5},            # non-extension: 5 s OK
+        {"name": "Annealing & Extension", "temp": 60, "time": 8},   # extension: 8 < 11 -> error
+    ]
+    errors = validate_stages(_stages(sub_stages=subs))
+    assert any("subStages[1].time" in e for e in errors)
+    assert not any("subStages[0].time" in e for e in errors)
+
+
+def test_cycles_above_max_is_error():
+    """A cycle count above 50 is flagged."""
+    errors = validate_stages(_stages(cycles=51))
+    assert any("cycles" in e for e in errors)
+
+
+def test_substage_count_below_two_is_error():
+    """Amplification must have 2 or 3 sub-stages; 1 is flagged."""
+    one = [{"name": "Denaturation", "temp": 95, "time": 11}]
+    errors = validate_stages(_stages(sub_stages=one))
+    assert any("subStages: Invalid Value" in e for e in errors)
+
+
+def test_disabled_stage_with_bad_values_is_skipped():
+    """A disabled optional Stage is not validated even if its values are out of range."""
+    stages = _stages(incubation={"enabled": False, "temp": 999, "time": -5})
+    assert validate_stages(stages) == []
+
+
+def test_non_numeric_value_is_error():
+    """A blank/non-numeric value on an enabled field is flagged, not raised."""
+    stages = _stages(incubation={"enabled": True, "temp": "", "time": 600})
+    errors = validate_stages(stages)
+    assert any("incubation.temp" in e for e in errors)
 
 
 def test_full_profile_ordering_all_stages_enabled():

--- a/unit_tests/test_profile_assembly.py
+++ b/unit_tests/test_profile_assembly.py
@@ -7,7 +7,7 @@ Spec: specs/backend/spec_profile_step_assembly.md (issue #198).
 """
 import pytest
 
-from aquila_web.profile_assembly import assemble_steps, validate_stages
+from aquila_web.profile_assembly import assemble_steps, validate_stages, _is_number
 
 pytestmark = pytest.mark.unit
 
@@ -150,6 +150,16 @@ def test_disabled_optional_stages_emit_nothing():
 # ---------------------------------------------------------------------------
 # validate_stages (A2 / #199)
 # ---------------------------------------------------------------------------
+
+
+def test_is_number_rejects_non_finite():
+    """NaN/Infinity are floats but not usable numeric values — reject them so they
+    can't slip through validation (defense-in-depth for the non-finite blocker)."""
+    assert _is_number(float("nan")) is False
+    assert _is_number(float("inf")) is False
+    assert _is_number(float("-inf")) is False
+    assert _is_number(95) is True
+    assert _is_number(60.5) is True
 
 
 def test_valid_stages_has_no_errors():

--- a/unit_tests/test_profile_assembly.py
+++ b/unit_tests/test_profile_assembly.py
@@ -239,12 +239,54 @@ def test_missing_amplification_returns_error_not_exception():
     assert any("amplification" in e for e in errors)
 
 
-def test_missing_optional_stage_key_does_not_raise():
-    """A stages object missing an optional stage key is tolerated (no crash)."""
+def test_missing_optional_stage_key_is_error():
+    """A missing optional stage key is flagged (assemble_steps subscripts it directly)."""
     stages = _stages()
     del stages["incubation"]
     errors = validate_stages(stages)  # must not raise
-    assert isinstance(errors, list)
+    assert any("incubation" in e for e in errors)
+
+
+# --- Finding #1: a validate-clean payload must be safe to assemble ---
+
+
+def test_substage_missing_name_is_error():
+    """A sub-stage without a name is flagged (assemble_steps reads sub['name'])."""
+    subs = [
+        {"temp": 95, "time": 11},  # no name
+        {"name": "Annealing & Extension", "temp": 60, "time": 38},
+    ]
+    errors = validate_stages(_stages(sub_stages=subs))
+    assert any("subStages[0].name" in e for e in errors)
+
+
+def test_optional_stage_missing_enabled_is_error():
+    """An optional stage without an `enabled` flag is flagged (assemble reads stage['enabled'])."""
+    stages = _stages()
+    stages["incubation"] = {"temp": 37, "time": 600}  # no enabled
+    errors = validate_stages(stages)
+    assert any("incubation" in e for e in errors)
+
+
+def test_non_dict_optional_stage_is_error():
+    """A present-but-non-dict optional stage is flagged, not silently skipped."""
+    stages = _stages()
+    stages["incubation"] = "garbage"
+    errors = validate_stages(stages)
+    assert any("incubation" in e for e in errors)
+
+
+def test_validate_clean_implies_assemble_does_not_raise():
+    """The trust-boundary guarantee: any payload validate_stages calls clean ([])
+    must assemble without raising. Spot-checks the finding-1 shapes."""
+    candidates = [
+        _stages(sub_stages=[{"temp": 95, "time": 11}, {"temp": 60, "time": 38}]),  # no names
+        {**_stages(), "incubation": {"temp": 37, "time": 600}},                     # no enabled
+        {**_stages(), "incubation": "garbage"},                                     # non-dict
+    ]
+    for stages in candidates:
+        if validate_stages(stages) == []:
+            assemble_steps(stages)  # must not raise when validation passed
 
 
 def test_full_profile_ordering_all_stages_enabled():

--- a/unit_tests/test_profile_assembly.py
+++ b/unit_tests/test_profile_assembly.py
@@ -215,6 +215,38 @@ def test_non_numeric_value_is_error():
     assert any("incubation.temp" in e for e in errors)
 
 
+def test_malformed_substages_returns_error_not_exception():
+    """A non-list subStages is reported as an error, never raised (trust boundary)."""
+    stages = _stages()
+    stages["amplification"]["subStages"] = None
+    errors = validate_stages(stages)  # must not raise
+    assert any("subStages" in e for e in errors)
+
+
+def test_substages_with_non_dict_elements_returns_error_not_exception():
+    """Non-dict sub-stage elements are reported, never raised."""
+    stages = _stages()
+    stages["amplification"]["subStages"] = [1, 2]
+    errors = validate_stages(stages)  # must not raise
+    assert errors
+
+
+def test_missing_amplification_returns_error_not_exception():
+    """A stages object missing the amplification key is reported, never raised."""
+    stages = _stages()
+    del stages["amplification"]
+    errors = validate_stages(stages)  # must not raise
+    assert any("amplification" in e for e in errors)
+
+
+def test_missing_optional_stage_key_does_not_raise():
+    """A stages object missing an optional stage key is tolerated (no crash)."""
+    stages = _stages()
+    del stages["incubation"]
+    errors = validate_stages(stages)  # must not raise
+    assert isinstance(errors, list)
+
+
 def test_full_profile_ordering_all_stages_enabled():
     """End-to-end: head -> incubation -> denaturation -> amplification -> final hold -> tail."""
     steps = assemble_steps(_stages(

--- a/unit_tests/test_profile_key_order.py
+++ b/unit_tests/test_profile_key_order.py
@@ -1,0 +1,82 @@
+"""
+Unit tests for aquila_web.main._order_profile_keys — canonical top-level key
+ordering for structured profiles (issue #213 / A4).
+
+Pure dict->dict logic. Marked ``unit``. Spec: specs/backend/spec_profile_key_order.md.
+"""
+import os
+import sys
+import types
+from pathlib import Path
+
+import pytest
+
+pytestmark = pytest.mark.unit
+
+# Stub heavy hardware deps before importing main (same approach as the other
+# unit test modules so importing aquila_web.main works on a dev machine / CI).
+for _mod in ("RPi", "RPi.GPIO"):
+    sys.modules.setdefault(_mod, types.ModuleType(_mod))
+
+if "serial" not in sys.modules:
+    _s = types.ModuleType("serial")
+    _st = types.ModuleType("serial.tools")
+    _lp = types.ModuleType("serial.tools.list_ports")
+    _lp.comports = lambda: []
+    _s.tools = _st
+    _st.list_ports = _lp
+    sys.modules.update({"serial": _s, "serial.tools": _st, "serial.tools.list_ports": _lp})
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(REPO_ROOT))
+sys.path.insert(0, str(REPO_ROOT / "aquila_web"))
+os.environ.setdefault("AQ_DEV_SIMULATE", "1")
+
+from aquila_web.main import _order_profile_keys
+
+
+def test_orders_keys_canonically_regardless_of_input_order():
+    """Keys are emitted in canonical order even when the input is scrambled."""
+    scrambled = {
+        "steps": [],
+        "labels": {"fam": "FAM"},
+        "title": "X",
+        "stages": {},
+        "output_dir": "pcr_data",
+        "estimated_completion_seconds": 60,
+        "post_in_gui": "True",
+        "time_unavailable": False,
+    }
+    assert list(_order_profile_keys(scrambled).keys()) == [
+        "output_dir", "post_in_gui", "title",
+        "time_unavailable", "estimated_completion_seconds",
+        "labels", "stages", "steps",
+    ]
+
+
+def test_only_present_keys_are_emitted():
+    """Absent canonical keys (e.g. rox_unavailable, labels) are not invented."""
+    profile = {"steps": [], "title": "X", "output_dir": "pcr_data"}
+    assert list(_order_profile_keys(profile).keys()) == ["output_dir", "title", "steps"]
+
+
+def test_rox_unavailable_placed_before_countdown_when_present():
+    """rox_unavailable sits after title, before the countdown fields."""
+    profile = {
+        "steps": [], "title": "X", "output_dir": "pcr_data",
+        "rox_unavailable": True, "time_unavailable": False,
+    }
+    assert list(_order_profile_keys(profile).keys()) == [
+        "output_dir", "title", "rox_unavailable", "time_unavailable", "steps",
+    ]
+
+
+def test_unknown_keys_are_preserved_and_appended():
+    """Keys not in the canonical list are kept (never dropped) and trail in order."""
+    profile = {
+        "steps": [], "output_dir": "pcr_data", "title": "X",
+        "custom_one": 1, "custom_two": 2,
+    }
+    result = _order_profile_keys(profile)
+    assert result["custom_one"] == 1 and result["custom_two"] == 2
+    assert list(result.keys()) == ["output_dir", "title", "steps", "custom_one", "custom_two"]


### PR DESCRIPTION
# Structured Profile Editor — promotion to `main` (#204 / C)

Promotes the complete structured-profile feature from `updated-profiles` to `main` as one reviewed unit. This is **PR 2 of 2** for the integration step (PR #216 landed the prep on `updated-profiles`).

Closes #197
Closes #198
Closes #199
Closes #200
Closes #201
Closes #202
Closes #203
Closes #211
Closes #213
Closes #219
Closes #237
Closes #252

## What ships
A guided editor that lets operators author PCR profiles in domain terms (Incubation / Initial Denaturation / Amplification / Final Temp Hold) while the backend assembles the real hardware `steps`. Per ADR-018, the structured `stages` object is the editable source of truth; `steps` is regenerated from it on every save.

**Backend (A1–A4)**
- A1 #198 — `assemble_steps(stages)`: head/tail boilerplate, ramps 1.6/1.75, per-cycle optics split `(t-10)/optics/10` on the extension sub-stage.
- A2 #199 — `validate_stages(stages)`: ranges (temp 25–100, time 1–600, extension ≥11, cycles 1–50, 2–3 sub-stages); hardened to never raise (trust boundary).
- A3 #201 — `POST /profiles` validates→assembles; `GET /profiles` exposes `structured`; malformed input → 400, not 500.
- A4 #213 — canonical JSON key order for structured saves.

**Frontend (B1–B4)**
- B1 #200 — builder shell (Stages, checkboxes, save). B2 #202 — Amplification sub-stages (add/remove + rename + cycles). B3 #203 — save-time validation UX + edit round-trip + list routing (structured→builder, legacy→read-only). B4 #211 — legacy read-only view.

## Verification (run on the merged `updated-profiles`)
- **e2e against the real backend: 25/25 pass** — `tests/e2e/test_profile_builder.py` + `test_legacy_view.py` (structured create → validate/assemble → save → reopen → repopulate; sub-stage transitions; validation display; list routing). This is the convergence the two routes deferred while building against stubs.
  - Reproduce: `AQ_DEV_SIMULATE=1 venv/Scripts/python -m uvicorn aquila_web.main:app --port 8090` then `AQUILA_TEST_URL=http://127.0.0.1:8090 venv/Scripts/python -m pytest tests/e2e/test_profile_builder.py tests/e2e/test_legacy_view.py -q` (needs `playwright install chromium`).
- **Full suite: 224 passed, 16 failed.** The 16 are long-standing **pre-existing environmental** failures (button/ready-screen state-bleed, device-filtering/results fixtures, profile-dir-state) — verified identical on `main`. **Zero new failures** introduced by this feature.
- **No regressions:** confirmed earlier against a clean `main` worktree (same failing set).
- **Data-loss guard:** structured saves regenerate `steps` from `stages`, so the optics read is always preserved; legacy profiles are read-only in-app.

## Notes
- The 16 environmental failures pre-date this work and aren't gated by CI (Docker-only workflows). Tracked as long-standing.
- ADR-018 records the architecture; per-issue specs live under `specs/backend/` and `specs/frontend/`.

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)

