### PR TITLE
#219 reject non-finite (NaN/Infinity) profile values (PR #218 blocker fix)

### DIFF
--- a/aquila_web/main.py
+++ b/aquila_web/main.py
@@ -1476,9 +1476,21 @@ async def save_profile(payload: ProfileSave):
     else:
         base_profile = _order_time_fields(base_profile)
 
+    # Serialize first with allow_nan=False so a non-finite value (NaN/Infinity)
+    # anywhere — including a disabled stage that validation skips — fails loudly
+    # with a 400 instead of writing invalid JSON that 500s on every later read.
+    # Serializing before opening the file also prevents truncating an existing
+    # profile when re-saving an edit that turns out to be invalid.
+    try:
+        profile_text = json.dumps(base_profile, indent=2, allow_nan=False)
+    except ValueError:
+        raise HTTPException(
+            status_code=400,
+            detail={"errors": ["Profile contains non-finite numeric values (NaN/Infinity)."]},
+        )
     try:
         with profile_path.open("w") as f:
-            json.dump(base_profile, f, indent=2)
+            f.write(profile_text)
     except Exception:
         raise HTTPException(status_code=500, detail="Failed to save profile")
 

--- a/aquila_web/profile_assembly.py
+++ b/aquila_web/profile_assembly.py
@@ -5,6 +5,8 @@ unit-testable in isolation. See specs/backend/spec_profile_step_assembly.md
 (#198) and ADR-018 for the fixed Boilerplate constants and ordering.
 """
 
+import math
+
 # Seconds held at the extension temperature after the optics read fires; the
 # extension-bearing sub-stage is split into (time - tail) -> optics -> tail (ADR-018).
 OPTICS_TAIL_SECONDS = 10
@@ -18,8 +20,12 @@ CYCLES_MIN, CYCLES_MAX = 1, 50
 
 
 def _is_number(value) -> bool:
-    """True for a real numeric value (rejects bools, strings, None)."""
-    return isinstance(value, (int, float)) and not isinstance(value, bool)
+    """True for a real, finite numeric value (rejects bools, strings, None, NaN, Inf)."""
+    return (
+        isinstance(value, (int, float))
+        and not isinstance(value, bool)
+        and math.isfinite(value)
+    )
 
 
 def _is_int(value) -> bool:

--- a/specs/backend/spec_stages_validation.md
+++ b/specs/backend/spec_stages_validation.md
@@ -38,6 +38,8 @@ Validated only for **enabled** Stages (Amplification is always enabled). Disable
 
 Constants per ADR-018. Non-numeric or missing values for enabled fields are errors (not exceptions).
 
+**Non-finite guard (#219):** `_is_number` rejects `NaN`/`Infinity`, and `save_profile` serializes with `allow_nan=False` *before* writing — so a non-finite value anywhere (including a disabled stage that validation skips) fails as a 400 with nothing written, rather than persisting literal `NaN`/`Infinity` that 500s on every later read.
+
 ---
 
 ## 8. Unit Tests

--- a/tests/contract/test_profile_endpoints.py
+++ b/tests/contract/test_profile_endpoints.py
@@ -503,6 +503,37 @@ def test_list_profiles_includes_structured_flag(client):
 
 
 @pytest.mark.contract
+def test_nonfinite_in_disabled_stage_rejected_not_persisted(client):
+    """A non-finite value (NaN/Infinity) anywhere — even in a DISABLED stage that
+    validation skips — must be rejected with 400 and never written to disk.
+
+    Regression for the trust-boundary blocker: such a value used to pass
+    validation, persist as literal NaN/Infinity, and 500 every later read.
+    """
+    from aquila_web import main as web_main
+
+    bad = json.loads(json.dumps(SAMPLE_STAGES))  # deep copy
+    bad["incubation"] = {"enabled": False, "temp": "__NAN__", "time": "__INF__"}
+    # Build a raw body with literal NaN/Infinity tokens — a crafted client can send
+    # these (Starlette's json.loads accepts them); httpx's json= encoder cannot.
+    body = json.dumps({"name": "NonFinite Poison", "fam_label": "FAM",
+                       "rox_label": "ROX", "stages": bad})
+    body = body.replace('"__NAN__"', "NaN").replace('"__INF__"', "Infinity")
+    resp = client.post("/profiles", content=body,
+                       headers={"Content-Type": "application/json"})
+    try:
+        assert resp.status_code == 400, f"expected 400, got {resp.status_code}"
+        # nothing written: the poison profile must not appear in the listing
+        ids = [p["id"] for p in client.get("/profiles").json()]
+        assert not any("NonFinite_Poison" in i for i in ids)
+    finally:
+        # defensive: remove any poison file a failing (pre-fix) run may have written,
+        # since it would 500 every subsequent read of the listing/details
+        for p in (web_main.resolve_profile_dir() / "local").glob("NonFinite_Poison*.json"):
+            p.unlink(missing_ok=True)
+
+
+@pytest.mark.contract
 def test_structured_profile_keys_in_canonical_order(client):
     """A saved structured profile writes its top-level keys in canonical order:
     output_dir, post_in_gui, title, countdown fields, labels, stages, steps."""

--- a/unit_tests/test_profile_assembly.py
+++ b/unit_tests/test_profile_assembly.py
@@ -7,7 +7,7 @@ Spec: specs/backend/spec_profile_step_assembly.md (issue #198).
 """
 import pytest
 
-from aquila_web.profile_assembly import assemble_steps, validate_stages
+from aquila_web.profile_assembly import assemble_steps, validate_stages, _is_number
 
 pytestmark = pytest.mark.unit
 
@@ -150,6 +150,16 @@ def test_disabled_optional_stages_emit_nothing():
 # ---------------------------------------------------------------------------
 # validate_stages (A2 / #199)
 # ---------------------------------------------------------------------------
+
+
+def test_is_number_rejects_non_finite():
+    """NaN/Infinity are floats but not usable numeric values — reject them so they
+    can't slip through validation (defense-in-depth for the non-finite blocker)."""
+    assert _is_number(float("nan")) is False
+    assert _is_number(float("inf")) is False
+    assert _is_number(float("-inf")) is False
+    assert _is_number(95) is True
+    assert _is_number(60.5) is True
 
 
 def test_valid_stages_has_no_errors():


### PR DESCRIPTION
Closes #219 — fixes the trust-boundary blocker found in the #218 promotion review. Targets `updated-profiles`, so it flows into the promotion PR automatically.

## The bug (reproduced end-to-end)
A non-finite float (`NaN`/`Infinity`) in a **disabled** stage bypassed validation, was persisted to disk as a literal token, and then **500'd every subsequent read** — permanently bricking the profile in-app.
1. `validate_stages` skips disabled stages → `{enabled:false, temp:NaN, time:Infinity}` returns `[]` (passes).
2. `save_profile` wrote literal `NaN`/`Infinity` (stdlib `json.dump` allows it).
3. `GET /profiles/details` → Starlette renders with `allow_nan=False` → `ValueError` → HTTP 500, forever.

Contradicts the PR's "malformed → 400, not 500" guarantee; the old tests never fed it non-finite values.

## Fix (belt-and-suspenders, closes the whole class)
- **`save_profile`** serializes with `json.dumps(..., allow_nan=False)` **before** opening the file → non-finite anywhere (disabled stage, unknown key, anywhere) → **400, nothing written**. Serializing first also prevents truncating an existing profile on an invalid edit.
- **`_is_number`** rejects non-finite via `math.isfinite` (validation hardening).

## Tests
- Contract: a **raw** request body with literal `NaN`/`Infinity` in a disabled stage → 400, not persisted (httpx's `json=` can't even encode NaN, so the test posts raw `content=` like a crafted client would).
- Unit: `_is_number` rejects `NaN`/`±Inf`, accepts finite numbers.
- Full suite: 226 passed / 16 failed — +2 new passing tests; the 16 are the known pre-existing environmental failures (zero new).

## Scope
Backend only (`main.py` write path + `profile_assembly._is_number`). No behavior change for valid profiles. The other review items (27px ✕ touch target — frontend/B-side; legacy view-only — intentional per #203/#211; `[object Object]` error render; `structured`-flag consistency) are tracked separately as non-blocking.

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)
