### PR TITLE
#237 builder: per-field 'Range (min - max)' validation message

### DIFF
--- a/aquila_web/static/profiles/builder.html
+++ b/aquila_web/static/profiles/builder.html
@@ -164,6 +164,6 @@
     </main>
   </div>
   <script src="/static/nav.js?v=1"></script>
-  <script src="/static/profiles/builder.js?v=4"></script>
+  <script src="/static/profiles/builder.js?v=5"></script>
 </body>
 </html>

--- a/aquila_web/static/profiles/builder.js
+++ b/aquila_web/static/profiles/builder.js
@@ -116,6 +116,16 @@
   var TIME_MIN = 1, TIME_MAX = 600, EXTENSION_TIME_MIN = 11;
   var CYCLES_MIN = 1, CYCLES_MAX = 50;
 
+  // Standardized error message naming the valid range; derived from the constants
+  // above so the text can never drift out of sync with the actual bounds.
+  function rangeMsg(min, max) {
+    return "Range (" + min + " - " + max + ")";
+  }
+  var MSG_TEMP = rangeMsg(TEMP_MIN, TEMP_MAX);
+  var MSG_TIME = rangeMsg(TIME_MIN, TIME_MAX);
+  var MSG_EXT_TIME = rangeMsg(EXTENSION_TIME_MIN, TIME_MAX);
+  var MSG_CYCLES = rangeMsg(CYCLES_MIN, CYCLES_MAX);
+
   function validTemp(v) {
     return typeof v === "number" && v >= TEMP_MIN && v <= TEMP_MAX;
   }
@@ -126,22 +136,27 @@
     return Number.isInteger(v) && v >= CYCLES_MIN && v <= CYCLES_MAX;
   }
 
-  // Ensure a hidden "Invalid Value" message exists right after the input.
-  function errorEl(input) {
+  // Ensure a hidden range-message element exists right after the input, and keep
+  // its text in sync with the field's range (default for non-range fields).
+  function errorEl(input, message) {
+    var msg = message || "Invalid Value";
     var next = input.nextElementSibling;
-    if (next && next.classList.contains("field-error")) return next;
+    if (next && next.classList.contains("field-error")) {
+      next.textContent = msg;
+      return next;
+    }
     var p = document.createElement("p");
     p.className = "field-error is-hidden";
-    p.textContent = "Invalid Value";
+    p.textContent = msg;
     input.insertAdjacentElement("afterend", p);
     return p;
   }
 
-  function setFieldValid(id, ok) {
+  function setFieldValid(id, ok, message) {
     var input = document.getElementById(id);
     if (!input) return ok;
     input.classList.toggle("is-invalid", !ok);
-    errorEl(input).classList.toggle("is-hidden", ok);
+    errorEl(input, message).classList.toggle("is-hidden", ok);
     return ok;
   }
 
@@ -173,23 +188,24 @@
       var box = document.getElementById("stage-" + key + "-enabled");
       var enabled = !box || box.checked;
       if (!enabled) {
-        setFieldValid("stage-" + key + "-temp", true);
-        setFieldValid("stage-" + key + "-time", true);
+        setFieldValid("stage-" + key + "-temp", true, MSG_TEMP);
+        setFieldValid("stage-" + key + "-time", true, MSG_TIME);
         return;
       }
-      valid = setFieldValid("stage-" + key + "-temp", validTemp(num("stage-" + key + "-temp"))) && valid;
-      valid = setFieldValid("stage-" + key + "-time", validTime(num("stage-" + key + "-time"), TIME_MIN)) && valid;
+      valid = setFieldValid("stage-" + key + "-temp", validTemp(num("stage-" + key + "-temp")), MSG_TEMP) && valid;
+      valid = setFieldValid("stage-" + key + "-time", validTime(num("stage-" + key + "-time"), TIME_MIN), MSG_TIME) && valid;
     });
 
