### PR TITLE
feat(device): generate keypair + CSR with CN = Pi serial (#239)

### DIFF
--- a/aq_lib/device_csr.py
+++ b/aq_lib/device_csr.py
@@ -1,0 +1,82 @@
+"""On-device keypair + CSR generation for Sentri enrollment (issue #239).
+
+A Sentri generates its own keypair on-device and a CSR whose Subject CN is its
+Device ID (the Pi hardware serial). The private key never leaves the Pi. The CSR
+is later submitted to acorn-ca ``POST /enroll`` (operator-mediated, #240).
+"""
+import os
+import sys
+
+from cryptography import x509
+from cryptography.hazmat.primitives import hashes, serialization
+from cryptography.hazmat.primitives.asymmetric import ec
+from cryptography.x509.oid import NameOID
+
+from aq_lib.device_id import read_rpi_serial
+
+
+def enrollment_device_id(cpuinfo_path: str = "/proc/cpuinfo") -> str:
+    """The Device ID to enroll under: the Pi hardware serial.
+
+    This is deliberately the serial, not the hostname — the cert CN must equal
+    what the platform treats as the Device ID (CONTEXT.md). There is no hostname
+    fallback: a device with no stable serial must not silently enroll under a
+    mutable identity.
+    """
+    serial = read_rpi_serial(cpuinfo_path)
+    if not serial:
+        raise RuntimeError(
+            f"no Raspberry Pi hardware serial in {cpuinfo_path}; "
+            "cannot derive a stable Device ID for enrollment"
+        )
+    return serial
+
+
+def generate_device_csr(device_id: str) -> tuple[bytes, bytes]:
+    """Generate a fresh device keypair and a CSR with Subject ``CN=device_id``.
+
+    Returns ``(private_key_pem, csr_pem)``.
+    """
+    key = ec.generate_private_key(ec.SECP256R1())
+    csr = x509.CertificateSigningRequestBuilder().subject_name(
+        x509.Name([x509.NameAttribute(NameOID.COMMON_NAME, device_id)])
+    ).sign(key, hashes.SHA256())
+
+    key_pem = key.private_bytes(
+        encoding=serialization.Encoding.PEM,
+        format=serialization.PrivateFormat.PKCS8,
+        encryption_algorithm=serialization.NoEncryption(),
+    )
+    csr_pem = csr.public_bytes(serialization.Encoding.PEM)
+    return key_pem, csr_pem
+
+
+KEY_FILENAME = "device.key"
+CSR_FILENAME = "device.csr"
+
+
+def write_device_csr(out_dir: str, cpuinfo_path: str = "/proc/cpuinfo") -> str:
+    """Generate the device keypair + CSR on-device and write them to ``out_dir``.
+
+    Resolves the Device ID from the Pi serial, writes the private key
+    owner-only (``0600``) and the CSR alongside it, and returns the Device ID
+    so the caller (the enroll step, #240) can submit the CSR under that identity.
+    """
+    device_id = enrollment_device_id(cpuinfo_path)
+    key_pem, csr_pem = generate_device_csr(device_id)
+
+    key_path = os.path.join(out_dir, KEY_FILENAME)
+    csr_path = os.path.join(out_dir, CSR_FILENAME)
+    # Create the key file owner-only from the start — never world-readable, even
+    # for the instant between write and chmod.
+    fd = os.open(key_path, os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
+    with os.fdopen(fd, "wb") as f:
+        f.write(key_pem)
+    with open(csr_path, "wb") as f:
+        f.write(csr_pem)
+    return device_id
+
+
+if __name__ == "__main__":  # pragma: no cover - on-device entrypoint
+    out = sys.argv[1] if len(sys.argv) > 1 else "."
+    print(write_device_csr(out))

--- a/requirements-backend.txt
+++ b/requirements-backend.txt
@@ -11,3 +11,4 @@ RPi.GPIO
 spidev
 smbus2
 simple-rpc
+cryptography

--- a/scripts/deploy/deployment2.sh
+++ b/scripts/deploy/deployment2.sh
@@ -317,9 +317,19 @@ prompt_if_unset AQ_SYNC_API_KEY   "Enter AQ_SYNC_API_KEY (fleet API key, leave b
 
 WATCHTOWER_TOKEN="${WATCHTOWER_TOKEN:-$(openssl rand -hex 32)}"
 
+# Device ID is the Pi hardware serial (CONTEXT.md / ADR-014), NOT the hostname:
+# the Device Certificate's CN must equal what the platform treats as the Device
+# ID. Mirrors aq_lib/device_id.read_rpi_serial (the host has no app deps until
+# images are pulled in Phase 9). Fail loud rather than enrol under a mutable id.
+DEVICE_ID="$(awk -F': ' '/^Serial/ {print $2}' /proc/cpuinfo | tr -d '[:space:]')"
+if [[ -z "${DEVICE_ID}" || "${DEVICE_ID}" =~ ^0+$ ]]; then
+    echo "  ✗ No Raspberry Pi hardware serial in /proc/cpuinfo — cannot derive Device ID" >&2
+    exit 1
+fi
+
 # device.env
 cat > /opt/aquila/config/device.env <<EOF
-DEVICE_ID=${DEVICE_HOSTNAME}
+DEVICE_ID=${DEVICE_ID}
 DEVICE_HOSTNAME=${DEVICE_HOSTNAME}
 IMAGE_TAG=${IMAGE_TAG}
 GHCR_REPO=${GHCR_REPO}
@@ -580,11 +590,24 @@ curl -fsSL \
     -o /opt/fleet/update.sh
 chmod +x /opt/fleet/update.sh
 
+# Generate the device keypair + CSR on-device (CN = Device ID = Pi serial). The
+# private key is written owner-only (0600) and never leaves the Pi; only the CSR
+# is later submitted to acorn-ca /enroll (#240). Runs in the app image, which
+# carries the crypto deps; the host does not. The container reads the same
+# /proc/cpuinfo serial, so its CN matches DEVICE_ID written above.
+docker run --rm \
+    -v /opt/aquila/config:/config \
+    -v /proc/cpuinfo:/proc/cpuinfo:ro \
+    "ghcr.io/${GHCR_REPO}-api:${IMAGE_TAG}" \
+    python -m aq_lib.device_csr /config
+
 run_test "docker-compose.yml downloaded"   "test -f /opt/fleet/docker-compose.yml"
 run_test "compose file non-empty"          "test -s /opt/fleet/docker-compose.yml"
 run_test "backend image pulled"            "docker images | grep -q 'aquilla-main-api'"
 run_test "ui image pulled"                 "docker images | grep -q 'aquilla-main-ui'"
 run_test "update.sh exists and executable" "test -x /opt/fleet/update.sh"
+run_test "device CSR generated"            "test -s /opt/aquila/config/device.csr"
+run_test "device key owner-only (0600)"    "test \"\$(stat -c '%a' /opt/aquila/config/device.key)\" = 600"
 
 phase_pass "docker-compose.yml downloaded, all images pulled"
 

--- a/specs/prd/kms-ca-enrollment-mtls-s3-verification-prd.md
+++ b/specs/prd/kms-ca-enrollment-mtls-s3-verification-prd.md
@@ -1,112 +1,177 @@
-# PRD: KMS-backed CA — password-gated device enrollment in deployment + mTLS→S3 verification slice
+# PRD: Device-side enrollment + mTLS cert verification slice (client of acorn-ca)
 
 > **Tracking issue:** [#176](https://github.com/AcornGenetics/aquilla-main/issues/176)
-> **Revision 1 — 2026-06-17**
+> **Revision 2 — 2026-06-26** (supersedes Rev 1, 2026-06-17)
 >
-> **Tracer-bullet vertical slice** carved from `specs/Data-pipline/device-edge-mtls-migration-prd.md`.
-> Anchored by **ADR-014** (device PKI: self-managed KMS-backed CA, on-device keygen, operator-authenticated enrollment) and **ADR-013** (device auth → mTLS; truststore in S3, consumed by API Gateway mTLS). Glossary in `CONTEXT.md` (Sentri, Device ID, Device Certificate, Ingest Endpoint, Sync, Event).
+> **What changed in Rev 2 — the six-repo split.** Rev 1 was written when aquilla-main
+> was a monolith: it had aquilla-main *bootstrap the CA*, *host the signing path*, and
+> *enable mTLS on its own SAM `HttpApi`* (`infra/template.yaml`), gated by an
+> **enrollment password**. That server side has since moved out and is **built and proven live**:
+> - **acorn-ca** owns the CA (KMS key + S3 truststore), the **`POST /enroll`** endpoint
+>   (operator-authenticated via **AWS SigV4/IAM**, *not* a password — ADR-0001), and the
+>   **`POST /renew`** mTLS endpoint.
+> - **acorn-analytics** owns the **Ingest Endpoint** (the Sync target) — *not yet built*.
 >
-> **Goal of this slice:** prove the whole chain end-to-end on real infrastructure — *KMS-backed CA exists → a Sentri enrolls during deployment (gated by an operator password) → the Sentri presents its Device Certificate to an mTLS gateway → the Event lands in S3.* It is the smallest runnable proof that ADR-014's PKI works before the broader renewal/Aurora/decommission work is built.
+> So aquilla-main is now **client-only**: it hosts **no endpoints**. This slice is the
+> on-device code that *calls out* to acorn-ca's endpoints — generate a keypair + CSR on
+> the Pi, get it enrolled, install the cert, present it over mTLS, and swap Sync off the
+> Fleet API Key. Anchored by **ADR-014** (device PKI) and **ADR-013** (device auth → mTLS).
+> Glossary in `CONTEXT.md`. acorn-ca's contract is in its `CONTEXT.md` + ADRs 0001–0006.
 
 ## Problem Statement
 
-I have ADR-014 (a self-managed, KMS-backed CA issuing per-device Device Certificates) on paper, but nothing that proves it works. Today a Sentri authenticates to the Ingest Endpoint with a shared Fleet API Key (`x-api-key`) that isn't even enforced, and my deployment script (`deployment2.sh`) just prompts for that shared key and writes it to `device.env`. There is:
+ADR-014's PKI is now real *on the CA side* — acorn-ca stands up a KMS-backed CA, issues
+short-lived per-device certificates via `POST /enroll` (operator SigV4), and renews them via
+`POST /renew` (mTLS). All of that is deployed and proven end-to-end.
 
-- no Certificate Authority actually standing (no KMS key, no root cert, no truststore in S3),
-- no way for a Sentri to *get* a certificate when I deploy it — and no gate stopping just anyone from minting one,
-- no demonstration that a certificate, once on a device, actually authenticates a real upload all the way into S3.
+But **no Sentri can use it yet.** On the device today:
 
-Until I can run that chain from nothing and watch an Event land in the bucket because of the certificate, I can't trust the design or build the rest of the migration on top of it.
+- there is no on-Pi step to **generate a keypair + CSR** (`CN=<Device ID>`) during deployment,
+- there is no step to **submit that CSR to acorn-ca `/enroll`** and **install** the returned
+  certificate + key,
+- `deployment2.sh` still prompts for and writes the retired shared **`AQ_SYNC_API_KEY`**, and
+  `aquila_web/sync.py` still authenticates Sync with an `x-api-key` header instead of a client
+  certificate,
+- there is no way to **verify** that a freshly enrolled certificate actually authenticates over
+  mTLS.
+
+Until a deployed Sentri can get a certificate from acorn-ca and prove it authenticates over
+mTLS, the device half of ADR-014 is unproven and the rest of the migration (renewal, Sync
+cutover, decommission) has nothing to build on.
 
 ## Solution
 
-From my (the operator's) and the fleet's perspective:
+From the operator's and the fleet's perspective — **device side only**:
 
-- **A CA exists, once, with one command.** A one-time bootstrap creates a non-extractable KMS asymmetric key, builds the self-signed root certificate by signing it through the KMS `Sign` API, and publishes the root (the **truststore**) to the S3 location the gateway's mTLS validation reads. The CA private key never exists outside the KMS HSM.
-- **Deploying a Sentri gets it a certificate.** When I run `deployment2.sh`, the Sentri generates its own keypair on-device and a CSR with `CN=<Device ID>`, I am prompted for an **enrollment password**, and the signing path issues a Device Certificate only if that password is valid. The certificate and key land on the Pi `chmod 600`; the device's private key never leaves the Pi and the Pi never holds a credential that could mint *other* certificates.
-- **The shared Fleet API Key is gone.** Deployment stops prompting for / writing `AQ_SYNC_API_KEY`; the Sentri presents its Device Certificate on Sync instead of an `x-api-key` header.
-- **I can verify it works.** A test/verification script run from the device presents the Device Certificate to the **mTLS Ingest Endpoint** and POSTs a sample Event; I can then see that exact Event archived as an object in the raw-events S3 bucket. A bad/absent/wrong-CA certificate fails the handshake and nothing lands. That is the proof.
+- **Deploying a Sentri gets it a certificate.** During `deployment2.sh` the Sentri generates
+  its own keypair on-device and a CSR with `CN=<Device ID>` (Device ID = the Pi hardware serial,
+  per `aq_lib/device_id.py` and `CONTEXT.md`). The CSR is submitted to acorn-ca **`POST /enroll`**.
+  The returned certificate and the device key land on the Pi `chmod 600`, with their paths
+  recorded in `device.env`. The device's private key never leaves the Pi.
+- **The gate is the operator's AWS identity, not a password.** `/enroll` is **SigV4/IAM**-authorized
+  (acorn-ca, ADR-0001), so the enroll call must be made by someone holding operator AWS credentials.
+  The Pi holds **no** AWS credentials and **no** credential that could mint *other* certificates —
+  it only ever holds its own keypair + leaf. (See *Implementation Decisions → Where the enroll call
+  runs* for the operator-mediated flow this implies.)
+- **The shared Fleet API Key is gone.** Deployment stops prompting for / writing `AQ_SYNC_API_KEY`;
+  `sync.py` drops the `x-api-key` header and presents the Device Certificate (client cert + key) on
+  the Sync POST instead.
+- **I can verify the certificate works.** A device-side verification script presents the Device
+  Certificate over **mTLS to acorn-ca `POST /renew`** and confirms the handshake succeeds (HTTP 200).
+  A missing / expired / wrong-CA certificate fails the TLS handshake and gets nothing. That is the
+  proof the certificate is CA-valid and that mTLS is actually enforced. *(Proving a real **Event**
+  lands in storage is the acorn-analytics Ingest Endpoint's job and waits on that edge — see Out of
+  Scope. `/renew` is the available, production-shaped mTLS target today.)*
 
 ## User Stories
 
-1. As an operator, I want a one-command CA bootstrap, so that I can stand up the Certificate Authority without hand-assembling keys.
-2. As a security-conscious operator, I want the CA private key created as a non-extractable KMS asymmetric key, so that the root signing key can never be exported or leaked.
-3. As an operator, I want the self-signed root certificate produced by signing through the KMS `Sign` API, so that the root is bound to the KMS key without the private key ever leaving the HSM.
-4. As an operator, I want the root certificate (truststore) published to the S3 location the gateway reads, so that API Gateway mTLS can validate device certificates against it.
-5. As an operator, I want the bootstrap to be idempotent / safe to re-run, so that re-running it does not silently create a second CA or clobber the live truststore.
-6. As a Sentri, I want to generate my own keypair on-device during deployment, so that my private key never leaves the Pi.
-7. As a Sentri, I want to build a CSR with `CN=<Device ID>`, so that my transport identity equals my data-model identity (the Pi hardware serial).
-8. As an operator, I want `deployment2.sh` to prompt me for an enrollment password (masked input), so that obtaining a certificate requires my authorization at provisioning time.
-9. As the signing path, I want to verify the enrollment password before signing a CSR, so that an unauthenticated caller cannot mint a Device Certificate.
-10. As the signing path, I want to sign the device CSR through the KMS `Sign` API, so that issuance uses the same HSM-held CA key as the root.
-11. As the signing path, I want to set the certificate's `CN` from the CSR's `CN` (the Device ID) and a short validity window, so that issued certificates carry the right identity and posture.
-12. As a Sentri, I want my certificate and private key written `chmod 600`, so that they are not world-readable on the device.
-13. As a Sentri, I want the certificate and key paths recorded in `device.env`, so that the Sync client and verification script can find them.
-14. As an operator, I want enrollment to fail loudly (non-zero exit, clear message) on a wrong password or signing error, so that a deployment never silently completes without a valid certificate.
-15. As an operator, I want `deployment2.sh` to stop prompting for and writing `AQ_SYNC_API_KEY`, so that the retired shared-key model is removed from new deployments.
-16. As a Sentri, I want to present my Device Certificate (client cert + key) on the Sync POST instead of an `x-api-key` header, so that I authenticate by mTLS.
-17. As an operator, I want the Ingest Endpoint gateway configured for mTLS with the S3 truststore, so that only certificates signed by my CA complete the handshake.
-18. As an operator, I want a verification script I can run from the device, so that I can confirm the certificate authenticates a real upload end-to-end.
-19. As an operator, I want the verification script to POST a sample Event over mTLS and then confirm the object exists in the raw-events S3 bucket, so that I have proof the chain works into storage, not just at the handshake.
-20. As an operator, I want the verification to fail when no certificate, an expired certificate, or a wrong-CA certificate is presented, so that I know the gateway is actually enforcing mTLS and not accepting anything.
-21. As a developer, I want the CSR-subject construction (`CN=Device ID`) extracted as pure logic, so that it is unit-testable without hardware.
-22. As a developer, I want the signing logic tested against a stubbed KMS, so that "valid password → signs; bad password → refuses" is verified without real AWS calls.
-23. As a developer, I want the device Sync auth change covered by the existing Sync test seam, so that "certificate sent, no `x-api-key`" is verified automatically.
-24. As a developer, I want the gateway mTLS + truststore configuration asserted against the infra template, so that a redeploy can't silently drop mTLS enforcement.
-25. As an operator, I want the existing raw-events S3 bucket and archiver path reused for verification, so that the slice proves the real ingest-to-storage route rather than a throwaway one.
+1. As a Sentri, I want to generate my own keypair on-device during deployment, so that my private key never leaves the Pi.
+2. As a Sentri, I want to build a CSR with `CN=<Device ID>` (the Pi hardware serial), so that my transport identity equals my data-model identity.
+3. As an operator, I want `deployment2.sh` to submit the CSR to acorn-ca `POST /enroll` using my AWS credentials (SigV4), so that issuance is gated by my AWS identity and no on-device secret can mint certificates.
+4. As a Sentri, I want my returned certificate and private key written `chmod 600`, so that they are not world-readable on the device.
+5. As a Sentri, I want the certificate and key paths recorded in `device.env`, so that the Sync client and verification script can find them.
+6. As an operator, I want enrollment to fail loudly (non-zero exit, clear message) on an auth or signing error, so that a deployment never silently completes without a valid certificate.
+7. As an operator, I want `deployment2.sh` to stop prompting for and writing `AQ_SYNC_API_KEY`, so that the retired shared-key model is removed from new deployments.
+8. As a Sentri, I want to present my Device Certificate (client cert + key) on the Sync POST instead of an `x-api-key` header, so that I authenticate by mTLS.
+9. As an operator, I want a device-side verification script that presents the certificate over mTLS to acorn-ca `/renew`, so that I can confirm the certificate authenticates and mTLS is enforced.
+10. As an operator, I want the verification to fail when no certificate, an expired certificate, or a wrong-CA certificate is presented, so that I know the gateway is actually enforcing mTLS and not accepting anything.
+11. As a developer, I want the CSR-subject construction (`CN=Device ID`) extracted as pure logic, so that it is unit-testable without hardware.
+12. As a developer, I want the device Sync auth change covered by the existing Sync test seam, so that "certificate sent, no `x-api-key`" is verified automatically.
+13. As a developer, I want the Device ID derivation reconciled to the Pi hardware serial (not the hostname) wherever the CSR `CN` is built, so that the device's `CN` matches what the platform treats as the Device ID.
 
 ## Implementation Decisions
 
-### CA bootstrap (self-managed, KMS-backed — ADR-014)
-- A one-time bootstrap (a `scripts/` utility) creates a **KMS asymmetric key** (usage `SIGN_VERIFY`, e.g. RSA/ECC), reads its **public key**, and assembles a **self-signed root certificate** whose signature is produced via the KMS `Sign` API (the private key is non-extractable and never leaves the HSM).
-- The root certificate (the **truststore** / CA public cert) is uploaded to the **S3 location the gateway's mTLS validation reads**. The KMS private key is the single root of trust; no raw CA key file ever exists on disk.
-- Bootstrap is **idempotent / guarded**: re-running detects an existing CA key + truststore and refuses to silently replace them.
+### Where the enroll call runs (operator-mediated) — *the key Rev-2 design point*
+`/enroll` is SigV4-authorized, and **the Pi has no AWS credentials by design** — so the Pi cannot
+call `/enroll` itself. Enrollment is therefore **operator-mediated**: the Pi produces the
+keypair + CSR, the **operator** (running with their AWS credentials) submits the CSR to `/enroll`,
+and the returned certificate is installed back onto the Pi. Concretely, `deployment2.sh` is run by
+the operator during provisioning in a context where AWS credentials are available (e.g. the operator's
+session/host), generating the CSR and orchestrating the enroll → install. **The private key never
+leaves the Pi and AWS credentials never land on the Pi.** *(This is the central change from Rev 1's
+password model, which the Pi could complete unattended — confirm before building.)*
 
-### Certificate signing path (operator-authenticated — "enrollment password")
-- A signing function takes a **CSR + an enrollment token/password**, **verifies the password first**, and only then signs the CSR via KMS `Sign`, returning a Device Certificate with `CN` carried from the CSR and a short validity window.
-- A wrong/absent password is rejected without signing. (Where the signing path is hosted — small Lambda vs. local invocation during this slice — is an implementation detail; the contract is *password-gated, KMS-signed issuance*. Auto-renewal and a cert-authenticated renewal endpoint are **out of scope** here — see Out of Scope.)
+### On-device keygen + CSR (`deployment2.sh`)
+- The Sentri generates its own keypair and a CSR with `CN=<Device ID>`. **Device ID is the Pi hardware
+  serial** (`aq_lib/device_id.py` → `/proc/cpuinfo`), *not* the hostname. `deployment2.sh` currently
+  derives `DEVICE_ID` from the hostname — reconcile it to the serial so the CSR `CN` matches the
+  platform identity (acorn-ca treats the cert `CN` as the Device ID).
+- The pure logic (CSR subject construction = `CN=Device ID`) is extracted into Python so it is
+  unit-testable; the on-device keygen/install steps are host-dependent.
 
-### Device enrollment in `deployment2.sh`
-- During deployment the Sentri **generates its own keypair** and a **CSR with `CN=<Device ID>`** (Device ID = the Pi hardware serial per `CONTEXT.md`; the script already establishes a `DEVICE_ID`).
-- `deployment2.sh` prompts for the **enrollment password using its existing masked-prompt helper** (`prompt_if_unset … true` / `read -rsp`), submits CSR + password to the signing path, and on success writes the **certificate and key `chmod 600`** and records their paths in `device.env`.
-- The script **stops prompting for and writing `AQ_SYNC_API_KEY`**; the Fleet API Key is removed from new deployments. Enrollment failure (bad password / signing error) **exits non-zero with a clear message** — no silent completion.
-- Pure logic (CSR subject construction = `CN=Device ID`) is extracted into Python so it is unit-testable; the on-device keygen/install steps are host-dependent.
+### Enroll + install
+- Submit CSR to acorn-ca **`POST /enroll`** with SigV4. On success, write the returned certificate and
+  the device key `chmod 600` and record their paths in `device.env`. Enrollment failure (auth error,
+  signing error, revoked Device ID → 403) **exits non-zero with a clear message** — no silent completion.
+- Stop prompting for / writing `AQ_SYNC_API_KEY`; remove the Fleet API Key from new deployments.
 
 ### Device Sync auth (`aquila_web/sync.py`)
-- The Sync client **drops the `x-api-key` header** and presents the **client certificate + key** on the POST (`cert=(client_cert, client_key)` style). Certificate/key paths come from `device.env`. The Event payload shape is **unchanged** (still keyed on `device_id`).
-
-### mTLS gateway → S3 (reuse existing SAM ingest path)
-- Enable **mTLS on the existing `AWS::Serverless::HttpApi` Ingest Endpoint** (`infra/template.yaml`) with the **S3 truststore** from bootstrap; disable the default execute-api endpoint so only the mTLS-validated path is reachable. The existing **`S3ArchiverFunction` → `RawEventsBucket` (`sentri-raw-events-${AccountId}`)** route is **reused** as the ingest-to-storage path under test.
-- This is the production-shaped verification path (API Gateway mTLS per ADR-013), not IAM Roles Anywhere.
+- The Sync client **drops the `x-api-key` header** and presents the **client certificate + key** on the
+  POST (`cert=(client_cert, client_key)` style). Certificate/key paths come from `device.env`. The Event
+  payload shape is **unchanged** (still keyed on `device_id`). *(The live Sync target is acorn-analytics'
+  Ingest Endpoint, which is not built yet — this slice lands the client-side auth change and unit-tests
+  it; the live Sync-to-storage acceptance is gated on that edge.)*
 
 ### Verification script
-- A device-side script loads the Device Certificate from `device.env`, **POSTs a sample Event over mTLS** to the Ingest Endpoint, then **confirms the resulting object exists in `RawEventsBucket`**. Negative cases (no cert / expired / wrong-CA) must fail the handshake and land nothing.
+- A device-side script loads the Device Certificate from `device.env` and **POSTs over mTLS to acorn-ca
+  `POST /renew`**, asserting a successful handshake (HTTP 200). Negative cases (no cert / expired /
+  wrong-CA) must fail the handshake and return nothing. This is the available, production-shaped mTLS
+  proof until the acorn-analytics ingest edge exists.
 
 ## Testing Decisions
 
-Good tests assert **external behavior at the highest available seam** — what the device puts on the wire, what the signing path returns for good vs. bad input, and what infra resources exist — not internal call order. Mock the network boundary (`requests.post`) and AWS boundaries (botocore `Stubber` / `tmp_path`) rather than reaching for real services in unit tests.
+Assert **external behavior at the highest available seam** — what the device puts on the wire, and the
+pure CSR-subject logic — not internal call order. Mock the network boundary (`requests.post`) rather
+than reaching real services in unit tests.
 
-- **Device Sync auth — existing seam (`POST /sync/flush` → `aquila_web.sync`).** Prior art: `tests/unit/test_background_sync.py` (monkeypatches `aquila_web.sync.requests.post`, captures call kwargs). Replace the `x-api-key` assertion with: the client-certificate tuple is passed and **no** `x-api-key` header is present. Keep "no endpoint → synced 0" and "network error swallowed, events stay pending" green.
-- **CSR subject construction.** Pure-logic unit test (`unit_tests/`): given a Device ID, the CSR subject is `CN=<Device ID>`. Prior art: `unit_tests/test_optics_history.py`, `tests/unit/test_device_id.py`.
-- **CA bootstrap + signing.** Unit test the cert-assembly + signing logic against a **stubbed KMS** (botocore `Stubber`): root cert is signed via KMS `Sign`; a device CSR with a valid enrollment password is signed and carries `CN` from the CSR; a **wrong/absent password is refused without a `Sign` call**; re-running bootstrap against an existing CA refuses to clobber. Prior art for handler/infra-style tests: `tests/infra/` (`test_s3_archiver.py`, `test_ingest_handler.py`).
-- **Gateway mTLS + truststore.** Light infra assertion: parse `infra/template.yaml` and assert the HttpApi has mTLS enabled, references the S3 truststore, disables the default execute-api endpoint, and that the `S3ArchiverFunction` → `RawEventsBucket` route is intact. Prior art: `tests/infra/conftest.py` template-parsing pattern.
-- **Enrollment / on-device keygen.** Host-dependent (keygen, install, `deployment2.sh`) — mark `@pytest.mark.hardware` with a documented "why not CI" note per the repo testing rules; cover the extractable pure logic (CSR subject) above.
-- **End-to-end acceptance (the real proof).** After `sam deploy` + bootstrap: from a Sentri with an enrolled certificate, the verification script POSTs a sample Event over mTLS and the matching object appears in `RawEventsBucket`; presenting no / expired / wrong-CA certificate fails the handshake and lands nothing.
+- **Device Sync auth — existing seam (`POST /sync/flush` → `aquila_web.sync`).** Prior art:
+  `tests/unit/test_background_sync.py` (monkeypatches `aquila_web.sync.requests.post`, captures call
+  kwargs). Replace the `x-api-key` assertion with: the client-certificate tuple is passed and **no**
+  `x-api-key` header is present. Keep "no endpoint → synced 0" and "network error swallowed, events
+  stay pending" green.
+- **CSR subject construction.** Pure-logic unit test (`unit_tests/`): given a Device ID, the CSR subject
+  is `CN=<Device ID>`. Prior art: `tests/unit/test_device_id.py`.
+- **Enrollment / on-device keygen + install.** Host-dependent (keygen, install, `deployment2.sh`) — mark
+  `@pytest.mark.hardware` with a documented "why not CI" note per the repo testing rules; cover the
+  extractable pure logic (CSR subject, Device ID = serial) above.
+- **End-to-end acceptance (the real proof).** Against a **live acorn-ca**: from a Sentri enrolled via
+  `/enroll`, the verification script presents the cert over mTLS to `/renew` and gets HTTP 200;
+  presenting no / expired / wrong-CA certificate fails the handshake.
+- **CA bootstrap / signing / truststore / gateway-mTLS tests are no longer in this repo** — they live in
+  **acorn-ca** (which owns and tests them). Do not re-create them here.
 
 ## Out of Scope
 
-Owned by the broader migration PRD (`specs/Data-pipline/device-edge-mtls-migration-prd.md`) or the **Sentri Analytics Platform** (`Acorn/sentri-analytics`), **not** this slice:
+Owned by **acorn-ca**, **acorn-analytics**, or later aquilla-main slices — **not** this slice:
 
-- **Automatic certificate renewal**, the cert-authenticated renewal endpoint (`POST /sync/cert/renew`), the on-device renewal daemon, atomic mid-renewal swap, and the offline-too-long re-enrollment path. This slice is **enroll-once + verify**; renewal is the next slice.
-- Revocation-by-non-renewal mechanics beyond the short validity window itself.
-- The full production **Sentri Analytics Platform edge** (VPC Link, internal ALB, ASG, the Node `/ingest` app, regional custom domain, rate-limit store). This slice reuses the existing SAM `HttpApi` + `S3ArchiverFunction` + `RawEventsBucket` purely to prove the certificate chain.
-- **Aurora connectivity** (peering, return route, `DBSecurityGroup` ingress, `sentri_readonly` role) — independent track in the broader PRD.
-- **Decommissioning** the old SAM ingest stack and the **big-bang fleet cutover**.
-- Backfill-tool auth change; any Event payload schema change (this slice is auth-only); any dev-fleet certificate isolation (one prod fleet, one CA).
+- **The entire CA + signing side** — KMS key, root cert, truststore publish (C1), `/enroll`, `/renew`,
+  the revocation feed (C2), enrollment-password logic. Owned and proven in **acorn-ca**.
+- **The Ingest Endpoint and the live Sync-to-storage proof** (mTLS gateway → S3/RDS) — owned by
+  **acorn-analytics** (ADR-015), not yet built. This slice verifies the certificate against acorn-ca
+  `/renew`; the full Event-into-storage acceptance follows once that edge exists.
+- **Automatic certificate renewal** — the on-device renewal daemon (daily attempt, atomic swap when
+  <3 days remain) and the offline-too-long **re-enrollment** fallback. Next aquilla-main slice.
+- **Decommissioning** the old SAM ingest stack and the big-bang fleet cutover.
+- Any Event payload schema change (this slice is auth-only); backfill-tool auth change; any dev-fleet
+  certificate isolation (one prod fleet, one CA).
+
+## Dependencies / Preconditions
+
+- **acorn-ca deployed and live** — `/enroll` + `/renew` reachable. *(Currently neither dev nor prod is
+  deployed; only the CI/CD stack exists. A dev redeploy or the prod deploy (#25) is required before the
+  acceptance test can run. Code + unit tests can be built now against mocks.)*
+- **Operator AWS credentials** available wherever the enroll call is made (for SigV4).
+- The `renew.cloud.acorngenetics.com` mTLS domain (prod) or the dev equivalent, depending on which
+  acorn-ca environment is live.
 
 ## Further Notes
 
-- This is intentionally the **smallest end-to-end runnable proof** of ADR-014: CA → enrollment (password-gated) → certificate on device → mTLS → S3. Everything in scope can be built and unit-tested now against mocks; the **acceptance test** needs the bootstrapped CA, the mTLS-enabled gateway, and one enrolled Sentri.
-- The short-validity posture is acceptable here because the slice doesn't yet auto-renew — certificates are issued fresh for the verification run. Renewal is deferred to the next slice by design.
-- The KMS-backed CA eliminates the ~$400/mo ACM Private CA cost while keeping HSM-grade key custody (ADR-014); long-lived certs + a deny-list remain the documented fallback if the eventual auto-renewal proves fragile.
-- Device ID note: `deployment2.sh` currently derives `DEVICE_ID` from the hostname; `CONTEXT.md`/ADR-014 define Device ID as the Pi hardware serial. Reconciling the two is a small clarification to settle during implementation (the CSR `CN` must equal whatever the platform treats as the Device ID).
+- This is the **smallest end-to-end runnable proof** of the *device half* of ADR-014 in the post-split
+  world: keypair/CSR on the Pi → operator-mediated enroll against acorn-ca → certificate installed →
+  mTLS handshake proven. Everything in scope can be built and unit-tested now against mocks; the
+  **acceptance test** needs a live acorn-ca.
+- BUILD.md sequences **acorn-analytics' ingest edge before** aquilla-main's device side precisely because
+  the device's ultimate Sync target lives there. Building the "get a cert + verify via `/renew`" half now
+  is fine and de-risks the device code; the live Sync proof waits on that edge.
+- The short-validity posture is acceptable here because this slice doesn't auto-renew — certificates are
+  issued fresh for the verification run. Renewal is the next slice by design.

--- a/unit_tests/test_device_csr.py
+++ b/unit_tests/test_device_csr.py
@@ -1,0 +1,93 @@
+"""
+Unit tests for on-device keypair + CSR generation (aq_lib/device_csr.py).
+
+Pure logic, no hardware: a Sentri generates its own keypair and a CSR whose
+Subject CN is its Device ID (the Pi hardware serial). Issue #239.
+"""
+from cryptography import x509
+from cryptography.hazmat.primitives import serialization
+from cryptography.hazmat.primitives.asymmetric import ec
+from cryptography.x509.oid import NameOID
+
+import pytest
+
+from aq_lib.device_csr import (
+    enrollment_device_id,
+    generate_device_csr,
+    write_device_csr,
+)
+
+CPUINFO_WITH_SERIAL = (
+    "Hardware\t: BCM2711\n"
+    "Serial\t\t: 10000000a6b7d43e\n"
+    "Model\t: Raspberry Pi 4 Model B Rev 1.5\n"
+)
+
+
+class TestGenerateDeviceCsr:
+    def test_csr_subject_cn_is_the_device_id(self):
+        device_id = "10000000a6b7d43e"
+        _key_pem, csr_pem = generate_device_csr(device_id)
+
+        csr = x509.load_pem_x509_csr(csr_pem)
+        (cn,) = csr.subject.get_attributes_for_oid(NameOID.COMMON_NAME)
+        assert cn.value == device_id
+
+    def test_csr_is_signed_by_its_own_key(self):
+        # The CSR proves the device holds the private key for the public key it
+        # presents — a CA can trust the CSR came from the device it names.
+        _key_pem, csr_pem = generate_device_csr("10000000a6b7d43e")
+
+        csr = x509.load_pem_x509_csr(csr_pem)
+        assert csr.is_signature_valid is True
+
+    def test_private_key_is_ec_p256_matching_the_csr(self):
+        # The returned key is a usable EC P-256 private key, and it is *the* key
+        # whose public half the CSR carries — so installing it lets the device
+        # use the certificate the CA issues against this CSR.
+        key_pem, csr_pem = generate_device_csr("10000000a6b7d43e")
+
+        key = serialization.load_pem_private_key(key_pem, password=None)
+        assert isinstance(key, ec.EllipticCurvePrivateKey)
+        assert isinstance(key.curve, ec.SECP256R1)
+
+        csr = x509.load_pem_x509_csr(csr_pem)
+        assert csr.public_key().public_numbers() == key.public_key().public_numbers()
+
+
+class TestEnrollmentDeviceId:
+    def test_is_the_pi_hardware_serial(self, tmp_path):
+        # The enrollment identity is the Pi serial (CONTEXT.md), not the
+        # hostname — the cert CN must equal what the platform treats as Device ID.
+        f = tmp_path / "cpuinfo"
+        f.write_text(CPUINFO_WITH_SERIAL)
+        assert enrollment_device_id(str(f)) == "10000000a6b7d43e"
+
+    def test_raises_rather_than_falling_back_to_hostname(self, tmp_path):
+        # No serial → fail loudly. Never enroll under a mutable identity (the old
+        # hostname-derived DEVICE_ID), which would mint a cert under the wrong CN.
+        with pytest.raises(RuntimeError):
+            enrollment_device_id(str(tmp_path / "nonexistent"))
+
+
+class TestWriteDeviceCsr:
+    def test_writes_owner_only_key_and_csr_named_for_the_serial(self, tmp_path):
+        cpuinfo = tmp_path / "cpuinfo"
+        cpuinfo.write_text(CPUINFO_WITH_SERIAL)
+        out = tmp_path / "config"
+        out.mkdir()
+
+        device_id = write_device_csr(str(out), cpuinfo_path=str(cpuinfo))
+
+        # Caller (the enroll step, #240) gets the Device ID back.
+        assert device_id == "10000000a6b7d43e"
+
+        key = out / "device.key"
+        csr_file = out / "device.csr"
+        assert key.exists() and csr_file.exists()
+        # The private key is written owner-only — never world-readable on the Pi.
+        assert (key.stat().st_mode & 0o777) == 0o600
+        # The CSR carries the Pi serial as its CN.
+        csr = x509.load_pem_x509_csr(csr_file.read_bytes())
+        (cn,) = csr.subject.get_attributes_for_oid(NameOID.COMMON_NAME)
+        assert cn.value == "10000000a6b7d43e"


### PR DESCRIPTION
Closes #239. First device-side slice of the acorn-ca enrollment flow (PRD Rev 2, included here).

## What this delivers
A Sentri generates its **own EC P-256 keypair on-device** and a **CSR whose Subject `CN` is its Device ID = the Pi hardware serial** (CONTEXT.md/ADR-014), not the mutable hostname. The private key is written **owner-only (`0600`)** and never leaves the Pi; only the CSR is later submitted to acorn-ca `/enroll` (#240).

## Changes
- **`aq_lib/device_csr.py`** (new) — `generate_device_csr`, `enrollment_device_id` (serial, **no hostname fallback** — fails loud), `write_device_csr` + CLI entrypoint.
- **`scripts/deploy/deployment2.sh`** — `DEVICE_ID` now derived from the Pi serial (was `${DEVICE_HOSTNAME}`); the keypair + CSR are generated **in-container after the image pull** (the host has no crypto deps until Phase 9). *Hardware-verified path.*
- **`requirements-backend.txt`** — pin `cryptography`.
- **PRD Rev 2** — revised for the six-repo split (device is client-only; SigV4 not password).

## Tests
6 new unit tests in `unit_tests/test_device_csr.py`, all green:
CN binding · CSR proof-of-possession · key↔CSR match · serial identity · no-hostname-fallback · owner-only key write. The on-Pi deploy invocation is hardware-only per the repo testing rules. (`device_id` regression: 7 green.)

## Out of scope (next slices)
Enroll submission + install into `device.env` + drop `AQ_SYNC_API_KEY` (#240); Sync mTLS swap (#241); verify via `/renew` (#242).

🤖 Generated with [Claude Code](https://claude.com/claude-code)