### PR TITLE
#230: Cut a version from the Run workflow (cut-version action)

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -5,14 +5,35 @@ on:
     branches: [main]
   workflow_dispatch:
     inputs:
-      ring_tag:
-        description: Optional ring tag to publish (dev/pilot/prod)
+      action:
+        description: "What to do"
+        required: true
+        default: cut-version
+        type: choice
+        options:
+          - cut-version
+          - assign-ring
+      version:
+        description: "cut-version: exact version (blank = auto patch-bump). assign-ring: version to deploy."
         required: false
         type: string
+      ring:
+        description: "assign-ring only: target ring"
+        required: false
+        type: choice
+        options:
+          - dev
+          - pilot
+          - prod
 
 permissions:
-  contents: read
+  contents: write
   packages: write
+
+# Serialize runs so two releases can't mint the same version concurrently.
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: false
 
 jobs:
   build-and-push:
@@ -20,19 +41,50 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: assign-ring is implemented in #231
+        if: github.event_name == 'workflow_dispatch' && inputs.action == 'assign-ring'
+        run: |
+          echo "::error::assign-ring is not available on this workflow yet (lands in #231). Use cut-version here."
+          exit 1
 
       - name: Set build vars
         run: |
           echo "REPO_LOWER=$(echo "$GITHUB_REPOSITORY" | tr '[:upper:]' '[:lower:]')" >> $GITHUB_ENV
           echo "SHORT_SHA=${GITHUB_SHA::7}" >> $GITHUB_ENV
 
+      - name: Compute version
+        id: ver
+        if: github.event_name == 'workflow_dispatch' && inputs.action == 'cut-version'
+        run: |
+          set -euo pipefail
+          latest=$(git tag --list 'v*' --sort=-v:refname | head -1 | sed 's/^v//')
+          existing=$(git tag --list 'v*' | sed 's/^v//' | paste -sd, -)
+          if [ -z "$latest" ] && [ -z "${{ inputs.version }}" ]; then
+            echo "::error::No v* tags exist yet — run the backfill (#233) first, or provide an exact version."
+            exit 1
+          fi
+          next=$(python3 -m aq_lib.version_tool --latest "${latest:-0.0.0}" --custom "${{ inputs.version }}" --existing "$existing") \
+            || { echo "::error::version computation failed (duplicate or invalid version)"; exit 1; }
+          echo "version=$next" >> "$GITHUB_OUTPUT"
+          {
+            echo "## Cut version \`v$next\`"
+            echo "- bump: ${{ inputs.version && 'custom' || 'auto patch' }}"
+            echo "- images tagged: \`$next\`"
+          } >> "$GITHUB_STEP_SUMMARY"
+
       - name: Set up QEMU
+        if: github.event_name == 'push' || inputs.action == 'cut-version'
         uses: docker/setup-qemu-action@v3
 
       - name: Set up Docker Buildx
+        if: github.event_name == 'push' || inputs.action == 'cut-version'
         uses: docker/setup-buildx-action@v3
 
       - name: Log in to GHCR
+        if: github.event_name == 'push' || inputs.action == 'cut-version'
         uses: docker/login-action@v3
         with:
           registry: ghcr.io
@@ -40,6 +92,7 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build and push backend image
+        if: github.event_name == 'push' || inputs.action == 'cut-version'
         uses: docker/build-push-action@v5
         with:
           context: .
@@ -47,13 +100,14 @@ jobs:
           platforms: linux/amd64,linux/arm64
           push: true
           build-args: |
-            AQ_APP_VERSION=${{ env.SHORT_SHA }}
+            AQ_APP_VERSION=${{ steps.ver.outputs.version || env.SHORT_SHA }}
           tags: |
             ghcr.io/${{ env.REPO_LOWER }}-api:latest
             ghcr.io/${{ env.REPO_LOWER }}-api:${{ github.sha }}
