### PR TITLE
#233: Backfill historical versions into the version history

### DIFF
--- a/aq_lib/version_history.py
+++ b/aq_lib/version_history.py
@@ -1,0 +1,28 @@
+"""
+History logic for the version backfill.
+
+Pure functions: parse the footer version out of a help.html blob, and reduce
+a version-per-commit history to first appearances. No git I/O here — the
+backfill script supplies the commits/blobs.
+"""
+import re
+
+_VERSION_SPAN_RE = re.compile(r'id="help-version-info"[^>]*>\s*V\s*([\d.]+)')
+
+
+def extract_version(html):
+    """Return the footer version (e.g. ``1.2.6.6``) in a help.html blob, or None."""
+    match = _VERSION_SPAN_RE.search(html)
+    return match.group(1) if match else None
+
+
+def first_appearances(pairs):
+    """Given ``(commit, version)`` pairs ordered oldest->newest, return the
+    pair for the first commit at which each distinct version appears."""
+    seen = set()
+    result = []
+    for commit, version in pairs:
+        if version not in seen:
+            seen.add(version)
+            result.append((commit, version))
+    return result

--- a/scripts/backfill_version_tags.py
+++ b/scripts/backfill_version_tags.py
@@ -1,0 +1,94 @@
+#!/usr/bin/env python3
+"""
+Backfill git tags + GitHub Releases for the historical help.html versions.
+
+Dry-run by default; pass --apply to actually create tags/Releases. Reuses the
+unit-tested aq_lib.version_history for version extraction + first-appearance
+reduction; this script only does the git/gh I/O.
+
+Prereqs: run from the repo root with full git history and `gh` authenticated
+with repo write access. Must be run AND pushed BEFORE the first cut-version
+run, or the auto patch-bump has no latest tag to read.
+
+    python3 scripts/backfill_version_tags.py            # dry-run (prints the plan)
+    python3 scripts/backfill_version_tags.py --apply    # create tags + Releases
+"""
+import os
+import subprocess
+import sys
+
+# Make the repo root importable when this script is run directly.
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from aq_lib.version_history import extract_version, first_appearances
+
+HELP = "aquila_web/static/help.html"
+
+
+def collect():
+    """Return [(sha, date, version)] for commits that set a footer version, oldest->newest."""
+    log = subprocess.run(
+        ["git", "log", "--reverse", "--format=%H %cI", "--", HELP],
+        capture_output=True, text=True, check=True,
+    ).stdout.splitlines()
+    rows = []
+    for line in log:
+        if not line.strip():
+            continue
+        sha, date = line.split(" ", 1)
+        blob = subprocess.run(["git", "show", f"{sha}:{HELP}"], capture_output=True, text=True)
+        if blob.returncode != 0:
+            continue
+        version = extract_version(blob.stdout)
+        if version:
+            rows.append((sha, date, version))
+    return rows
+
+
+def plan(rows):
+    """Reduce to the first commit at which each distinct version appears."""
+    by_sha = {sha: (sha, date, version) for sha, date, version in rows}
+    pairs = [(sha, version) for sha, _date, version in rows]
+    return [by_sha[sha] for sha, _version in first_appearances(pairs)]
+
+
+def main(argv):
+    apply = "--apply" in argv
+    selected = plan(collect())
+    if not selected:
+        print("No historical versions found.")
+        return 0
+
+    print("Planned version tags/Releases (oldest -> newest):")
+    for sha, date, version in selected:
+        print(f"  v{version}  <-  {sha[:8]}  ({date})")
+
+    if not apply:
+        print("\n[dry-run] nothing created. Re-run with --apply, then: git push origin --tags")
+        return 0
+
+    for sha, date, version in selected:
+        tag = f"v{version}"
+        if subprocess.run(["git", "rev-parse", tag], capture_output=True).returncode == 0:
+            print(f"skip (exists): {tag}")
+            continue
+        subprocess.run(
+            ["git", "tag", "-a", tag, sha, "-m",
+             f"Backfilled release {version} — help.html @ {sha[:8]} (originally {date})"],
+            env={**os.environ, "GIT_COMMITTER_DATE": date}, check=True,
+        )
+        subprocess.run(["git", "push", "origin", tag], check=True)
+        subprocess.run(
+            ["gh", "release", "create", tag, "--verify-tag",
+             "--title", f"{tag} — {date.split('T')[0]} (backfilled)",
+             "--notes", f"Originally released {date} (help.html @ {sha[:8]}). Backfilled.",
+             "--latest=false"],
+            check=True,
+        )
+        print(f"created: {tag}")
+    print("Done.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/tests/unit/test_version_history.py
+++ b/tests/unit/test_version_history.py
@@ -1,0 +1,38 @@
+"""
+Unit tests for the backfill's history logic: pulling the footer version out
+of a help.html blob, and reducing a version-per-commit history to the first
+appearance of each distinct version. Pure logic — no git I/O.
+"""
+from aq_lib.version_history import extract_version, first_appearances
+
+
+def test_extract_version_from_footer_span():
+    html = '<span class="help-footer__meta" id="help-version-info">V 1.2.6.6</span>'
+    assert extract_version(html) == "1.2.6.6"
+
+
+def test_extract_version_tolerates_multiline_span():
+    """The git history has the span split across lines with indentation."""
+    html = (
+        '<span class="help-footer__meta" id="help-version-info"\n'
+        "              >V 1.2.5.5</span\n"
+        "              >"
+    )
+    assert extract_version(html) == "1.2.5.5"
+
+
+def test_extract_version_returns_none_when_absent():
+    """An old commit with no version footer yields no version."""
+    assert extract_version("<div>no footer here</div>") is None
+
+
+def test_first_appearances_keeps_first_of_each_distinct_version():
+    """Consecutive repeats collapse to the commit where the version first appeared."""
+    pairs = [("a", "1.2.5"), ("b", "1.2.5"), ("c", "1.2.6")]
+    assert first_appearances(pairs) == [("a", "1.2.5"), ("c", "1.2.6")]
+
+
+def test_first_appearances_ignores_version_reappearing_after_revert():
+    """If a version reappears later (e.g. a revert), only its first commit is kept."""
+    pairs = [("a", "1.2.6.5"), ("b", "1.2.6.6"), ("c", "1.2.6.5")]
+    assert first_appearances(pairs) == [("a", "1.2.6.5"), ("b", "1.2.6.6")]


### PR DESCRIPTION
Closes #233. Final slice of #228. **Branches off `main`** (not the cut-version stack) — the history logic is independent, so this is conflict-free and mergeable on its own.

## What this delivers
Seeds the version history "in hindsight" so the Releases page is complete.

- **`aq_lib/version_history.py`** — `extract_version(html)` (footer version, tolerant of the multiline span variant in real history) and `first_appearances(pairs)` (first commit of each distinct version, oldest→newest, ignoring reverts).
- **`scripts/backfill_version_tags.py`** — dry-run by default; `--apply` creates a **backdated annotated tag** + a **`--latest=false` GitHub Release** (real date in title/notes) per distinct historical version, oldest→newest. Reuses the tested module; git/`gh` I/O stays in the script.

> Note: written as `.py` rather than the `.sh` named in the issue — it cleanly reuses the unit-tested module instead of embedding Python in bash. Same behavior (dry-run default, `--apply`).

## Tests (TDD, unit seam)
`tests/unit/test_version_history.py` — five behaviors, one RED→GREEN each (extract normal / multiline / absent; first-appearance dedup; revert reappearance ignored). 5 cases. Full collectable suite: 497 passed, 0 new failures (same 6 pre-existing wifi/env + 2 hardware-import collection errors).

**The dry-run was smoke-tested against the real git history** — produced the full chain `v1.1.2 → v1.2.6.6` (24 versions, each at its first-appearance commit with the real date), creating nothing. The smoke test also caught a real bug (script run directly didn't have the repo root on `sys.path`).

## Rollout (manual, gated)
Running `--apply` is a deliberate human step: review the dry-run, then `--apply`, then `git push origin --tags`. **It must run before the first real `cut-version`** (#230), or the auto patch-bump has no latest tag to read. Merging this PR only delivers the tested dry-run script — it does **not** run the backfill.

Design per ADR-016.

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)