### PR TITLE
#222: Images self-report their version (baked in + shown in footer)

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -21,8 +21,10 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Set lowercase repo
-        run: echo "REPO_LOWER=$(echo "$GITHUB_REPOSITORY" | tr '[:upper:]' '[:lower:]')" >> $GITHUB_ENV
+      - name: Set build vars
+        run: |
+          echo "REPO_LOWER=$(echo "$GITHUB_REPOSITORY" | tr '[:upper:]' '[:lower:]')" >> $GITHUB_ENV
+          echo "SHORT_SHA=${GITHUB_SHA::7}" >> $GITHUB_ENV
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
@@ -44,6 +46,8 @@ jobs:
           file: docker/Dockerfile.api
           platforms: linux/amd64,linux/arm64
           push: true
+          build-args: |
+            AQ_APP_VERSION=${{ env.SHORT_SHA }}
           tags: |
             ghcr.io/${{ env.REPO_LOWER }}-api:latest
             ghcr.io/${{ env.REPO_LOWER }}-api:${{ github.sha }}

--- a/aquila_web/main.py
+++ b/aquila_web/main.py
@@ -659,7 +659,7 @@ async def health_check():
 
 @app.get("/version")
 async def version_check():
-    return {"version": os.getenv("AQ_APP_VERSION", "unknown")}
+    return {"version": os.getenv("AQ_APP_VERSION") or "unknown"}
 
 
 @app.get("/results")

--- a/aquila_web/static/help.html
+++ b/aquila_web/static/help.html
@@ -304,15 +304,14 @@
       catch (err) { console.error("Exit failed", err); }
     }
 
-    fetch("/button_status")
+    // Show the version baked into the running image. Falls back to the
+    // hardcoded value in the markup if /version is unreachable.
+    fetch("/version")
       .then(r => r.ok ? r.json() : null)
       .then(data => {
-        if (!data) return;
-        const el = document.getElementById("help-version-info");
-        const parts = [];
-        if (data.firmware) parts.push("Firmware " + data.firmware);
-        if (data.device_id) parts.push("Device " + data.device_id);
-        if (parts.length) el.textContent = parts.join(" · ");
+        if (data && data.version) {
+          document.getElementById("help-version-info").textContent = "V " + data.version;
+        }
       }).catch(() => {});
   </script>
   <script src="/static/keyboard.js?v=14"></script>

--- a/docker/Dockerfile.api
+++ b/docker/Dockerfile.api
@@ -17,6 +17,13 @@ COPY profiles/bundled/ /opt/aquila/profiles_bundled/
 COPY docker/entrypoint.sh /opt/aquila/entrypoint.sh
 RUN chmod +x /opt/aquila/entrypoint.sh
 
+# App version injected at build time by the release workflow
+# (--build-arg AQ_APP_VERSION=x.y.z). Served by /version and shown in the UI
+# footer. Defaults to "unknown"; non-release builds pass the short commit SHA.
+ARG AQ_APP_VERSION=unknown
+ENV AQ_APP_VERSION=${AQ_APP_VERSION}
+LABEL org.opencontainers.image.version=${AQ_APP_VERSION}
+
 ENV DATA_DIR=/opt/aquila \
     PROFILE_DIR=/opt/aquila/profiles \
     RESULTS_PATH=/opt/aquila/results/results.json

--- a/tests/contract/test_version_endpoint.py
+++ b/tests/contract/test_version_endpoint.py
@@ -1,0 +1,39 @@
+"""
+Contract tests for the /version endpoint.
+
+The endpoint reports the app version baked into the image via the
+AQ_APP_VERSION env var, so a deployed Sentri can self-report what it runs.
+
+All tests carry the `@pytest.mark.contract` marker; run with:
+
+    pytest tests/contract/ -m contract
+"""
+import pytest
+
+
+@pytest.mark.contract
+def test_version_returns_configured_version(client, monkeypatch):
+    """GET /version returns the AQ_APP_VERSION value when it is set."""
+    monkeypatch.setenv("AQ_APP_VERSION", "1.2.6.7")
+    response = client.get("/version")
+    assert response.status_code == 200
+    assert response.json() == {"version": "1.2.6.7"}
+
+
+@pytest.mark.contract
+def test_version_unknown_when_unset(client, monkeypatch):
+    """GET /version reports 'unknown' when AQ_APP_VERSION is not set."""
+    monkeypatch.delenv("AQ_APP_VERSION", raising=False)
+    response = client.get("/version")
+    assert response.status_code == 200
+    assert response.json() == {"version": "unknown"}
+
+
+@pytest.mark.contract
+def test_version_unknown_when_empty(client, monkeypatch):
+    """An empty AQ_APP_VERSION (e.g. an empty build-arg) reports 'unknown',
+    not an empty string that would render a blank 'V' in the footer."""
+    monkeypatch.setenv("AQ_APP_VERSION", "")
+    response = client.get("/version")
+    assert response.status_code == 200
+    assert response.json() == {"version": "unknown"}


### PR DESCRIPTION
Closes #229. First tracer-bullet slice of #228 (image versioning).

## What this delivers
Every built image now carries a version and self-reports it end-to-end:

- **`Dockerfile.api`** — `AQ_APP_VERSION` build arg → env var + `org.opencontainers.image.version` OCI label.
- **`docker-build.yml`** — per-merge builds stamp the **short commit SHA** into `AQ_APP_VERSION` (new `SHORT_SHA` var), so non-release images are traceable, never a bare "unknown".
- **`/version`** — hardened to return `"unknown"` for an empty *or* unset `AQ_APP_VERSION` (an empty build-arg previously yielded `""` → a blank `V` in the footer).
- **`help.html`** — the footer now `fetch("/version")` and shows `V <version>`, replacing the dead `button_status` firmware/device block (which depended on fields the endpoint never returned). Script logic only — visible markup unchanged; hardcoded value kept as a fetch-failure fallback.

## Tests (TDD, contract seam)
`tests/contract/test_version_endpoint.py` — built one-test-at-a-time:
1. `/version` returns the configured version when set
2. `/version` → `"unknown"` when unset
3. `/version` → `"unknown"` (not `""`) when empty  ← drove the endpoint change

`pytest tests/contract/test_version_endpoint.py` → 3 passed. Full collectable suite: 495 passed, 0 new failures (6 pre-existing wifi/env failures and 2 hardware-import collection errors confirmed present on clean main, unrelated to this change).

## Deferred / out of scope
- e2e footer-rendering test (`seam:e2e`) — deferred per the issue (optional/lower priority).
- The `cut-version` workflow action, version minting, and Releases are #230.

Design per ADR-016.

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)