-            ${{ inputs.ring_tag && format('ghcr.io/{0}-api:{1}', env.REPO_LOWER, inputs.ring_tag) || '' }}
+            ${{ steps.ver.outputs.version && format('ghcr.io/{0}-api:{1}', env.REPO_LOWER, steps.ver.outputs.version) || '' }}
 
       - name: Build and push UI image
+        if: github.event_name == 'push' || inputs.action == 'cut-version'
         uses: docker/build-push-action@v5
         with:
           context: .
@@ -63,4 +117,16 @@ jobs:
           tags: |
             ghcr.io/${{ env.REPO_LOWER }}-ui:latest
             ghcr.io/${{ env.REPO_LOWER }}-ui:${{ github.sha }}
-            ${{ inputs.ring_tag && format('ghcr.io/{0}-ui:{1}', env.REPO_LOWER, inputs.ring_tag) || '' }}
+            ${{ steps.ver.outputs.version && format('ghcr.io/{0}-ui:{1}', env.REPO_LOWER, steps.ver.outputs.version) || '' }}
+
+      - name: Create GitHub Release
+        if: github.event_name == 'workflow_dispatch' && inputs.action == 'cut-version'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          v="v${{ steps.ver.outputs.version }}"
+          gh release create "$v" \
+            --title "$v" \
+            --notes "Release $v — image tag \`${{ steps.ver.outputs.version }}\` (commit ${{ github.sha }})." \
+            --target "${{ github.sha }}"

--- a/aq_lib/version_tool.py
+++ b/aq_lib/version_tool.py
@@ -1,0 +1,73 @@
+"""
+Version-computation helper for the cut-version release workflow.
+
+Pure logic: the workflow supplies the latest tag and the set of existing
+versions; this module decides the next version. No git / network I/O here.
+"""
+import re
+
+_VERSION_RE = re.compile(r"^\d+(\.\d+)*$")
+
+
+def is_valid_version(s):
+    """True if ``s`` is dot-separated integers (e.g. ``1.2.6.7``)."""
+    return bool(_VERSION_RE.match(s))
+
+
+def _version_key(s):
+    """Numeric sort key for a dotted version string."""
+    return tuple(int(p) for p in s.split("."))
+
+
+def sorts_below(candidate, latest):
+    """True if ``candidate`` orders earlier than ``latest`` numerically
+    (used to warn about a likely-mistyped custom version)."""
+    return _version_key(candidate) < _version_key(latest)
+
+
+def resolve_next(latest, custom, existing):
+    """Return the next version to cut.
+
+    A custom version (when given) is used verbatim; otherwise increment the
+    last segment of ``latest``.
+    """
+    if custom:
+        if not is_valid_version(custom):
+            raise ValueError(f"invalid version format: {custom!r}")
+        if custom in existing:
+            raise ValueError(f"version {custom} already exists (versions are write-once)")
+        return custom
+    parts = latest.split(".")
+    parts[-1] = str(int(parts[-1]) + 1)
+    return ".".join(parts)
+
+
+def _main(argv=None):
+    """Thin CLI for the workflow: prints the next version, or exits non-zero
+    with an error on stderr. The caller (workflow) supplies the latest tag and
+    the existing versions read from git — this module does no git I/O itself.
+    """
+    import argparse
+    import sys
+
+    parser = argparse.ArgumentParser(description="Compute the next release version.")
+    parser.add_argument("--latest", required=True, help="latest existing version, e.g. 1.2.6.6")
+    parser.add_argument("--custom", default="", help="exact version to cut (blank = auto patch-bump)")
+    parser.add_argument("--existing", default="", help="comma-separated existing versions")
+    args = parser.parse_args(argv)
+
+    existing = {v for v in args.existing.split(",") if v}
+    custom = args.custom or None
+    try:
+        version = resolve_next(args.latest, custom, existing)
+    except ValueError as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 1
+    if custom and sorts_below(custom, args.latest):
+        print(f"warning: {custom} sorts below latest {args.latest}", file=sys.stderr)
+    print(version)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(_main())

