### PR TITLE
feat(device): Sync presents the Device Certificate over mTLS, drops x-api-key (#241)

### DIFF
--- a/aquila_web/sync.py
+++ b/aquila_web/sync.py
@@ -26,12 +26,18 @@ def sync_pending_events(
         "device_id": os.getenv("AQ_SYNC_DEVICE_ID") or os.getenv("DEVICE_ID"),
         "events": pending_events,
     }
-    headers = {}
-    api_key = os.getenv("AQ_SYNC_API_KEY")
-    if api_key:
-        headers["x-api-key"] = api_key
+    # The Sentri authenticates Sync with its Device Certificate (mTLS), not the
+    # retired Fleet API Key (ADR-013). Cert/key paths are installed into
+    # device.env at enrollment (#240); present them for the TLS handshake.
+    cert = None
+    client_cert = os.getenv("AQ_SYNC_CLIENT_CERT")
+    client_key = os.getenv("AQ_SYNC_CLIENT_KEY")
+    if client_cert and client_key:
+        cert = (client_cert, client_key)
     try:
-        response = requests.post(resolved_endpoint, json=payload, headers=headers, timeout=resolved_timeout)
+        response = requests.post(
+            resolved_endpoint, json=payload, cert=cert, timeout=resolved_timeout
+        )
         response.raise_for_status()
     except requests.exceptions.RequestException as exc:
         logger.warning("Sync failed (will retry next interval): %s", exc)

--- a/tests/unit/test_background_sync.py
+++ b/tests/unit/test_background_sync.py
@@ -28,14 +28,15 @@ def _seed_event(local_db, tmp_path):
     local_db.enqueue_event("run_complete", {"run_name": "Run 1", "profile": "p.json", "result": "ok"})
 
 
-class TestApiKeyHeader:
-    """AQ_SYNC_API_KEY is sent as x-api-key header."""
+class TestClientCertificate:
+    """Sync authenticates with the Device Certificate (mTLS), not x-api-key."""
 
-    def test_api_key_sent_as_header_when_set(self, db_client, tmp_path, monkeypatch):
+    def test_presents_client_cert_and_sends_no_api_key(self, db_client, tmp_path, monkeypatch):
         client, local_db = db_client
         _seed_event(local_db, tmp_path)
         monkeypatch.setenv("AQ_SYNC_ENDPOINT", "http://fake-aws/ingest")
-        monkeypatch.setenv("AQ_SYNC_API_KEY", "test-fleet-key-abc")
+        monkeypatch.setenv("AQ_SYNC_CLIENT_CERT", "/opt/aquila/config/device.crt")
+        monkeypatch.setenv("AQ_SYNC_CLIENT_KEY", "/opt/aquila/config/device.key")
 
         captured = {}
 
@@ -44,18 +45,27 @@ class TestApiKeyHeader:
             def raise_for_status(self): pass
 
         def _capture(*a, **kw):
-            captured["headers"] = kw.get("headers", {})
+            captured.update(kw)
             return _OK()
 
         monkeypatch.setattr("aquila_web.sync.requests.post", _capture)
         client.post("/sync/flush")
-        assert captured["headers"].get("x-api-key") == "test-fleet-key-abc"
 
-    def test_no_api_key_header_when_env_var_not_set(self, db_client, tmp_path, monkeypatch):
+        # The client certificate tuple is presented for the mTLS handshake...
+        assert captured["cert"] == (
+            "/opt/aquila/config/device.crt",
+            "/opt/aquila/config/device.key",
+        )
+        # ...and the retired Fleet API Key header is gone.
+        assert "x-api-key" not in captured.get("headers", {})
+
+    def test_lingering_api_key_env_var_is_ignored(self, db_client, tmp_path, monkeypatch):
+        # A stale AQ_SYNC_API_KEY left in the environment must never resurrect
+        # the retired header — the key model is gone, not merely defaulted off.
         client, local_db = db_client
         _seed_event(local_db, tmp_path)
         monkeypatch.setenv("AQ_SYNC_ENDPOINT", "http://fake-aws/ingest")
-        monkeypatch.delenv("AQ_SYNC_API_KEY", raising=False)
+        monkeypatch.setenv("AQ_SYNC_API_KEY", "stale-fleet-key")
 
         captured = {}
 
@@ -64,11 +74,12 @@ class TestApiKeyHeader:
             def raise_for_status(self): pass
 
         def _capture(*a, **kw):
-            captured["headers"] = kw.get("headers", {})
+            captured.update(kw)
             return _OK()
 
         monkeypatch.setattr("aquila_web.sync.requests.post", _capture)
         client.post("/sync/flush")
+
         assert "x-api-key" not in captured.get("headers", {})
 
 


### PR DESCRIPTION
Closes #241. Third slice of the device enrollment feature → targets the **`feature/device-cert-enrollment`** integration branch (stacked on #239 + #240).

## What this delivers
The Sentri authenticates Sync with its **Device Certificate (mTLS)** instead of the retired Fleet API Key (ADR-013).

## Changes
- **`aquila_web/sync.py`** — presents `cert=(client_cert, client_key)` on the Sync POST, reading the paths installed into `device.env` at enrollment (#240: `AQ_SYNC_CLIENT_CERT`/`AQ_SYNC_CLIENT_KEY`). The `x-api-key` header and `AQ_SYNC_API_KEY` are gone — a stale key var is **ignored, not resurrected**. Event payload shape unchanged (still keyed on `device_id`).

## Tests (existing seam — monkeypatched `requests.post`)
- client-cert tuple presented **and no `x-api-key`**
- a lingering `AQ_SYNC_API_KEY` is ignored
- the endpoint behaviours stay green: count · no-endpoint→0 · network error swallowed, events stay pending

The **live Sync-to-storage proof** belongs to acorn-analytics' Ingest Endpoint (not yet built) and is out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)