### PR TITLE
#232: Close the loophole — version guard on promote-images

### DIFF
--- a/.github/workflows/promote-images.yml
+++ b/.github/workflows/promote-images.yml
@@ -20,6 +20,9 @@ jobs:
   promote:
     runs-on: ubuntu-latest
     steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
       - name: Set lowercase repo
         run: echo "REPO_LOWER=$(echo "$GITHUB_REPOSITORY" | tr '[:upper:]' '[:lower:]')" >> $GITHUB_ENV
 
@@ -32,6 +35,21 @@ jobs:
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
+
+      - name: Gate — source must be a built version, target a valid ring
+        run: |
+          set -euo pipefail
+          repo="ghcr.io/${{ env.REPO_LOWER }}"
+          version="${{ inputs.source_tag }}"
+          ring="${{ inputs.target_tag }}"
+          # image-exists gate: probe the registry for the :<version> image
+          if docker buildx imagetools inspect "${repo}-api:${version}" >/dev/null 2>&1; then
+            existing="$version"
+          else
+            existing=""
+          fi
+          python3 -m aq_lib.version_tool assign --version "$version" --ring "$ring" --existing "$existing" \
+            || { echo "::error::refused — source must be an existing version image (not a raw SHA/latest) and target must be dev/pilot/prod"; exit 1; }
 
       - name: Retag and push ring images
         run: |


### PR DESCRIPTION
Closes #232. Fourth slice of #228. **Stacked on #231** (PR #235) → base `feat/231-assign-ring`. Stack: #227→#234→#235→**#236-this**. Merge in order.

## What this delivers
Closes the last un-gated path to a ring. `promote-images` could retag **any** image — including a raw `:<sha>` or `:latest` — straight onto `:prod`, putting an un-versioned image on customer Sentris. This adds the **same gate** `assign-ring` uses.

- `promote-images.yml`: add `actions/checkout` (was missing) + a gate step that probes GHCR for the `:<source_tag>` image and runs `validate_ring_assignment` (via the `assign` CLI). Refuses unless the source is an **existing version** and the target is `dev`/`pilot`/`prod`. The existing retag then runs only for validated promotions.

## TDD note
**No new unit tests** — the gate logic (`validate_ring_assignment`) was fully TDD'd in #231 (4 behaviors). This slice only *wires* that tested function into `promote-images`; duplicating the tests here would be redundant. The wiring is run-verified glue. Helper suite still green (14 cases); `promote-images.yml` is valid YAML.

## Result
No remaining workflow path can push an un-versioned image onto a ring — both `assign-ring` (blessed) and `promote-images` (legacy) now gate identically.

Design per ADR-016.

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)