--- a/tests/unit/test_version_tool.py
+++ b/tests/unit/test_version_tool.py
@@ -1,0 +1,43 @@
+"""
+Unit tests for the version-computation helper used by the cut-version
+release workflow. Pure logic only — no git / network I/O.
+"""
+import pytest
+
+from aq_lib.version_tool import resolve_next, sorts_below
+
+
+def test_blank_custom_bumps_last_segment():
+    """With no custom version, the next version increments the last segment."""
+    assert resolve_next("1.2.6.6", None, existing=set()) == "1.2.6.7"
+
+
+def test_bump_is_length_agnostic():
+    """The last segment is bumped regardless of how many segments exist."""
+    assert resolve_next("1.2.6", None, existing=set()) == "1.2.7"
+    assert resolve_next("1.2.5.5.4", None, existing=set()) == "1.2.5.5.5"
+
+
+def test_custom_version_is_used_verbatim():
+    """A valid, novel custom version overrides the auto-bump and is used as-is."""
+    assert resolve_next("1.2.6.6", "2.0.0", existing=set()) == "2.0.0"
+
+
+def test_custom_version_that_exists_is_rejected():
+    """Versions are write-once: a custom value already in use is rejected."""
+    with pytest.raises(ValueError):
+        resolve_next("1.2.6.6", "1.2.6.5", existing={"1.2.6.5"})
+
+
+@pytest.mark.parametrize("bad", ["1.2.x", "v1.2", "1..2", "1.2."])
+def test_malformed_custom_version_is_rejected(bad):
+    """A custom version must be dot-separated integers."""
+    with pytest.raises(ValueError):
+        resolve_next("1.2.6.6", bad, existing=set())
+
+
+def test_sorts_below_detects_a_lower_custom_version():
+    """sorts_below flags a candidate that orders earlier than the latest
+    (a likely typo) while accepting a higher one."""
+    assert sorts_below("1.2.5.9", "1.2.6.6") is True
+    assert sorts_below("1.2.6.7", "1.2.6.6") is False


### PR DESCRIPTION
Closes #230. Second slice of #228 (image versioning). **Stacked on #229** (PR #227) — base is `feat/222-version-self-report`; retarget to `main` once #229 merges.

## What this delivers
On-demand version minting from the build-and-push-images "Run workflow" screen.

- **`aq_lib/version_tool.py`** — pure version logic + thin CLI:
  - blank version → auto-bump the **last segment** of the latest tag (length-agnostic: `1.2.6.6→1.2.6.7`, `1.2.6→1.2.7`, `1.2.5.5.4→…5`)
  - custom version → validated (`^\d+(\.\d+)*$`), rejected if it already exists (**write-once**), warned (not blocked) if it sorts below latest
- **`docker-build.yml`** — `action`/`version`/`ring` inputs replace `ring_tag`. `cut-version` computes the version, builds both images with `AQ_APP_VERSION` baked in, publishes `:<version>`, and creates a **GitHub Release** (build-first / release-last) under a `concurrency` lock (`contents: write`). `assign-ring` is a fail-fast guard pending #231.

## Tests (TDD, unit seam)
`tests/unit/test_version_tool.py` — six behaviors, one RED→GREEN cycle each (auto-bump, length-agnostic, custom verbatim, write-once reject, malformed reject, sorts-below warning). 9 cases pass. Full collectable suite: 504 passed, 0 new failures (same 6 pre-existing wifi/env failures + 2 hardware-import collection errors, confirmed on clean main).

The CLI was smoke-tested manually and caught a definition-order bug the import-based unit tests couldn't.

## Not unit-tested (run-verified)
The workflow orchestration (build, `gh release create`, concurrency) — verified by running, per the issue. Pure logic is fully covered.

## Rollout note
The backfill (#233) must be applied before the first real `cut-version`, or the auto-bump has no latest tag to read.

Design per ADR-016.

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)