-    valid = setFieldValid("stage-amp-cycles", validCycles(num("stage-amp-cycles"))) && valid;
+    valid = setFieldValid("stage-amp-cycles", validCycles(num("stage-amp-cycles")), MSG_CYCLES) && valid;
 
     var rows = document.querySelectorAll(".amp-substage");
     for (var i = 0; i < rows.length; i++) {
       var idx = rows[i].getAttribute("data-sub");
       var isLast = i === rows.length - 1; // extension-bearing Sub-stage
       var minTime = isLast ? EXTENSION_TIME_MIN : TIME_MIN;
-      valid = setFieldValid("stage-amp-sub-" + idx + "-temp", validTemp(num("stage-amp-sub-" + idx + "-temp"))) && valid;
-      valid = setFieldValid("stage-amp-sub-" + idx + "-time", validTime(num("stage-amp-sub-" + idx + "-time"), minTime)) && valid;
+      var timeMsg = isLast ? MSG_EXT_TIME : MSG_TIME;
+      valid = setFieldValid("stage-amp-sub-" + idx + "-temp", validTemp(num("stage-amp-sub-" + idx + "-temp")), MSG_TEMP) && valid;
+      valid = setFieldValid("stage-amp-sub-" + idx + "-time", validTime(num("stage-amp-sub-" + idx + "-time"), minTime), timeMsg) && valid;
     }
 
     return valid;

--- a/tests/e2e/test_profile_builder.py
+++ b/tests/e2e/test_profile_builder.py
@@ -313,8 +313,8 @@ def test_pristine_form_has_no_validation_errors(page, base_url):
 
 
 def test_blank_save_flags_every_enabled_field_and_blocks(page, base_url):
-    """Saving an all-blank form flags every enabled field red with 'Invalid
-    Value' and does not navigate away."""
+    """Saving an all-blank form flags every enabled field red with a range
+    message naming the valid bounds, and does not navigate away."""
     _goto_builder(page, base_url)
     page.locator("#profile-name").fill("B3 Blank")
 
@@ -324,7 +324,12 @@ def test_blank_save_flags_every_enabled_field_and_blocks(page, base_url):
         assert _is_invalid(page, sel), f"{sel} should be flagged invalid"
     errors = page.locator(".field-error:visible")
     assert errors.count() >= 1
-    assert "Invalid Value" in errors.first.inner_text()
+    texts = errors.all_inner_texts()
+    assert any("Range (25 - 100)" in t for t in texts), "temp range message"
+    assert any("Range (1 - 600)" in t for t in texts), "time range message"
+    assert any("Range (11 - 600)" in t for t in texts), "extension time range message"
+    assert any("Range (1 - 50)" in t for t in texts), "cycles range message"
+    assert not any("Invalid Value" in t for t in texts), "generic message replaced"
 
     # Blocked: still on the builder, no redirect to the Profiles list.
     assert page.url.rstrip("/").endswith("/profiles/builder")
@@ -573,7 +578,7 @@ def test_legacy_profile_opens_read_only(page, base_url):
 
 
 def test_invalid_value_message_is_red(page, base_url):
-    """The 'Invalid Value' message renders red, not the muted card-text grey."""
+    """The range error message renders red, not the muted card-text grey."""
     _goto_builder(page, base_url)
     page.locator("#save-profile-button").click()  # all-blank -> errors shown
     color = page.eval_on_selector(".field-error:visible", "el => getComputedStyle(el).color")


### PR DESCRIPTION
Closes #237 — refines B3's validation UX. Targets `updated-profiles`, so it flows into the promotion PR #218.

## What
Replaces the builder's generic `Invalid Value` with a standardized per-field message naming the valid bounds:
- temp → `Range (25 - 100)`
- time → `Range (1 - 600)`
- extension-bearing sub-stage time → `Range (11 - 600)`
- cycles → `Range (1 - 50)`

Still red, still shown only on save attempt. `setFieldValid`/`errorEl` now take a message; the strings are built by `rangeMsg(min, max)` **from the existing range constants**, so the text can't drift out of sync with the actual validation bounds.

## Tests
- e2e `test_blank_save_flags_every_enabled_field_and_blocks` now asserts each of the four `Range (...)` messages appears and the generic text is gone.
- Full builder e2e: **20/20 pass** against the real backend; red-color test still green.

## Scope
Frontend only (`builder.js` + `builder.html` cache-bust `?v=5`). No backend change, no behavior change beyond the message text.

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)
