### PR TITLE
feat(device): verify the Device Certificate over mTLS to /renew (#242)

### DIFF
--- a/aq_lib/verify.py
+++ b/aq_lib/verify.py
@@ -1,0 +1,38 @@
+"""Device-side certificate verification against acorn-ca ``POST /renew`` (#242).
+
+The Sentri presents its installed Device Certificate over mTLS to ``/renew`` to
+prove the certificate authenticates and that mTLS is enforced. This runs on the
+device: it presents the cert as a TLS client credential and needs no AWS
+credentials. A missing/expired/wrong-CA certificate fails the TLS handshake and
+nothing is renewed.
+"""
+import requests
+
+from aq_lib.device_csr import generate_device_csr
+
+
+class VerificationError(RuntimeError):
+    """The certificate did not authenticate against /renew."""
+
+
+def verify_renew(renew_endpoint, *, cert_path, key_path, device_id, http_post=None):
+    """Present the Device Certificate over mTLS to ``/renew``; return the renewed cert.
+
+    Builds a CSR with ``CN=device_id`` (renew requires the CSR CN to match the
+    client cert CN) and POSTs it presenting ``cert=(cert_path, key_path)``.
+    """
+    if http_post is None:  # pragma: no cover - real network default
+        http_post = requests.post
+
+    _key_pem, csr_pem = generate_device_csr(device_id)
+    try:
+        response = http_post(renew_endpoint, data=csr_pem, cert=(cert_path, key_path))
+    except requests.exceptions.SSLError as exc:
+        raise VerificationError(f"mTLS handshake rejected: {exc}") from exc
+
+    if response.status_code != 200:
+        raise VerificationError(
+            f"renew rejected the certificate: HTTP {response.status_code} "
+            f"{response.json().get('error', '')}".strip()
+        )
+    return response.json()["certificate"]

--- a/scripts/verify_device_cert.py
+++ b/scripts/verify_device_cert.py
@@ -1,0 +1,57 @@
+#!/usr/bin/env python3
+"""Device-side certificate verification (#242).
+
+Runs ON the Pi. Presents the installed Device Certificate over mTLS to acorn-ca
+``/renew`` and reports whether it authenticates. Exits 0 (PASS) or non-zero
+(FAIL). No AWS credentials are needed — the certificate is the credential.
+
+    python scripts/verify_device_cert.py \
+        --renew-endpoint https://renew.cloud.acorngenetics.com/renew
+
+Cert/key paths and the Device ID default to the values enrollment wrote into
+``device.env`` (#240).
+"""
+import argparse
+import os
+import sys
+
+from aq_lib.verify import VerificationError, verify_renew
+
+
+def main(argv=None):
+    p = argparse.ArgumentParser(description="Verify the Device Certificate over mTLS.")
+    p.add_argument("--renew-endpoint", default=os.getenv("AQ_RENEW_ENDPOINT"))
+    p.add_argument("--cert", default=os.getenv("AQ_SYNC_CLIENT_CERT"))
+    p.add_argument("--key", default=os.getenv("AQ_SYNC_CLIENT_KEY"))
+    p.add_argument(
+        "--device-id",
+        default=os.getenv("AQ_SYNC_DEVICE_ID") or os.getenv("DEVICE_ID"),
+    )
+    args = p.parse_args(argv)
+
+    missing = [
+        name
+        for name, value in [
+            ("--renew-endpoint", args.renew_endpoint),
+            ("--cert", args.cert),
+            ("--key", args.key),
+            ("--device-id", args.device_id),
+        ]
+        if not value
+    ]
+    if missing:
+        sys.exit(f"missing required value(s): {', '.join(missing)}")
+
+    try:
+        verify_renew(
+            args.renew_endpoint,
+            cert_path=args.cert, key_path=args.key, device_id=args.device_id,
+        )
+    except VerificationError as e:
+        sys.exit(f"FAIL: {e}")
+
+    print("PASS: Device Certificate authenticated over mTLS to /renew")
+
+
+if __name__ == "__main__":
+    main()

--- a/unit_tests/test_verify.py
+++ b/unit_tests/test_verify.py
@@ -1,0 +1,80 @@
+"""
+Unit tests for device-side certificate verification against acorn-ca /renew (#242).
+
+The Sentri presents its installed Device Certificate over mTLS to /renew to prove
+the certificate authenticates and that mTLS is enforced. Network boundary is
+injected/mocked; no real TLS.
+"""
+import pytest
+import requests
+from cryptography import x509
+from cryptography.x509.oid import NameOID
+
+from aq_lib.verify import VerificationError, verify_renew
+
+RENEW_ENDPOINT = "https://renew.example/renew"
+CERT_PATH = "/opt/aquila/config/device.crt"
+KEY_PATH = "/opt/aquila/config/device.key"
+DEVICE_ID = "10000000a6b7d43e"
+RENEWED_PEM = "-----BEGIN CERTIFICATE-----\nMIIRENEWED\n-----END CERTIFICATE-----\n"
+
+
+class FakeResponse:
+    def __init__(self, status_code, json_body):
+        self.status_code = status_code
+        self._json = json_body
+
+    def json(self):
+        return self._json
+
+
+class TestVerifyRenew:
+    def test_presents_cert_and_csr_and_returns_renewed_cert_on_200(self):
+        captured = {}
+
+        def fake_post(url, data=None, cert=None):
+            captured.update(url=url, data=data, cert=cert)
+            return FakeResponse(200, {"certificate": RENEWED_PEM})
+
+        cert = verify_renew(
+            RENEW_ENDPOINT, cert_path=CERT_PATH, key_path=KEY_PATH,
+            device_id=DEVICE_ID, http_post=fake_post,
+        )
+
+        assert cert == RENEWED_PEM
+        # The Device Certificate is presented for the mTLS handshake...
+        assert captured["cert"] == (CERT_PATH, KEY_PATH)
+        assert captured["url"] == RENEW_ENDPOINT
+        # ...alongside a CSR whose CN matches the cert identity (renew requires it).
+        csr = x509.load_pem_x509_csr(
+            captured["data"] if isinstance(captured["data"], bytes) else captured["data"].encode()
+        )
+        (cn,) = csr.subject.get_attributes_for_oid(NameOID.COMMON_NAME)
+        assert cn.value == DEVICE_ID
+
+    def test_tls_handshake_rejection_raises_verification_error(self):
+        # A missing/expired/wrong-CA client cert is rejected at the TLS layer —
+        # requests surfaces that as SSLError. Verification must fail clearly, not
+        # leak a raw SSL traceback.
+        def fake_post(url, data=None, cert=None):
+            raise requests.exceptions.SSLError("certificate verify failed")
+
+        with pytest.raises(VerificationError) as exc:
+            verify_renew(
+                RENEW_ENDPOINT, cert_path=CERT_PATH, key_path=KEY_PATH,
+                device_id=DEVICE_ID, http_post=fake_post,
+            )
+        assert "handshake" in str(exc.value).lower()
+
+    def test_non_200_response_raises_verification_error_with_status(self):
+        # The handshake succeeded but the app rejected it (e.g. 403 CN mismatch).
+        # Still a verification failure, surfaced with the status.
+        def fake_post(url, data=None, cert=None):
+            return FakeResponse(403, {"error": "mTLS client certificate required"})
+
+        with pytest.raises(VerificationError) as exc:
+            verify_renew(
+                RENEW_ENDPOINT, cert_path=CERT_PATH, key_path=KEY_PATH,
+                device_id=DEVICE_ID, http_post=fake_post,
+            )
+        assert "403" in str(exc.value)


### PR DESCRIPTION
Closes #242. Fourth/final slice of the device enrollment feature → targets the **`feature/device-cert-enrollment`** integration branch.

## What this delivers
A device-side verification that the installed Device Certificate actually authenticates: it presents the cert over **mTLS to acorn-ca `/renew`** and confirms a successful handshake. Runs on the Pi — the certificate is the credential, **no AWS creds**.

## Changes
- **`aq_lib/verify.py`** (new) — `verify_renew()` builds a CSR (`CN=device_id`, which `/renew` requires to match the client-cert CN) and POSTs it presenting `cert=(cert_path, key_path)`. **200 → renewed cert**; `SSLError` (missing/expired/wrong-CA cert rejected at TLS) → `VerificationError("handshake rejected")`; other non-200 (e.g. 403) → `VerificationError` with status.
- **`scripts/verify_device_cert.py`** (new) — device CLI, PASS / non-zero FAIL, defaults from `device.env`.

## Tests
3 unit tests: 200→cert presenting cert+CSR · `SSLError`→error · non-200→error. (Full feature suite across all 4 slices: **26 green**.)

## ⚠️ Live acceptance gap
The live acceptance (cert→200, certless→TLS reject) needs an **mTLS-enforcing `/renew`**, which is a **custom-domain** feature. The dev CA currently has **no renew domain** (no `RENEW_DOMAIN_NAME`), so the default `execute-api` endpoint never captures a client cert and can't prove mTLS. Live mTLS proof awaits a renew domain (dev or prod). The logic is fully unit-tested here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)