### PR TITLE
feat(device): operator-mediated enroll + install Device Certificate (#240)

### DIFF
--- a/aq_lib/enroll.py
+++ b/aq_lib/enroll.py
@@ -1,0 +1,73 @@
+"""Operator-side device enrollment against acorn-ca ``POST /enroll`` (#240).
+
+The operator (holding AWS credentials) SigV4-signs a POST of a Sentri's CSR to
+acorn-ca's IAM-authorized ``/enroll`` endpoint and receives the Device
+Certificate. The Pi never holds AWS credentials — this runs on the operator's
+machine; the issued certificate is installed back onto the Pi separately.
+"""
+from botocore.auth import SigV4Auth
+from botocore.awsrequest import AWSRequest
+
+SERVICE = "execute-api"
+
+
+class EnrollmentError(RuntimeError):
+    """Enrollment failed — provisioning must stop, no certificate was issued."""
+
+
+class EnrollmentDenied(EnrollmentError):
+    """acorn-ca refused to issue (e.g. the Device ID is revoked — HTTP 403)."""
+
+
+def enroll(csr_pem, endpoint, *, region, credentials, http_post=None):
+    """Enrol a CSR and return the issued Device Certificate (PEM).
+
+    SigV4-signs a POST of ``csr_pem`` to ``endpoint`` and returns the
+    ``certificate`` from the response.
+    """
+    if http_post is None:  # pragma: no cover - real network default
+        import requests
+
+        http_post = requests.post
+
+    request = AWSRequest(method="POST", url=endpoint, data=csr_pem)
+    SigV4Auth(credentials, SERVICE, region).add_auth(request)
+
+    response = http_post(endpoint, data=csr_pem, headers=dict(request.headers))
+
+    if response.status_code == 403:
+        raise EnrollmentDenied(_error_message(response))
+    if response.status_code != 200:
+        raise EnrollmentError(
+            f"enroll failed: HTTP {response.status_code} {_error_message(response)}".strip()
+        )
+    return response.json()["certificate"]
+
+
+def _error_message(response):
+    try:
+        return response.json().get("error", "")
+    except Exception:
+        return ""
+
+
+CERT_ENV_VAR = "AQ_SYNC_CLIENT_CERT"
+KEY_ENV_VAR = "AQ_SYNC_CLIENT_KEY"
+RETIRED_VAR = "AQ_SYNC_API_KEY"
+
+
+def device_env_after_enroll(env_text, *, cert_path, key_path):
+    """Return ``device.env`` updated to use the Device Certificate.
+
+    Records the cert/key paths the Sync client reads (#241) and removes the
+    retired Fleet API Key. All other lines are preserved in order.
+    """
+    managed = {CERT_ENV_VAR, KEY_ENV_VAR, RETIRED_VAR}
+    kept = [
+        line
+        for line in env_text.splitlines()
+        if line.split("=", 1)[0] not in managed
+    ]
+    kept.append(f"{CERT_ENV_VAR}={cert_path}")
+    kept.append(f"{KEY_ENV_VAR}={key_path}")
+    return "\n".join(kept) + "\n"

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -6,6 +6,8 @@ fastapi
 uvicorn[standard]
 pydantic
 requests
+botocore
+cryptography
 numpy
 pandas
 playwright

--- a/scripts/deploy/deployment2.sh
+++ b/scripts/deploy/deployment2.sh
@@ -313,7 +313,8 @@ prompt_if_unset LID_HEATER_UPPER_BOUND "Enter lid heater upper bound voltage (e.
 prompt_if_unset LID_HEATER_LOWER_BOUND "Enter lid heater lower bound voltage (e.g. 0.20)"
 prompt_if_unset DRAWER_READ_STEPS      "Enter drawer read_steps for this device (e.g. 160)"
 prompt_if_unset AQ_SYNC_ENDPOINT  "Enter AQ_SYNC_ENDPOINT (AWS ingest URL, leave blank to skip)"
-prompt_if_unset AQ_SYNC_API_KEY   "Enter AQ_SYNC_API_KEY (fleet API key, leave blank to skip)"
+# The Fleet API Key is retired (ADR-013): the Sentri authenticates Sync with its
+# Device Certificate (mTLS), installed by scripts/enroll_device.py after deploy.
 
 WATCHTOWER_TOKEN="${WATCHTOWER_TOKEN:-$(openssl rand -hex 32)}"
 
@@ -340,7 +341,6 @@ GHCR_TOKEN=${GHCR_TOKEN}
 GHCR_TOKEN_2=${GHCR_TOKEN_2:-}
 AQ_SRC_BASEDIR=/opt/aquila
 AQ_SYNC_ENDPOINT=${AQ_SYNC_ENDPOINT}
-AQ_SYNC_API_KEY=${AQ_SYNC_API_KEY}
 EOF
 chown root:root /opt/aquila/config/device.env
 chmod 600 /opt/aquila/config/device.env

--- a/scripts/enroll_device.py
+++ b/scripts/enroll_device.py
@@ -1,0 +1,79 @@
+#!/usr/bin/env python3
+"""Operator-side device enrollment over Tailscale SSH (#240).
+
+Run this on the OPERATOR'S machine, where AWS credentials are present — never on
+the Pi. It pulls the Sentri's CSR off the Pi, enrols it against acorn-ca
+``/enroll`` (SigV4-signed with the operator's AWS identity), then installs the
+issued Device Certificate (``0600``) and updates ``device.env`` on the Pi over
+SSH. AWS credentials never touch the Pi.
+
+    python scripts/enroll_device.py --pi sn04 \
+        --endpoint https://rf2f9a0wie.execute-api.us-east-2.amazonaws.com/enroll \
+        --region us-east-2
+
+The CSR is produced on the Pi during deployment (#239). The Sync client reads
+the installed cert/key paths from ``device.env`` (#241).
+"""
+import argparse
+import subprocess
+import sys
+
+import botocore.session
+
+from aq_lib.enroll import EnrollmentError, device_env_after_enroll, enroll
+
+CONFIG_DIR = "/opt/aquila/config"
+CSR_PATH = f"{CONFIG_DIR}/device.csr"
+CERT_PATH = f"{CONFIG_DIR}/device.crt"
+KEY_PATH = f"{CONFIG_DIR}/device.key"
+ENV_PATH = f"{CONFIG_DIR}/device.env"
+
+
+def _ssh_read(pi, path):
+    return subprocess.run(
+        ["ssh", pi, "cat", path], check=True, capture_output=True, text=True
+    ).stdout
+
+
+def _ssh_write(pi, path, content, mode="600"):
+    # umask first so the file is never world-readable, even momentarily.
+    subprocess.run(
+        ["ssh", pi, f"umask 077 && cat > {path} && chmod {mode} {path}"],
+        input=content, check=True, capture_output=True, text=True,
+    )
+
+
+def main(argv=None):
+    p = argparse.ArgumentParser(description="Enrol a Sentri's Device Certificate.")
+    p.add_argument("--pi", required=True, help="Tailscale host/IP of the Sentri")
+    p.add_argument("--endpoint", required=True, help="acorn-ca /enroll URL")
+    p.add_argument("--region", default="us-east-2")
+    args = p.parse_args(argv)
+
+    creds = botocore.session.get_session().get_credentials()
+    if creds is None:
+        sys.exit(
+            "no AWS credentials on this machine — enrolment must run where the "
+            "operator is authenticated (creds never go on the Pi)"
+        )
+
+    csr_pem = _ssh_read(args.pi, CSR_PATH)
+    try:
+        cert_pem = enroll(
+            csr_pem, args.endpoint,
+            region=args.region, credentials=creds.get_frozen_credentials(),
+        )
+    except EnrollmentError as e:
+        sys.exit(f"enrolment failed: {e}")
+
+    _ssh_write(args.pi, CERT_PATH, cert_pem)
+    new_env = device_env_after_enroll(
+        _ssh_read(args.pi, ENV_PATH), cert_path=CERT_PATH, key_path=KEY_PATH
+    )
+    _ssh_write(args.pi, ENV_PATH, new_env)
+
+    print(f"enrolled {args.pi}: certificate installed at {CERT_PATH}")
+
+
+if __name__ == "__main__":
+    main()

--- a/unit_tests/test_enroll.py
+++ b/unit_tests/test_enroll.py
@@ -1,0 +1,111 @@
+"""
+Unit tests for operator-side device enrollment against acorn-ca /enroll (#240).
+
+The operator (with AWS creds) SigV4-POSTs a Sentri's CSR to acorn-ca /enroll and
+gets back the Device Certificate. The Pi makes no AWS call. Network boundary is
+injected/mocked; no real AWS.
+"""
+import pytest
+from botocore.credentials import Credentials
+
+from aq_lib.enroll import (
+    EnrollmentDenied,
+    EnrollmentError,
+    device_env_after_enroll,
+    enroll,
+)
+
+DUMMY_CREDS = Credentials("AKIDEXAMPLE", "secret")
+ENDPOINT = "https://rf2f9a0wie.execute-api.us-east-2.amazonaws.com/enroll"
+CSR_PEM = "-----BEGIN CERTIFICATE REQUEST-----\nMIIB...\n-----END CERTIFICATE REQUEST-----\n"
+CERT_PEM = "-----BEGIN CERTIFICATE-----\nMIIC...\n-----END CERTIFICATE-----\n"
+
+
+class FakeResponse:
+    def __init__(self, status_code, json_body):
+        self.status_code = status_code
+        self._json = json_body
+
+    def json(self):
+        return self._json
+
+
+class TestEnroll:
+    def test_returns_the_certificate_on_200(self):
+        def fake_post(url, data=None, headers=None):
+            return FakeResponse(200, {"certificate": CERT_PEM})
+
+        cert = enroll(
+            CSR_PEM, ENDPOINT, region="us-east-2",
+            credentials=DUMMY_CREDS, http_post=fake_post,
+        )
+        assert cert == CERT_PEM
+
+    def test_posts_the_csr_body_sigv4_signed_to_enroll(self):
+        captured = {}
+
+        def fake_post(url, data=None, headers=None):
+            captured.update(url=url, data=data, headers=headers)
+            return FakeResponse(200, {"certificate": CERT_PEM})
+
+        enroll(
+            CSR_PEM, ENDPOINT, region="us-east-2",
+            credentials=DUMMY_CREDS, http_post=fake_post,
+        )
+
+        assert captured["url"] == ENDPOINT
+        assert captured["data"] == CSR_PEM
+        # SigV4 over the execute-api service in the given region.
+        auth = captured["headers"]["Authorization"]
+        assert auth.startswith("AWS4-HMAC-SHA256")
+        assert "/us-east-2/execute-api/aws4_request" in auth
+
+    def test_revoked_device_raises_enrollment_denied(self):
+        # acorn-ca returns 403 for a revoked Device ID — provisioning must stop
+        # loudly, not write a non-cert as if it were a certificate.
+        def fake_post(url, data=None, headers=None):
+            return FakeResponse(403, {"error": "Device ID 10000000a6b7d43e is revoked"})
+
+        with pytest.raises(EnrollmentDenied) as exc:
+            enroll(
+                CSR_PEM, ENDPOINT, region="us-east-2",
+                credentials=DUMMY_CREDS, http_post=fake_post,
+            )
+        assert "revoked" in str(exc.value)
+
+    def test_malformed_csr_400_raises_enrollment_error(self):
+        # Any other non-200 (e.g. 400 malformed Device ID) also fails loudly,
+        # carrying the status so the operator can see what happened.
+        def fake_post(url, data=None, headers=None):
+            return FakeResponse(400, {"error": "malformed Device ID: nope"})
+
+        with pytest.raises(EnrollmentError) as exc:
+            enroll(
+                CSR_PEM, ENDPOINT, region="us-east-2",
+                credentials=DUMMY_CREDS, http_post=fake_post,
+            )
+        assert "400" in str(exc.value)
+
+
+class TestDeviceEnvAfterEnroll:
+    def test_adds_cert_and_key_paths_and_drops_the_api_key(self):
+        env = (
+            "DEVICE_ID=10000000a6b7d43e\n"
+            "AQ_SYNC_ENDPOINT=https://ingest.example\n"
+            "AQ_SYNC_API_KEY=old-fleet-secret\n"
+        )
+        out = device_env_after_enroll(
+            env,
+            cert_path="/opt/aquila/config/device.crt",
+            key_path="/opt/aquila/config/device.key",
+        )
+        lines = out.splitlines()
+
+        # The retired Fleet API Key is gone entirely.
+        assert not any(line.startswith("AQ_SYNC_API_KEY") for line in lines)
+        # The Device Certificate paths are recorded for the Sync client (#241).
+        assert "AQ_SYNC_CLIENT_CERT=/opt/aquila/config/device.crt" in lines
+        assert "AQ_SYNC_CLIENT_KEY=/opt/aquila/config/device.key" in lines
+        # Unrelated config is preserved.
+        assert "DEVICE_ID=10000000a6b7d43e" in lines
+        assert "AQ_SYNC_ENDPOINT=https://ingest.example" in lines


### PR DESCRIPTION
Closes #240. Second slice of the device enrollment feature → targets the **`feature/device-cert-enrollment`** integration branch (stacked on #239).

## What this delivers
The operator (holding AWS creds) enrols a Sentri's CSR against acorn-ca `/enroll` and installs the issued Device Certificate onto the Pi — **AWS credentials never touch the Pi** (the agreed operator-over-SSH flow).

## Changes
- **`aq_lib/enroll.py`** (new) — `enroll()` SigV4-signs a POST of the CSR to `/enroll` (`execute-api`) and returns the certificate. **403 → `EnrollmentDenied`** (revoked), any other non-200 → `EnrollmentError` — fail loud, never write a non-cert. `device_env_after_enroll()` records the cert/key paths the Sync client reads (#241) and **drops the retired `AQ_SYNC_API_KEY`**.
- **`scripts/enroll_device.py`** (new) — operator CLI: SSH-reads the CSR off the Pi, enrols, SSH-writes `device.crt` `0600` + rewrites `device.env` over Tailscale. Creds via `botocore` on the operator's machine.
- **`deployment2.sh`** — stop prompting for / writing `AQ_SYNC_API_KEY`.
- **`requirements-test`** — `botocore` + `cryptography`.

## Tests
5 unit tests (200→cert · CSR body SigV4-signed to `/enroll` · 403→denied · other→error · `device.env` transform). **Verified LIVE against the dev CA**: a real CSR enrolled → CA-chained 14-day cert whose `CN` == the Device ID, issuer `Sentri Fleet Root CA`. The SSH transport is operator/hardware-only per the repo testing rules. (Repo unit suites: 57 green.)

## Out of scope (next slices)
Sync presents the cert over mTLS / drops `x-api-key` (#241); verify script via `/renew` (#242).

🤖 Generated with [Claude Code](https://claude.com/claude-code)