### PR TITLE
feat(device): mTLS Device Certificate enrollment + verification

### DIFF
--- a/aq_lib/device_csr.py
+++ b/aq_lib/device_csr.py
@@ -1,0 +1,82 @@
+"""On-device keypair + CSR generation for Sentri enrollment (issue #239).
+
+A Sentri generates its own keypair on-device and a CSR whose Subject CN is its
+Device ID (the Pi hardware serial). The private key never leaves the Pi. The CSR
+is later submitted to acorn-ca ``POST /enroll`` (operator-mediated, #240).
+"""
+import os
+import sys
+
+from cryptography import x509
+from cryptography.hazmat.primitives import hashes, serialization
+from cryptography.hazmat.primitives.asymmetric import ec
+from cryptography.x509.oid import NameOID
+
+from aq_lib.device_id import read_rpi_serial
+
+
+def enrollment_device_id(cpuinfo_path: str = "/proc/cpuinfo") -> str:
+    """The Device ID to enroll under: the Pi hardware serial.
+
+    This is deliberately the serial, not the hostname — the cert CN must equal
+    what the platform treats as the Device ID (CONTEXT.md). There is no hostname
+    fallback: a device with no stable serial must not silently enroll under a
+    mutable identity.
+    """
+    serial = read_rpi_serial(cpuinfo_path)
+    if not serial:
+        raise RuntimeError(
+            f"no Raspberry Pi hardware serial in {cpuinfo_path}; "
+            "cannot derive a stable Device ID for enrollment"
+        )
+    return serial
+
+
+def generate_device_csr(device_id: str) -> tuple[bytes, bytes]:
+    """Generate a fresh device keypair and a CSR with Subject ``CN=device_id``.
+
+    Returns ``(private_key_pem, csr_pem)``.
+    """
+    key = ec.generate_private_key(ec.SECP256R1())
+    csr = x509.CertificateSigningRequestBuilder().subject_name(
+        x509.Name([x509.NameAttribute(NameOID.COMMON_NAME, device_id)])
+    ).sign(key, hashes.SHA256())
+
+    key_pem = key.private_bytes(
+        encoding=serialization.Encoding.PEM,
+        format=serialization.PrivateFormat.PKCS8,
+        encryption_algorithm=serialization.NoEncryption(),
+    )
+    csr_pem = csr.public_bytes(serialization.Encoding.PEM)
+    return key_pem, csr_pem
+
+
+KEY_FILENAME = "device.key"
+CSR_FILENAME = "device.csr"
+
+
+def write_device_csr(out_dir: str, cpuinfo_path: str = "/proc/cpuinfo") -> str:
+    """Generate the device keypair + CSR on-device and write them to ``out_dir``.
+
+    Resolves the Device ID from the Pi serial, writes the private key
+    owner-only (``0600``) and the CSR alongside it, and returns the Device ID
+    so the caller (the enroll step, #240) can submit the CSR under that identity.
+    """
+    device_id = enrollment_device_id(cpuinfo_path)
+    key_pem, csr_pem = generate_device_csr(device_id)
+
+    key_path = os.path.join(out_dir, KEY_FILENAME)
+    csr_path = os.path.join(out_dir, CSR_FILENAME)
+    # Create the key file owner-only from the start — never world-readable, even
+    # for the instant between write and chmod.
+    fd = os.open(key_path, os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
+    with os.fdopen(fd, "wb") as f:
+        f.write(key_pem)
+    with open(csr_path, "wb") as f:
+        f.write(csr_pem)
+    return device_id
+
+
+if __name__ == "__main__":  # pragma: no cover - on-device entrypoint
+    out = sys.argv[1] if len(sys.argv) > 1 else "."
+    print(write_device_csr(out))

--- a/aq_lib/enroll.py
+++ b/aq_lib/enroll.py
@@ -1,0 +1,73 @@
+"""Operator-side device enrollment against acorn-ca ``POST /enroll`` (#240).
+
+The operator (holding AWS credentials) SigV4-signs a POST of a Sentri's CSR to
+acorn-ca's IAM-authorized ``/enroll`` endpoint and receives the Device
+Certificate. The Pi never holds AWS credentials — this runs on the operator's
+machine; the issued certificate is installed back onto the Pi separately.
+"""
+from botocore.auth import SigV4Auth
+from botocore.awsrequest import AWSRequest
+
+SERVICE = "execute-api"
+
+
+class EnrollmentError(RuntimeError):
+    """Enrollment failed — provisioning must stop, no certificate was issued."""
+
+
+class EnrollmentDenied(EnrollmentError):
+    """acorn-ca refused to issue (e.g. the Device ID is revoked — HTTP 403)."""
+
+
+def enroll(csr_pem, endpoint, *, region, credentials, http_post=None):
+    """Enrol a CSR and return the issued Device Certificate (PEM).
+
+    SigV4-signs a POST of ``csr_pem`` to ``endpoint`` and returns the
+    ``certificate`` from the response.
+    """
+    if http_post is None:  # pragma: no cover - real network default
+        import requests
+
+        http_post = requests.post
+
+    request = AWSRequest(method="POST", url=endpoint, data=csr_pem)
+    SigV4Auth(credentials, SERVICE, region).add_auth(request)
+
+    response = http_post(endpoint, data=csr_pem, headers=dict(request.headers))
+
+    if response.status_code == 403:
+        raise EnrollmentDenied(_error_message(response))
+    if response.status_code != 200:
+        raise EnrollmentError(
+            f"enroll failed: HTTP {response.status_code} {_error_message(response)}".strip()
+        )
+    return response.json()["certificate"]
+
+
+def _error_message(response):
+    try:
+        return response.json().get("error", "")
+    except Exception:
+        return ""
+
+
+CERT_ENV_VAR = "AQ_SYNC_CLIENT_CERT"
+KEY_ENV_VAR = "AQ_SYNC_CLIENT_KEY"
+RETIRED_VAR = "AQ_SYNC_API_KEY"
+
+
+def device_env_after_enroll(env_text, *, cert_path, key_path):
+    """Return ``device.env`` updated to use the Device Certificate.
+
+    Records the cert/key paths the Sync client reads (#241) and removes the
+    retired Fleet API Key. All other lines are preserved in order.
+    """
+    managed = {CERT_ENV_VAR, KEY_ENV_VAR, RETIRED_VAR}
+    kept = [
+        line
+        for line in env_text.splitlines()
+        if line.split("=", 1)[0] not in managed
+    ]
+    kept.append(f"{CERT_ENV_VAR}={cert_path}")
+    kept.append(f"{KEY_ENV_VAR}={key_path}")
+    return "\n".join(kept) + "\n"

--- a/aq_lib/verify.py
+++ b/aq_lib/verify.py
@@ -1,0 +1,38 @@
+"""Device-side certificate verification against acorn-ca ``POST /renew`` (#242).
+
+The Sentri presents its installed Device Certificate over mTLS to ``/renew`` to
+prove the certificate authenticates and that mTLS is enforced. This runs on the
+device: it presents the cert as a TLS client credential and needs no AWS
+credentials. A missing/expired/wrong-CA certificate fails the TLS handshake and
+nothing is renewed.
+"""
+import requests
+
+from aq_lib.device_csr import generate_device_csr
+
+
+class VerificationError(RuntimeError):
+    """The certificate did not authenticate against /renew."""
+
+
+def verify_renew(renew_endpoint, *, cert_path, key_path, device_id, http_post=None):
+    """Present the Device Certificate over mTLS to ``/renew``; return the renewed cert.
+
+    Builds a CSR with ``CN=device_id`` (renew requires the CSR CN to match the
+    client cert CN) and POSTs it presenting ``cert=(cert_path, key_path)``.
+    """
+    if http_post is None:  # pragma: no cover - real network default
+        http_post = requests.post
+
+    _key_pem, csr_pem = generate_device_csr(device_id)
+    try:
+        response = http_post(renew_endpoint, data=csr_pem, cert=(cert_path, key_path))
+    except requests.exceptions.SSLError as exc:
+        raise VerificationError(f"mTLS handshake rejected: {exc}") from exc
+
+    if response.status_code != 200:
+        raise VerificationError(
+            f"renew rejected the certificate: HTTP {response.status_code} "
+            f"{response.json().get('error', '')}".strip()
+        )
+    return response.json()["certificate"]

--- a/aquila_web/sync.py
+++ b/aquila_web/sync.py
@@ -26,12 +26,18 @@ def sync_pending_events(
         "device_id": os.getenv("AQ_SYNC_DEVICE_ID") or os.getenv("DEVICE_ID"),
         "events": pending_events,
     }
-    headers = {}
-    api_key = os.getenv("AQ_SYNC_API_KEY")
-    if api_key:
-        headers["x-api-key"] = api_key
+    # The Sentri authenticates Sync with its Device Certificate (mTLS), not the
+    # retired Fleet API Key (ADR-013). Cert/key paths are installed into
+    # device.env at enrollment (#240); present them for the TLS handshake.
+    cert = None
+    client_cert = os.getenv("AQ_SYNC_CLIENT_CERT")
+    client_key = os.getenv("AQ_SYNC_CLIENT_KEY")
+    if client_cert and client_key:
+        cert = (client_cert, client_key)
     try:
-        response = requests.post(resolved_endpoint, json=payload, headers=headers, timeout=resolved_timeout)
+        response = requests.post(
+            resolved_endpoint, json=payload, cert=cert, timeout=resolved_timeout
+        )
         response.raise_for_status()
     except requests.exceptions.RequestException as exc:
         logger.warning("Sync failed (will retry next interval): %s", exc)

--- a/docs/deployment/enrolling-a-device.md
+++ b/docs/deployment/enrolling-a-device.md
@@ -1,0 +1,114 @@
+# Enrolling a Sentri (Device Certificate)
+
+How to get a newly-deployed Sentri its **Device Certificate** so it can Sync over
+mTLS. This replaces the retired Fleet API Key (`AQ_SYNC_API_KEY`) — see ADR-013/014.
+
+## The model in one paragraph
+
+Each Sentri has its **own** keypair and a short-lived X.509 **Device Certificate**
+issued by **acorn-ca**. The certificate's Subject `CN` is the **Device ID** (the Pi
+hardware serial). The Pi generates its keypair + CSR locally — **the private key
+never leaves the Pi** — and the **operator** (who holds AWS credentials) submits the
+CSR to acorn-ca's `POST /enroll`. The Pi never holds AWS credentials, and never
+holds anything that could mint *other* certificates.
+
+```
+Pi (deployment2.sh)            Operator workstation (AWS creds)        acorn-ca
+  keypair + CSR (CN=serial)
+  device.csr  ───────────────► enroll_device.py
+                                  POST /enroll (SigV4) ──────────────► issues leaf
+  device.crt 0600  ◄──────────── installs cert + device.env (over SSH)  (CA-signed)
+```
+
+## Prerequisites
+
+- The Sentri is deployed (`scripts/deploy/deployment2.sh` has run) — so
+  `/opt/aquila/config/device.csr` exists and Tailscale SSH is up.
+- You can `ssh <pi>` to it (Tailscale hostname or IP).
+- **AWS credentials** on your workstation with permission to invoke the enroll API
+  (`execute-api:Invoke` on the acorn-ca `/enroll` route). Never put these on the Pi.
+- The acorn-ca **enroll endpoint URL** for the target environment. Find it with:
+  ```bash
+  aws apigatewayv2 get-apis \
+    --query "Items[?Name=='EnrollApi'].ApiEndpoint" --output text
+  # → https://<id>.execute-api.us-east-2.amazonaws.com   (append /enroll)
+  ```
+- A local checkout of this repo with `botocore` + `cryptography` installed
+  (`pip install -r requirements-test.txt` covers both).
+
+## Enroll
+
+From your workstation (not the Pi):
+
+```bash
+python scripts/enroll_device.py \
+    --pi sn04 \
+    --endpoint https://<id>.execute-api.us-east-2.amazonaws.com/enroll \
+    --region us-east-2
+```
+
+This:
+1. SSH-reads the CSR (`/opt/aquila/config/device.csr`) off the Pi.
+2. SigV4-signs a POST of the CSR to `/enroll` with **your** AWS identity.
+3. SSH-writes the issued certificate to `/opt/aquila/config/device.crt` (`0600`).
+4. Rewrites `/opt/aquila/config/device.env`: adds `AQ_SYNC_CLIENT_CERT` /
+   `AQ_SYNC_CLIENT_KEY` and removes any stale `AQ_SYNC_API_KEY`.
+
+Success prints `enrolled <pi>: certificate installed at /opt/aquila/config/device.crt`.
+
+## Verify (optional, runs on the Pi)
+
+Once the prod renew domain is live (`renew.cloud.acorngenetics.com`), confirm the
+certificate authenticates over mTLS — no AWS credentials needed, the cert is the
+credential:
+
+```bash
+ssh <pi> 'cd /opt/aquila && set -a && . config/device.env && \
+  python scripts/verify_device_cert.py \
+    --renew-endpoint https://renew.cloud.acorngenetics.com/renew'
+# PASS: Device Certificate authenticated over mTLS to /renew
+```
+
+A missing / expired / wrong-CA certificate fails the TLS handshake and reports `FAIL`.
+
+## What changed in `deployment2.sh`
+
+The deploy script no longer touches a shared key; it sets up the device *identity*
+and generates the CSR. Three edits:
+
+1. **`DEVICE_ID` is the Pi hardware serial, not the hostname** (Phase 8).
+   Was `DEVICE_ID=${DEVICE_HOSTNAME}` (e.g. `sn04`). Now it reads the serial from
+   `/proc/cpuinfo` and **fails loud** if there isn't one — so the Device Certificate's
+   `CN` matches what the platform treats as the Device ID (the serial survives
+   reimages; the hostname doesn't). `DEVICE_HOSTNAME` is still written separately for
+   hardware config (`host_config.json`).
+
+2. **Keypair + CSR generated on-device** (Phase 9, after the image pull).
+   A `docker run … python -m aq_lib.device_csr /config` produces
+   `device.key` (`0600`) + `device.csr` with `CN=<serial>`. It runs **in the app
+   image** because the host has no crypto deps, and mounts `/proc/cpuinfo` read-only so
+   the container derives the **same** serial. Two `run_test` checks assert the CSR
+   exists and the key is owner-only.
+
+3. **Fleet API Key removed.** The `AQ_SYNC_API_KEY` prompt and its `device.env` line
+   are gone — the Sentri authenticates Sync with its Device Certificate instead.
+
+The deploy script does **not** enroll — enrollment is the operator step above, because
+it needs AWS credentials that must never land on the Pi.
+
+## Troubleshooting
+
+| Symptom | Cause / fix |
+|---|---|
+| `enrolment failed: … HTTP 403 … is revoked` | The Device ID is revoked in acorn-ca. It will not be issued a cert — investigate the device before un-revoking. |
+| `enrolment failed: … HTTP 400 malformed Device ID` | The CSR `CN` isn't a valid Pi serial. Check Phase 8 didn't fall back / the Pi has a real serial. |
+| `no AWS credentials on this machine` | You ran the enroll tool without AWS creds. Authenticate your workstation (the Pi must stay credential-free). |
+| `ssh: … device.csr: No such file` | Deployment didn't reach Phase 9, or the image lacks `aq_lib`. Re-run `deployment2.sh`. |
+| Verify `FAIL` / handshake rejected | Cert missing/expired/wrong-CA, **or** you're hitting an endpoint without mTLS (only the prod `renew.cloud…` custom domain enforces it; the default `execute-api` URL does not). |
+
+## Related
+
+- acorn-ca `CONTEXT.md` — Enrollment, Renewal, Revocation, Cohort definitions.
+- `specs/prd/kms-ca-enrollment-mtls-s3-verification-prd.md` (Rev 2) — the slice spec.
+- Renewal (automatic, before expiry) and the offline re-enrollment fallback are a
+  later slice; this covers first-time enrollment.

--- a/requirements-backend.txt
+++ b/requirements-backend.txt
@@ -11,3 +11,4 @@ RPi.GPIO
 spidev
 smbus2
 simple-rpc
+cryptography

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -6,6 +6,8 @@ fastapi
 uvicorn[standard]
 pydantic
 requests
+botocore
+cryptography
 numpy
 pandas
 playwright

--- a/scripts/deploy/deployment2.sh
+++ b/scripts/deploy/deployment2.sh
@@ -317,9 +317,19 @@ prompt_if_unset AQ_SYNC_API_KEY   "Enter AQ_SYNC_API_KEY (fleet API key, leave b
 
 WATCHTOWER_TOKEN="${WATCHTOWER_TOKEN:-$(openssl rand -hex 32)}"
 
+# Device ID is the Pi hardware serial (CONTEXT.md / ADR-014), NOT the hostname:
+# the Device Certificate's CN must equal what the platform treats as the Device
+# ID. Mirrors aq_lib/device_id.read_rpi_serial (the host has no app deps until
+# images are pulled in Phase 9). Fail loud rather than enrol under a mutable id.
+DEVICE_ID="$(awk -F': ' '/^Serial/ {print $2}' /proc/cpuinfo | tr -d '[:space:]')"
+if [[ -z "${DEVICE_ID}" || "${DEVICE_ID}" =~ ^0+$ ]]; then
+    echo "  ✗ No Raspberry Pi hardware serial in /proc/cpuinfo — cannot derive Device ID" >&2
+    exit 1
+fi
+
 # device.env
 cat > /opt/aquila/config/device.env <<EOF
-DEVICE_ID=${DEVICE_HOSTNAME}
+DEVICE_ID=${DEVICE_ID}
 DEVICE_HOSTNAME=${DEVICE_HOSTNAME}
 IMAGE_TAG=${IMAGE_TAG}
 GHCR_REPO=${GHCR_REPO}
@@ -580,11 +590,24 @@ curl -fsSL \
     -o /opt/fleet/update.sh
 chmod +x /opt/fleet/update.sh
 
+# Generate the device keypair + CSR on-device (CN = Device ID = Pi serial). The
+# private key is written owner-only (0600) and never leaves the Pi; only the CSR
+# is later submitted to acorn-ca /enroll (#240). Runs in the app image, which
+# carries the crypto deps; the host does not. The container reads the same
+# /proc/cpuinfo serial, so its CN matches DEVICE_ID written above.
+docker run --rm \
+    -v /opt/aquila/config:/config \
+    -v /proc/cpuinfo:/proc/cpuinfo:ro \
+    "ghcr.io/${GHCR_REPO}-api:${IMAGE_TAG}" \
+    python -m aq_lib.device_csr /config
+
 run_test "docker-compose.yml downloaded"   "test -f /opt/fleet/docker-compose.yml"
 run_test "compose file non-empty"          "test -s /opt/fleet/docker-compose.yml"
 run_test "backend image pulled"            "docker images | grep -q 'aquilla-main-api'"
 run_test "ui image pulled"                 "docker images | grep -q 'aquilla-main-ui'"
 run_test "update.sh exists and executable" "test -x /opt/fleet/update.sh"
+run_test "device CSR generated"            "test -s /opt/aquila/config/device.csr"
+run_test "device key owner-only (0600)"    "test \"\$(stat -c '%a' /opt/aquila/config/device.key)\" = 600"
 
 phase_pass "docker-compose.yml downloaded, all images pulled"
 

--- a/scripts/deploy/deployment2.sh
+++ b/scripts/deploy/deployment2.sh
@@ -313,7 +313,8 @@ prompt_if_unset LID_HEATER_UPPER_BOUND "Enter lid heater upper bound voltage (e.
 prompt_if_unset LID_HEATER_LOWER_BOUND "Enter lid heater lower bound voltage (e.g. 0.20)"
 prompt_if_unset DRAWER_READ_STEPS      "Enter drawer read_steps for this device (e.g. 160)"
 prompt_if_unset AQ_SYNC_ENDPOINT  "Enter AQ_SYNC_ENDPOINT (AWS ingest URL, leave blank to skip)"
-prompt_if_unset AQ_SYNC_API_KEY   "Enter AQ_SYNC_API_KEY (fleet API key, leave blank to skip)"
+# The Fleet API Key is retired (ADR-013): the Sentri authenticates Sync with its
+# Device Certificate (mTLS), installed by scripts/enroll_device.py after deploy.
 
 WATCHTOWER_TOKEN="${WATCHTOWER_TOKEN:-$(openssl rand -hex 32)}"
 
@@ -340,7 +341,6 @@ GHCR_TOKEN=${GHCR_TOKEN}
 GHCR_TOKEN_2=${GHCR_TOKEN_2:-}
 AQ_SRC_BASEDIR=/opt/aquila
 AQ_SYNC_ENDPOINT=${AQ_SYNC_ENDPOINT}
-AQ_SYNC_API_KEY=${AQ_SYNC_API_KEY}
 EOF
 chown root:root /opt/aquila/config/device.env
 chmod 600 /opt/aquila/config/device.env

--- a/scripts/enroll_device.py
+++ b/scripts/enroll_device.py
@@ -1,0 +1,79 @@
+#!/usr/bin/env python3
+"""Operator-side device enrollment over Tailscale SSH (#240).
+
+Run this on the OPERATOR'S machine, where AWS credentials are present — never on
+the Pi. It pulls the Sentri's CSR off the Pi, enrols it against acorn-ca
+``/enroll`` (SigV4-signed with the operator's AWS identity), then installs the
+issued Device Certificate (``0600``) and updates ``device.env`` on the Pi over
+SSH. AWS credentials never touch the Pi.
+
+    python scripts/enroll_device.py --pi sn04 \
+        --endpoint https://rf2f9a0wie.execute-api.us-east-2.amazonaws.com/enroll \
+        --region us-east-2
+
+The CSR is produced on the Pi during deployment (#239). The Sync client reads
+the installed cert/key paths from ``device.env`` (#241).
+"""
+import argparse
+import subprocess
+import sys
+
+import botocore.session
+
+from aq_lib.enroll import EnrollmentError, device_env_after_enroll, enroll
+
+CONFIG_DIR = "/opt/aquila/config"
+CSR_PATH = f"{CONFIG_DIR}/device.csr"
+CERT_PATH = f"{CONFIG_DIR}/device.crt"
+KEY_PATH = f"{CONFIG_DIR}/device.key"
+ENV_PATH = f"{CONFIG_DIR}/device.env"
+
+
+def _ssh_read(pi, path):
+    return subprocess.run(
+        ["ssh", pi, "cat", path], check=True, capture_output=True, text=True
+    ).stdout
+
+
+def _ssh_write(pi, path, content, mode="600"):
+    # umask first so the file is never world-readable, even momentarily.
+    subprocess.run(
+        ["ssh", pi, f"umask 077 && cat > {path} && chmod {mode} {path}"],
+        input=content, check=True, capture_output=True, text=True,
+    )
+
+
+def main(argv=None):
+    p = argparse.ArgumentParser(description="Enrol a Sentri's Device Certificate.")
+    p.add_argument("--pi", required=True, help="Tailscale host/IP of the Sentri")
+    p.add_argument("--endpoint", required=True, help="acorn-ca /enroll URL")
+    p.add_argument("--region", default="us-east-2")
+    args = p.parse_args(argv)
+
+    creds = botocore.session.get_session().get_credentials()
+    if creds is None:
+        sys.exit(
+            "no AWS credentials on this machine — enrolment must run where the "
+            "operator is authenticated (creds never go on the Pi)"
+        )
+
+    csr_pem = _ssh_read(args.pi, CSR_PATH)
+    try:
+        cert_pem = enroll(
+            csr_pem, args.endpoint,
+            region=args.region, credentials=creds.get_frozen_credentials(),
+        )
+    except EnrollmentError as e:
+        sys.exit(f"enrolment failed: {e}")
+
+    _ssh_write(args.pi, CERT_PATH, cert_pem)
+    new_env = device_env_after_enroll(
+        _ssh_read(args.pi, ENV_PATH), cert_path=CERT_PATH, key_path=KEY_PATH
+    )
+    _ssh_write(args.pi, ENV_PATH, new_env)
+
+    print(f"enrolled {args.pi}: certificate installed at {CERT_PATH}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/verify_device_cert.py
+++ b/scripts/verify_device_cert.py
@@ -1,0 +1,57 @@
+#!/usr/bin/env python3
+"""Device-side certificate verification (#242).
+
+Runs ON the Pi. Presents the installed Device Certificate over mTLS to acorn-ca
+``/renew`` and reports whether it authenticates. Exits 0 (PASS) or non-zero
+(FAIL). No AWS credentials are needed — the certificate is the credential.
+
+    python scripts/verify_device_cert.py \
+        --renew-endpoint https://renew.cloud.acorngenetics.com/renew
+
+Cert/key paths and the Device ID default to the values enrollment wrote into
+``device.env`` (#240).
+"""
+import argparse
+import os
+import sys
+
+from aq_lib.verify import VerificationError, verify_renew
+
+
+def main(argv=None):
+    p = argparse.ArgumentParser(description="Verify the Device Certificate over mTLS.")
+    p.add_argument("--renew-endpoint", default=os.getenv("AQ_RENEW_ENDPOINT"))
+    p.add_argument("--cert", default=os.getenv("AQ_SYNC_CLIENT_CERT"))
+    p.add_argument("--key", default=os.getenv("AQ_SYNC_CLIENT_KEY"))
+    p.add_argument(
+        "--device-id",
+        default=os.getenv("AQ_SYNC_DEVICE_ID") or os.getenv("DEVICE_ID"),
+    )
+    args = p.parse_args(argv)
+
+    missing = [
+        name
+        for name, value in [
+            ("--renew-endpoint", args.renew_endpoint),
+            ("--cert", args.cert),
+            ("--key", args.key),
+            ("--device-id", args.device_id),
+        ]
+        if not value
+    ]
+    if missing:
+        sys.exit(f"missing required value(s): {', '.join(missing)}")
+
+    try:
+        verify_renew(
+            args.renew_endpoint,
+            cert_path=args.cert, key_path=args.key, device_id=args.device_id,
+        )
+    except VerificationError as e:
+        sys.exit(f"FAIL: {e}")
+
+    print("PASS: Device Certificate authenticated over mTLS to /renew")
+
+
+if __name__ == "__main__":
+    main()

--- a/specs/prd/kms-ca-enrollment-mtls-s3-verification-prd.md
+++ b/specs/prd/kms-ca-enrollment-mtls-s3-verification-prd.md
@@ -1,112 +1,177 @@
-# PRD: KMS-backed CA — password-gated device enrollment in deployment + mTLS→S3 verification slice
+# PRD: Device-side enrollment + mTLS cert verification slice (client of acorn-ca)
 
 > **Tracking issue:** [#176](https://github.com/AcornGenetics/aquilla-main/issues/176)
-> **Revision 1 — 2026-06-17**
+> **Revision 2 — 2026-06-26** (supersedes Rev 1, 2026-06-17)
 >
-> **Tracer-bullet vertical slice** carved from `specs/Data-pipline/device-edge-mtls-migration-prd.md`.
-> Anchored by **ADR-014** (device PKI: self-managed KMS-backed CA, on-device keygen, operator-authenticated enrollment) and **ADR-013** (device auth → mTLS; truststore in S3, consumed by API Gateway mTLS). Glossary in `CONTEXT.md` (Sentri, Device ID, Device Certificate, Ingest Endpoint, Sync, Event).
+> **What changed in Rev 2 — the six-repo split.** Rev 1 was written when aquilla-main
+> was a monolith: it had aquilla-main *bootstrap the CA*, *host the signing path*, and
+> *enable mTLS on its own SAM `HttpApi`* (`infra/template.yaml`), gated by an
+> **enrollment password**. That server side has since moved out and is **built and proven live**:
+> - **acorn-ca** owns the CA (KMS key + S3 truststore), the **`POST /enroll`** endpoint
+>   (operator-authenticated via **AWS SigV4/IAM**, *not* a password — ADR-0001), and the
+>   **`POST /renew`** mTLS endpoint.
+> - **acorn-analytics** owns the **Ingest Endpoint** (the Sync target) — *not yet built*.
 >
-> **Goal of this slice:** prove the whole chain end-to-end on real infrastructure — *KMS-backed CA exists → a Sentri enrolls during deployment (gated by an operator password) → the Sentri presents its Device Certificate to an mTLS gateway → the Event lands in S3.* It is the smallest runnable proof that ADR-014's PKI works before the broader renewal/Aurora/decommission work is built.
+> So aquilla-main is now **client-only**: it hosts **no endpoints**. This slice is the
+> on-device code that *calls out* to acorn-ca's endpoints — generate a keypair + CSR on
+> the Pi, get it enrolled, install the cert, present it over mTLS, and swap Sync off the
+> Fleet API Key. Anchored by **ADR-014** (device PKI) and **ADR-013** (device auth → mTLS).
+> Glossary in `CONTEXT.md`. acorn-ca's contract is in its `CONTEXT.md` + ADRs 0001–0006.
 
 ## Problem Statement
 
-I have ADR-014 (a self-managed, KMS-backed CA issuing per-device Device Certificates) on paper, but nothing that proves it works. Today a Sentri authenticates to the Ingest Endpoint with a shared Fleet API Key (`x-api-key`) that isn't even enforced, and my deployment script (`deployment2.sh`) just prompts for that shared key and writes it to `device.env`. There is:
+ADR-014's PKI is now real *on the CA side* — acorn-ca stands up a KMS-backed CA, issues
+short-lived per-device certificates via `POST /enroll` (operator SigV4), and renews them via
+`POST /renew` (mTLS). All of that is deployed and proven end-to-end.
 
-- no Certificate Authority actually standing (no KMS key, no root cert, no truststore in S3),
-- no way for a Sentri to *get* a certificate when I deploy it — and no gate stopping just anyone from minting one,
-- no demonstration that a certificate, once on a device, actually authenticates a real upload all the way into S3.
+But **no Sentri can use it yet.** On the device today:
 
-Until I can run that chain from nothing and watch an Event land in the bucket because of the certificate, I can't trust the design or build the rest of the migration on top of it.
+- there is no on-Pi step to **generate a keypair + CSR** (`CN=<Device ID>`) during deployment,
+- there is no step to **submit that CSR to acorn-ca `/enroll`** and **install** the returned
+  certificate + key,
+- `deployment2.sh` still prompts for and writes the retired shared **`AQ_SYNC_API_KEY`**, and
+  `aquila_web/sync.py` still authenticates Sync with an `x-api-key` header instead of a client
+  certificate,
+- there is no way to **verify** that a freshly enrolled certificate actually authenticates over
+  mTLS.
+
+Until a deployed Sentri can get a certificate from acorn-ca and prove it authenticates over
+mTLS, the device half of ADR-014 is unproven and the rest of the migration (renewal, Sync
+cutover, decommission) has nothing to build on.
 
 ## Solution
 
-From my (the operator's) and the fleet's perspective:
+From the operator's and the fleet's perspective — **device side only**:
 
-- **A CA exists, once, with one command.** A one-time bootstrap creates a non-extractable KMS asymmetric key, builds the self-signed root certificate by signing it through the KMS `Sign` API, and publishes the root (the **truststore**) to the S3 location the gateway's mTLS validation reads. The CA private key never exists outside the KMS HSM.
-- **Deploying a Sentri gets it a certificate.** When I run `deployment2.sh`, the Sentri generates its own keypair on-device and a CSR with `CN=<Device ID>`, I am prompted for an **enrollment password**, and the signing path issues a Device Certificate only if that password is valid. The certificate and key land on the Pi `chmod 600`; the device's private key never leaves the Pi and the Pi never holds a credential that could mint *other* certificates.
-- **The shared Fleet API Key is gone.** Deployment stops prompting for / writing `AQ_SYNC_API_KEY`; the Sentri presents its Device Certificate on Sync instead of an `x-api-key` header.
-- **I can verify it works.** A test/verification script run from the device presents the Device Certificate to the **mTLS Ingest Endpoint** and POSTs a sample Event; I can then see that exact Event archived as an object in the raw-events S3 bucket. A bad/absent/wrong-CA certificate fails the handshake and nothing lands. That is the proof.
+- **Deploying a Sentri gets it a certificate.** During `deployment2.sh` the Sentri generates
+  its own keypair on-device and a CSR with `CN=<Device ID>` (Device ID = the Pi hardware serial,
+  per `aq_lib/device_id.py` and `CONTEXT.md`). The CSR is submitted to acorn-ca **`POST /enroll`**.
+  The returned certificate and the device key land on the Pi `chmod 600`, with their paths
+  recorded in `device.env`. The device's private key never leaves the Pi.
+- **The gate is the operator's AWS identity, not a password.** `/enroll` is **SigV4/IAM**-authorized
+  (acorn-ca, ADR-0001), so the enroll call must be made by someone holding operator AWS credentials.
+  The Pi holds **no** AWS credentials and **no** credential that could mint *other* certificates —
+  it only ever holds its own keypair + leaf. (See *Implementation Decisions → Where the enroll call
+  runs* for the operator-mediated flow this implies.)
+- **The shared Fleet API Key is gone.** Deployment stops prompting for / writing `AQ_SYNC_API_KEY`;
+  `sync.py` drops the `x-api-key` header and presents the Device Certificate (client cert + key) on
+  the Sync POST instead.
+- **I can verify the certificate works.** A device-side verification script presents the Device
+  Certificate over **mTLS to acorn-ca `POST /renew`** and confirms the handshake succeeds (HTTP 200).
+  A missing / expired / wrong-CA certificate fails the TLS handshake and gets nothing. That is the
+  proof the certificate is CA-valid and that mTLS is actually enforced. *(Proving a real **Event**
+  lands in storage is the acorn-analytics Ingest Endpoint's job and waits on that edge — see Out of
+  Scope. `/renew` is the available, production-shaped mTLS target today.)*
 
 ## User Stories
 
-1. As an operator, I want a one-command CA bootstrap, so that I can stand up the Certificate Authority without hand-assembling keys.
-2. As a security-conscious operator, I want the CA private key created as a non-extractable KMS asymmetric key, so that the root signing key can never be exported or leaked.
-3. As an operator, I want the self-signed root certificate produced by signing through the KMS `Sign` API, so that the root is bound to the KMS key without the private key ever leaving the HSM.
-4. As an operator, I want the root certificate (truststore) published to the S3 location the gateway reads, so that API Gateway mTLS can validate device certificates against it.
-5. As an operator, I want the bootstrap to be idempotent / safe to re-run, so that re-running it does not silently create a second CA or clobber the live truststore.
-6. As a Sentri, I want to generate my own keypair on-device during deployment, so that my private key never leaves the Pi.
-7. As a Sentri, I want to build a CSR with `CN=<Device ID>`, so that my transport identity equals my data-model identity (the Pi hardware serial).
-8. As an operator, I want `deployment2.sh` to prompt me for an enrollment password (masked input), so that obtaining a certificate requires my authorization at provisioning time.
-9. As the signing path, I want to verify the enrollment password before signing a CSR, so that an unauthenticated caller cannot mint a Device Certificate.
-10. As the signing path, I want to sign the device CSR through the KMS `Sign` API, so that issuance uses the same HSM-held CA key as the root.
-11. As the signing path, I want to set the certificate's `CN` from the CSR's `CN` (the Device ID) and a short validity window, so that issued certificates carry the right identity and posture.
-12. As a Sentri, I want my certificate and private key written `chmod 600`, so that they are not world-readable on the device.
-13. As a Sentri, I want the certificate and key paths recorded in `device.env`, so that the Sync client and verification script can find them.
-14. As an operator, I want enrollment to fail loudly (non-zero exit, clear message) on a wrong password or signing error, so that a deployment never silently completes without a valid certificate.
-15. As an operator, I want `deployment2.sh` to stop prompting for and writing `AQ_SYNC_API_KEY`, so that the retired shared-key model is removed from new deployments.
-16. As a Sentri, I want to present my Device Certificate (client cert + key) on the Sync POST instead of an `x-api-key` header, so that I authenticate by mTLS.
-17. As an operator, I want the Ingest Endpoint gateway configured for mTLS with the S3 truststore, so that only certificates signed by my CA complete the handshake.
-18. As an operator, I want a verification script I can run from the device, so that I can confirm the certificate authenticates a real upload end-to-end.
-19. As an operator, I want the verification script to POST a sample Event over mTLS and then confirm the object exists in the raw-events S3 bucket, so that I have proof the chain works into storage, not just at the handshake.
-20. As an operator, I want the verification to fail when no certificate, an expired certificate, or a wrong-CA certificate is presented, so that I know the gateway is actually enforcing mTLS and not accepting anything.
-21. As a developer, I want the CSR-subject construction (`CN=Device ID`) extracted as pure logic, so that it is unit-testable without hardware.
-22. As a developer, I want the signing logic tested against a stubbed KMS, so that "valid password → signs; bad password → refuses" is verified without real AWS calls.
-23. As a developer, I want the device Sync auth change covered by the existing Sync test seam, so that "certificate sent, no `x-api-key`" is verified automatically.
-24. As a developer, I want the gateway mTLS + truststore configuration asserted against the infra template, so that a redeploy can't silently drop mTLS enforcement.
-25. As an operator, I want the existing raw-events S3 bucket and archiver path reused for verification, so that the slice proves the real ingest-to-storage route rather than a throwaway one.
+1. As a Sentri, I want to generate my own keypair on-device during deployment, so that my private key never leaves the Pi.
+2. As a Sentri, I want to build a CSR with `CN=<Device ID>` (the Pi hardware serial), so that my transport identity equals my data-model identity.
+3. As an operator, I want `deployment2.sh` to submit the CSR to acorn-ca `POST /enroll` using my AWS credentials (SigV4), so that issuance is gated by my AWS identity and no on-device secret can mint certificates.
+4. As a Sentri, I want my returned certificate and private key written `chmod 600`, so that they are not world-readable on the device.
+5. As a Sentri, I want the certificate and key paths recorded in `device.env`, so that the Sync client and verification script can find them.
+6. As an operator, I want enrollment to fail loudly (non-zero exit, clear message) on an auth or signing error, so that a deployment never silently completes without a valid certificate.
+7. As an operator, I want `deployment2.sh` to stop prompting for and writing `AQ_SYNC_API_KEY`, so that the retired shared-key model is removed from new deployments.
+8. As a Sentri, I want to present my Device Certificate (client cert + key) on the Sync POST instead of an `x-api-key` header, so that I authenticate by mTLS.
+9. As an operator, I want a device-side verification script that presents the certificate over mTLS to acorn-ca `/renew`, so that I can confirm the certificate authenticates and mTLS is enforced.
+10. As an operator, I want the verification to fail when no certificate, an expired certificate, or a wrong-CA certificate is presented, so that I know the gateway is actually enforcing mTLS and not accepting anything.
+11. As a developer, I want the CSR-subject construction (`CN=Device ID`) extracted as pure logic, so that it is unit-testable without hardware.
+12. As a developer, I want the device Sync auth change covered by the existing Sync test seam, so that "certificate sent, no `x-api-key`" is verified automatically.
+13. As a developer, I want the Device ID derivation reconciled to the Pi hardware serial (not the hostname) wherever the CSR `CN` is built, so that the device's `CN` matches what the platform treats as the Device ID.
 
 ## Implementation Decisions
 
-### CA bootstrap (self-managed, KMS-backed — ADR-014)
-- A one-time bootstrap (a `scripts/` utility) creates a **KMS asymmetric key** (usage `SIGN_VERIFY`, e.g. RSA/ECC), reads its **public key**, and assembles a **self-signed root certificate** whose signature is produced via the KMS `Sign` API (the private key is non-extractable and never leaves the HSM).
-- The root certificate (the **truststore** / CA public cert) is uploaded to the **S3 location the gateway's mTLS validation reads**. The KMS private key is the single root of trust; no raw CA key file ever exists on disk.
-- Bootstrap is **idempotent / guarded**: re-running detects an existing CA key + truststore and refuses to silently replace them.
+### Where the enroll call runs (operator-mediated) — *the key Rev-2 design point*
+`/enroll` is SigV4-authorized, and **the Pi has no AWS credentials by design** — so the Pi cannot
+call `/enroll` itself. Enrollment is therefore **operator-mediated**: the Pi produces the
+keypair + CSR, the **operator** (running with their AWS credentials) submits the CSR to `/enroll`,
+and the returned certificate is installed back onto the Pi. Concretely, `deployment2.sh` is run by
+the operator during provisioning in a context where AWS credentials are available (e.g. the operator's
+session/host), generating the CSR and orchestrating the enroll → install. **The private key never
+leaves the Pi and AWS credentials never land on the Pi.** *(This is the central change from Rev 1's
+password model, which the Pi could complete unattended — confirm before building.)*
 
-### Certificate signing path (operator-authenticated — "enrollment password")
-- A signing function takes a **CSR + an enrollment token/password**, **verifies the password first**, and only then signs the CSR via KMS `Sign`, returning a Device Certificate with `CN` carried from the CSR and a short validity window.
-- A wrong/absent password is rejected without signing. (Where the signing path is hosted — small Lambda vs. local invocation during this slice — is an implementation detail; the contract is *password-gated, KMS-signed issuance*. Auto-renewal and a cert-authenticated renewal endpoint are **out of scope** here — see Out of Scope.)
+### On-device keygen + CSR (`deployment2.sh`)
+- The Sentri generates its own keypair and a CSR with `CN=<Device ID>`. **Device ID is the Pi hardware
+  serial** (`aq_lib/device_id.py` → `/proc/cpuinfo`), *not* the hostname. `deployment2.sh` currently
+  derives `DEVICE_ID` from the hostname — reconcile it to the serial so the CSR `CN` matches the
+  platform identity (acorn-ca treats the cert `CN` as the Device ID).
+- The pure logic (CSR subject construction = `CN=Device ID`) is extracted into Python so it is
+  unit-testable; the on-device keygen/install steps are host-dependent.
 
-### Device enrollment in `deployment2.sh`
-- During deployment the Sentri **generates its own keypair** and a **CSR with `CN=<Device ID>`** (Device ID = the Pi hardware serial per `CONTEXT.md`; the script already establishes a `DEVICE_ID`).
-- `deployment2.sh` prompts for the **enrollment password using its existing masked-prompt helper** (`prompt_if_unset … true` / `read -rsp`), submits CSR + password to the signing path, and on success writes the **certificate and key `chmod 600`** and records their paths in `device.env`.
-- The script **stops prompting for and writing `AQ_SYNC_API_KEY`**; the Fleet API Key is removed from new deployments. Enrollment failure (bad password / signing error) **exits non-zero with a clear message** — no silent completion.
-- Pure logic (CSR subject construction = `CN=Device ID`) is extracted into Python so it is unit-testable; the on-device keygen/install steps are host-dependent.
+### Enroll + install
+- Submit CSR to acorn-ca **`POST /enroll`** with SigV4. On success, write the returned certificate and
+  the device key `chmod 600` and record their paths in `device.env`. Enrollment failure (auth error,
+  signing error, revoked Device ID → 403) **exits non-zero with a clear message** — no silent completion.
+- Stop prompting for / writing `AQ_SYNC_API_KEY`; remove the Fleet API Key from new deployments.
 
 ### Device Sync auth (`aquila_web/sync.py`)
-- The Sync client **drops the `x-api-key` header** and presents the **client certificate + key** on the POST (`cert=(client_cert, client_key)` style). Certificate/key paths come from `device.env`. The Event payload shape is **unchanged** (still keyed on `device_id`).
-
-### mTLS gateway → S3 (reuse existing SAM ingest path)
-- Enable **mTLS on the existing `AWS::Serverless::HttpApi` Ingest Endpoint** (`infra/template.yaml`) with the **S3 truststore** from bootstrap; disable the default execute-api endpoint so only the mTLS-validated path is reachable. The existing **`S3ArchiverFunction` → `RawEventsBucket` (`sentri-raw-events-${AccountId}`)** route is **reused** as the ingest-to-storage path under test.
-- This is the production-shaped verification path (API Gateway mTLS per ADR-013), not IAM Roles Anywhere.
+- The Sync client **drops the `x-api-key` header** and presents the **client certificate + key** on the
+  POST (`cert=(client_cert, client_key)` style). Certificate/key paths come from `device.env`. The Event
+  payload shape is **unchanged** (still keyed on `device_id`). *(The live Sync target is acorn-analytics'
+  Ingest Endpoint, which is not built yet — this slice lands the client-side auth change and unit-tests
+  it; the live Sync-to-storage acceptance is gated on that edge.)*
 
 ### Verification script
-- A device-side script loads the Device Certificate from `device.env`, **POSTs a sample Event over mTLS** to the Ingest Endpoint, then **confirms the resulting object exists in `RawEventsBucket`**. Negative cases (no cert / expired / wrong-CA) must fail the handshake and land nothing.
+- A device-side script loads the Device Certificate from `device.env` and **POSTs over mTLS to acorn-ca
+  `POST /renew`**, asserting a successful handshake (HTTP 200). Negative cases (no cert / expired /
+  wrong-CA) must fail the handshake and return nothing. This is the available, production-shaped mTLS
+  proof until the acorn-analytics ingest edge exists.
 
 ## Testing Decisions
 
-Good tests assert **external behavior at the highest available seam** — what the device puts on the wire, what the signing path returns for good vs. bad input, and what infra resources exist — not internal call order. Mock the network boundary (`requests.post`) and AWS boundaries (botocore `Stubber` / `tmp_path`) rather than reaching for real services in unit tests.
+Assert **external behavior at the highest available seam** — what the device puts on the wire, and the
+pure CSR-subject logic — not internal call order. Mock the network boundary (`requests.post`) rather
+than reaching real services in unit tests.
 
-- **Device Sync auth — existing seam (`POST /sync/flush` → `aquila_web.sync`).** Prior art: `tests/unit/test_background_sync.py` (monkeypatches `aquila_web.sync.requests.post`, captures call kwargs). Replace the `x-api-key` assertion with: the client-certificate tuple is passed and **no** `x-api-key` header is present. Keep "no endpoint → synced 0" and "network error swallowed, events stay pending" green.
-- **CSR subject construction.** Pure-logic unit test (`unit_tests/`): given a Device ID, the CSR subject is `CN=<Device ID>`. Prior art: `unit_tests/test_optics_history.py`, `tests/unit/test_device_id.py`.
-- **CA bootstrap + signing.** Unit test the cert-assembly + signing logic against a **stubbed KMS** (botocore `Stubber`): root cert is signed via KMS `Sign`; a device CSR with a valid enrollment password is signed and carries `CN` from the CSR; a **wrong/absent password is refused without a `Sign` call**; re-running bootstrap against an existing CA refuses to clobber. Prior art for handler/infra-style tests: `tests/infra/` (`test_s3_archiver.py`, `test_ingest_handler.py`).
-- **Gateway mTLS + truststore.** Light infra assertion: parse `infra/template.yaml` and assert the HttpApi has mTLS enabled, references the S3 truststore, disables the default execute-api endpoint, and that the `S3ArchiverFunction` → `RawEventsBucket` route is intact. Prior art: `tests/infra/conftest.py` template-parsing pattern.
-- **Enrollment / on-device keygen.** Host-dependent (keygen, install, `deployment2.sh`) — mark `@pytest.mark.hardware` with a documented "why not CI" note per the repo testing rules; cover the extractable pure logic (CSR subject) above.
-- **End-to-end acceptance (the real proof).** After `sam deploy` + bootstrap: from a Sentri with an enrolled certificate, the verification script POSTs a sample Event over mTLS and the matching object appears in `RawEventsBucket`; presenting no / expired / wrong-CA certificate fails the handshake and lands nothing.
+- **Device Sync auth — existing seam (`POST /sync/flush` → `aquila_web.sync`).** Prior art:
+  `tests/unit/test_background_sync.py` (monkeypatches `aquila_web.sync.requests.post`, captures call
+  kwargs). Replace the `x-api-key` assertion with: the client-certificate tuple is passed and **no**
+  `x-api-key` header is present. Keep "no endpoint → synced 0" and "network error swallowed, events
+  stay pending" green.
+- **CSR subject construction.** Pure-logic unit test (`unit_tests/`): given a Device ID, the CSR subject
+  is `CN=<Device ID>`. Prior art: `tests/unit/test_device_id.py`.
+- **Enrollment / on-device keygen + install.** Host-dependent (keygen, install, `deployment2.sh`) — mark
+  `@pytest.mark.hardware` with a documented "why not CI" note per the repo testing rules; cover the
+  extractable pure logic (CSR subject, Device ID = serial) above.
+- **End-to-end acceptance (the real proof).** Against a **live acorn-ca**: from a Sentri enrolled via
+  `/enroll`, the verification script presents the cert over mTLS to `/renew` and gets HTTP 200;
+  presenting no / expired / wrong-CA certificate fails the handshake.
+- **CA bootstrap / signing / truststore / gateway-mTLS tests are no longer in this repo** — they live in
+  **acorn-ca** (which owns and tests them). Do not re-create them here.
 
 ## Out of Scope
 
-Owned by the broader migration PRD (`specs/Data-pipline/device-edge-mtls-migration-prd.md`) or the **Sentri Analytics Platform** (`Acorn/sentri-analytics`), **not** this slice:
+Owned by **acorn-ca**, **acorn-analytics**, or later aquilla-main slices — **not** this slice:
 
-- **Automatic certificate renewal**, the cert-authenticated renewal endpoint (`POST /sync/cert/renew`), the on-device renewal daemon, atomic mid-renewal swap, and the offline-too-long re-enrollment path. This slice is **enroll-once + verify**; renewal is the next slice.
-- Revocation-by-non-renewal mechanics beyond the short validity window itself.
-- The full production **Sentri Analytics Platform edge** (VPC Link, internal ALB, ASG, the Node `/ingest` app, regional custom domain, rate-limit store). This slice reuses the existing SAM `HttpApi` + `S3ArchiverFunction` + `RawEventsBucket` purely to prove the certificate chain.
-- **Aurora connectivity** (peering, return route, `DBSecurityGroup` ingress, `sentri_readonly` role) — independent track in the broader PRD.
-- **Decommissioning** the old SAM ingest stack and the **big-bang fleet cutover**.
-- Backfill-tool auth change; any Event payload schema change (this slice is auth-only); any dev-fleet certificate isolation (one prod fleet, one CA).
+- **The entire CA + signing side** — KMS key, root cert, truststore publish (C1), `/enroll`, `/renew`,
+  the revocation feed (C2), enrollment-password logic. Owned and proven in **acorn-ca**.
+- **The Ingest Endpoint and the live Sync-to-storage proof** (mTLS gateway → S3/RDS) — owned by
+  **acorn-analytics** (ADR-015), not yet built. This slice verifies the certificate against acorn-ca
+  `/renew`; the full Event-into-storage acceptance follows once that edge exists.
+- **Automatic certificate renewal** — the on-device renewal daemon (daily attempt, atomic swap when
+  <3 days remain) and the offline-too-long **re-enrollment** fallback. Next aquilla-main slice.
+- **Decommissioning** the old SAM ingest stack and the big-bang fleet cutover.
+- Any Event payload schema change (this slice is auth-only); backfill-tool auth change; any dev-fleet
+  certificate isolation (one prod fleet, one CA).
+
+## Dependencies / Preconditions
+
+- **acorn-ca deployed and live** — `/enroll` + `/renew` reachable. *(Currently neither dev nor prod is
+  deployed; only the CI/CD stack exists. A dev redeploy or the prod deploy (#25) is required before the
+  acceptance test can run. Code + unit tests can be built now against mocks.)*
+- **Operator AWS credentials** available wherever the enroll call is made (for SigV4).
+- The `renew.cloud.acorngenetics.com` mTLS domain (prod) or the dev equivalent, depending on which
+  acorn-ca environment is live.
 
 ## Further Notes
 
-- This is intentionally the **smallest end-to-end runnable proof** of ADR-014: CA → enrollment (password-gated) → certificate on device → mTLS → S3. Everything in scope can be built and unit-tested now against mocks; the **acceptance test** needs the bootstrapped CA, the mTLS-enabled gateway, and one enrolled Sentri.
-- The short-validity posture is acceptable here because the slice doesn't yet auto-renew — certificates are issued fresh for the verification run. Renewal is deferred to the next slice by design.
-- The KMS-backed CA eliminates the ~$400/mo ACM Private CA cost while keeping HSM-grade key custody (ADR-014); long-lived certs + a deny-list remain the documented fallback if the eventual auto-renewal proves fragile.
-- Device ID note: `deployment2.sh` currently derives `DEVICE_ID` from the hostname; `CONTEXT.md`/ADR-014 define Device ID as the Pi hardware serial. Reconciling the two is a small clarification to settle during implementation (the CSR `CN` must equal whatever the platform treats as the Device ID).
+- This is the **smallest end-to-end runnable proof** of the *device half* of ADR-014 in the post-split
+  world: keypair/CSR on the Pi → operator-mediated enroll against acorn-ca → certificate installed →
+  mTLS handshake proven. Everything in scope can be built and unit-tested now against mocks; the
+  **acceptance test** needs a live acorn-ca.
+- BUILD.md sequences **acorn-analytics' ingest edge before** aquilla-main's device side precisely because
+  the device's ultimate Sync target lives there. Building the "get a cert + verify via `/renew`" half now
+  is fine and de-risks the device code; the live Sync proof waits on that edge.
+- The short-validity posture is acceptable here because this slice doesn't auto-renew — certificates are
+  issued fresh for the verification run. Renewal is the next slice by design.

--- a/tests/unit/test_background_sync.py
+++ b/tests/unit/test_background_sync.py
@@ -28,14 +28,15 @@ def _seed_event(local_db, tmp_path):
     local_db.enqueue_event("run_complete", {"run_name": "Run 1", "profile": "p.json", "result": "ok"})
 
 
-class TestApiKeyHeader:
-    """AQ_SYNC_API_KEY is sent as x-api-key header."""
+class TestClientCertificate:
+    """Sync authenticates with the Device Certificate (mTLS), not x-api-key."""
 
-    def test_api_key_sent_as_header_when_set(self, db_client, tmp_path, monkeypatch):
+    def test_presents_client_cert_and_sends_no_api_key(self, db_client, tmp_path, monkeypatch):
         client, local_db = db_client
         _seed_event(local_db, tmp_path)
         monkeypatch.setenv("AQ_SYNC_ENDPOINT", "http://fake-aws/ingest")
-        monkeypatch.setenv("AQ_SYNC_API_KEY", "test-fleet-key-abc")
+        monkeypatch.setenv("AQ_SYNC_CLIENT_CERT", "/opt/aquila/config/device.crt")
+        monkeypatch.setenv("AQ_SYNC_CLIENT_KEY", "/opt/aquila/config/device.key")
 
         captured = {}
 
@@ -44,18 +45,27 @@ class TestApiKeyHeader:
             def raise_for_status(self): pass
 
         def _capture(*a, **kw):
-            captured["headers"] = kw.get("headers", {})
+            captured.update(kw)
             return _OK()
 
         monkeypatch.setattr("aquila_web.sync.requests.post", _capture)
         client.post("/sync/flush")
-        assert captured["headers"].get("x-api-key") == "test-fleet-key-abc"
 
-    def test_no_api_key_header_when_env_var_not_set(self, db_client, tmp_path, monkeypatch):
+        # The client certificate tuple is presented for the mTLS handshake...
+        assert captured["cert"] == (
+            "/opt/aquila/config/device.crt",
+            "/opt/aquila/config/device.key",
+        )
+        # ...and the retired Fleet API Key header is gone.
+        assert "x-api-key" not in captured.get("headers", {})
+
+    def test_lingering_api_key_env_var_is_ignored(self, db_client, tmp_path, monkeypatch):
+        # A stale AQ_SYNC_API_KEY left in the environment must never resurrect
+        # the retired header — the key model is gone, not merely defaulted off.
         client, local_db = db_client
         _seed_event(local_db, tmp_path)
         monkeypatch.setenv("AQ_SYNC_ENDPOINT", "http://fake-aws/ingest")
-        monkeypatch.delenv("AQ_SYNC_API_KEY", raising=False)
+        monkeypatch.setenv("AQ_SYNC_API_KEY", "stale-fleet-key")
 
         captured = {}
 
@@ -64,11 +74,12 @@ class TestApiKeyHeader:
             def raise_for_status(self): pass
 
         def _capture(*a, **kw):
-            captured["headers"] = kw.get("headers", {})
+            captured.update(kw)
             return _OK()
 
         monkeypatch.setattr("aquila_web.sync.requests.post", _capture)
         client.post("/sync/flush")
+
         assert "x-api-key" not in captured.get("headers", {})
 
 

--- a/unit_tests/test_device_csr.py
+++ b/unit_tests/test_device_csr.py
@@ -1,0 +1,93 @@
+"""
+Unit tests for on-device keypair + CSR generation (aq_lib/device_csr.py).
+
+Pure logic, no hardware: a Sentri generates its own keypair and a CSR whose
+Subject CN is its Device ID (the Pi hardware serial). Issue #239.
+"""
+from cryptography import x509
+from cryptography.hazmat.primitives import serialization
+from cryptography.hazmat.primitives.asymmetric import ec
+from cryptography.x509.oid import NameOID
+
+import pytest
+
+from aq_lib.device_csr import (
+    enrollment_device_id,
+    generate_device_csr,
+    write_device_csr,
+)
+
+CPUINFO_WITH_SERIAL = (
+    "Hardware\t: BCM2711\n"
+    "Serial\t\t: 10000000a6b7d43e\n"
+    "Model\t: Raspberry Pi 4 Model B Rev 1.5\n"
+)
+
+
+class TestGenerateDeviceCsr:
+    def test_csr_subject_cn_is_the_device_id(self):
+        device_id = "10000000a6b7d43e"
+        _key_pem, csr_pem = generate_device_csr(device_id)
+
+        csr = x509.load_pem_x509_csr(csr_pem)
+        (cn,) = csr.subject.get_attributes_for_oid(NameOID.COMMON_NAME)
+        assert cn.value == device_id
+
+    def test_csr_is_signed_by_its_own_key(self):
+        # The CSR proves the device holds the private key for the public key it
+        # presents — a CA can trust the CSR came from the device it names.
+        _key_pem, csr_pem = generate_device_csr("10000000a6b7d43e")
+
+        csr = x509.load_pem_x509_csr(csr_pem)
+        assert csr.is_signature_valid is True
+
+    def test_private_key_is_ec_p256_matching_the_csr(self):
+        # The returned key is a usable EC P-256 private key, and it is *the* key
+        # whose public half the CSR carries — so installing it lets the device
+        # use the certificate the CA issues against this CSR.
+        key_pem, csr_pem = generate_device_csr("10000000a6b7d43e")
+
+        key = serialization.load_pem_private_key(key_pem, password=None)
+        assert isinstance(key, ec.EllipticCurvePrivateKey)
+        assert isinstance(key.curve, ec.SECP256R1)
+
+        csr = x509.load_pem_x509_csr(csr_pem)
+        assert csr.public_key().public_numbers() == key.public_key().public_numbers()
+
+
+class TestEnrollmentDeviceId:
+    def test_is_the_pi_hardware_serial(self, tmp_path):
+        # The enrollment identity is the Pi serial (CONTEXT.md), not the
+        # hostname — the cert CN must equal what the platform treats as Device ID.
+        f = tmp_path / "cpuinfo"
+        f.write_text(CPUINFO_WITH_SERIAL)
+        assert enrollment_device_id(str(f)) == "10000000a6b7d43e"
+
+    def test_raises_rather_than_falling_back_to_hostname(self, tmp_path):
+        # No serial → fail loudly. Never enroll under a mutable identity (the old
+        # hostname-derived DEVICE_ID), which would mint a cert under the wrong CN.
+        with pytest.raises(RuntimeError):
+            enrollment_device_id(str(tmp_path / "nonexistent"))
+
+
+class TestWriteDeviceCsr:
+    def test_writes_owner_only_key_and_csr_named_for_the_serial(self, tmp_path):
+        cpuinfo = tmp_path / "cpuinfo"
+        cpuinfo.write_text(CPUINFO_WITH_SERIAL)
+        out = tmp_path / "config"
+        out.mkdir()
+
+        device_id = write_device_csr(str(out), cpuinfo_path=str(cpuinfo))
+
+        # Caller (the enroll step, #240) gets the Device ID back.
+        assert device_id == "10000000a6b7d43e"
+
+        key = out / "device.key"
+        csr_file = out / "device.csr"
+        assert key.exists() and csr_file.exists()
+        # The private key is written owner-only — never world-readable on the Pi.
+        assert (key.stat().st_mode & 0o777) == 0o600
+        # The CSR carries the Pi serial as its CN.
+        csr = x509.load_pem_x509_csr(csr_file.read_bytes())
+        (cn,) = csr.subject.get_attributes_for_oid(NameOID.COMMON_NAME)
+        assert cn.value == "10000000a6b7d43e"

--- a/unit_tests/test_enroll.py
+++ b/unit_tests/test_enroll.py
@@ -1,0 +1,111 @@
+"""
+Unit tests for operator-side device enrollment against acorn-ca /enroll (#240).
+
+The operator (with AWS creds) SigV4-POSTs a Sentri's CSR to acorn-ca /enroll and
+gets back the Device Certificate. The Pi makes no AWS call. Network boundary is
+injected/mocked; no real AWS.
+"""
+import pytest
+from botocore.credentials import Credentials
+
+from aq_lib.enroll import (
+    EnrollmentDenied,
+    EnrollmentError,
+    device_env_after_enroll,
+    enroll,
+)
+
+DUMMY_CREDS = Credentials("AKIDEXAMPLE", "secret")
+ENDPOINT = "https://rf2f9a0wie.execute-api.us-east-2.amazonaws.com/enroll"
+CSR_PEM = "-----BEGIN CERTIFICATE REQUEST-----\nMIIB...\n-----END CERTIFICATE REQUEST-----\n"
+CERT_PEM = "-----BEGIN CERTIFICATE-----\nMIIC...\n-----END CERTIFICATE-----\n"
+
+
+class FakeResponse:
+    def __init__(self, status_code, json_body):
+        self.status_code = status_code
+        self._json = json_body
+
+    def json(self):
+        return self._json
+
+
+class TestEnroll:
+    def test_returns_the_certificate_on_200(self):
+        def fake_post(url, data=None, headers=None):
+            return FakeResponse(200, {"certificate": CERT_PEM})
+
+        cert = enroll(
+            CSR_PEM, ENDPOINT, region="us-east-2",
+            credentials=DUMMY_CREDS, http_post=fake_post,
+        )
+        assert cert == CERT_PEM
+
+    def test_posts_the_csr_body_sigv4_signed_to_enroll(self):
+        captured = {}
+
+        def fake_post(url, data=None, headers=None):
+            captured.update(url=url, data=data, headers=headers)
+            return FakeResponse(200, {"certificate": CERT_PEM})
+
+        enroll(
+            CSR_PEM, ENDPOINT, region="us-east-2",
+            credentials=DUMMY_CREDS, http_post=fake_post,
+        )
+
+        assert captured["url"] == ENDPOINT
+        assert captured["data"] == CSR_PEM
+        # SigV4 over the execute-api service in the given region.
+        auth = captured["headers"]["Authorization"]
+        assert auth.startswith("AWS4-HMAC-SHA256")
+        assert "/us-east-2/execute-api/aws4_request" in auth
+
+    def test_revoked_device_raises_enrollment_denied(self):
+        # acorn-ca returns 403 for a revoked Device ID — provisioning must stop
+        # loudly, not write a non-cert as if it were a certificate.
+        def fake_post(url, data=None, headers=None):
+            return FakeResponse(403, {"error": "Device ID 10000000a6b7d43e is revoked"})
+
+        with pytest.raises(EnrollmentDenied) as exc:
+            enroll(
+                CSR_PEM, ENDPOINT, region="us-east-2",
+                credentials=DUMMY_CREDS, http_post=fake_post,
+            )
+        assert "revoked" in str(exc.value)
+
+    def test_malformed_csr_400_raises_enrollment_error(self):
+        # Any other non-200 (e.g. 400 malformed Device ID) also fails loudly,
+        # carrying the status so the operator can see what happened.
+        def fake_post(url, data=None, headers=None):
+            return FakeResponse(400, {"error": "malformed Device ID: nope"})
+
+        with pytest.raises(EnrollmentError) as exc:
+            enroll(
+                CSR_PEM, ENDPOINT, region="us-east-2",
+                credentials=DUMMY_CREDS, http_post=fake_post,
+            )
+        assert "400" in str(exc.value)
+
+
+class TestDeviceEnvAfterEnroll:
+    def test_adds_cert_and_key_paths_and_drops_the_api_key(self):
+        env = (
+            "DEVICE_ID=10000000a6b7d43e\n"
+            "AQ_SYNC_ENDPOINT=https://ingest.example\n"
+            "AQ_SYNC_API_KEY=old-fleet-secret\n"
+        )
+        out = device_env_after_enroll(
+            env,
+            cert_path="/opt/aquila/config/device.crt",
+            key_path="/opt/aquila/config/device.key",
+        )
+        lines = out.splitlines()
+
+        # The retired Fleet API Key is gone entirely.
+        assert not any(line.startswith("AQ_SYNC_API_KEY") for line in lines)
+        # The Device Certificate paths are recorded for the Sync client (#241).
+        assert "AQ_SYNC_CLIENT_CERT=/opt/aquila/config/device.crt" in lines
+        assert "AQ_SYNC_CLIENT_KEY=/opt/aquila/config/device.key" in lines
+        # Unrelated config is preserved.
+        assert "DEVICE_ID=10000000a6b7d43e" in lines
+        assert "AQ_SYNC_ENDPOINT=https://ingest.example" in lines

--- a/unit_tests/test_verify.py
+++ b/unit_tests/test_verify.py
@@ -1,0 +1,80 @@
+"""
+Unit tests for device-side certificate verification against acorn-ca /renew (#242).
+
+The Sentri presents its installed Device Certificate over mTLS to /renew to prove
+the certificate authenticates and that mTLS is enforced. Network boundary is
+injected/mocked; no real TLS.
+"""
+import pytest
+import requests
+from cryptography import x509
+from cryptography.x509.oid import NameOID
+
+from aq_lib.verify import VerificationError, verify_renew
+
+RENEW_ENDPOINT = "https://renew.example/renew"
+CERT_PATH = "/opt/aquila/config/device.crt"
+KEY_PATH = "/opt/aquila/config/device.key"
+DEVICE_ID = "10000000a6b7d43e"
+RENEWED_PEM = "-----BEGIN CERTIFICATE-----\nMIIRENEWED\n-----END CERTIFICATE-----\n"
+
+
+class FakeResponse:
+    def __init__(self, status_code, json_body):
+        self.status_code = status_code
+        self._json = json_body
+
+    def json(self):
+        return self._json
+
+
+class TestVerifyRenew:
+    def test_presents_cert_and_csr_and_returns_renewed_cert_on_200(self):
+        captured = {}
+
+        def fake_post(url, data=None, cert=None):
+            captured.update(url=url, data=data, cert=cert)
+            return FakeResponse(200, {"certificate": RENEWED_PEM})
+
+        cert = verify_renew(
+            RENEW_ENDPOINT, cert_path=CERT_PATH, key_path=KEY_PATH,
+            device_id=DEVICE_ID, http_post=fake_post,
+        )
+
+        assert cert == RENEWED_PEM
+        # The Device Certificate is presented for the mTLS handshake...
+        assert captured["cert"] == (CERT_PATH, KEY_PATH)
+        assert captured["url"] == RENEW_ENDPOINT
+        # ...alongside a CSR whose CN matches the cert identity (renew requires it).
+        csr = x509.load_pem_x509_csr(
+            captured["data"] if isinstance(captured["data"], bytes) else captured["data"].encode()
+        )
+        (cn,) = csr.subject.get_attributes_for_oid(NameOID.COMMON_NAME)
+        assert cn.value == DEVICE_ID
+
+    def test_tls_handshake_rejection_raises_verification_error(self):
+        # A missing/expired/wrong-CA client cert is rejected at the TLS layer —
+        # requests surfaces that as SSLError. Verification must fail clearly, not
+        # leak a raw SSL traceback.
+        def fake_post(url, data=None, cert=None):
+            raise requests.exceptions.SSLError("certificate verify failed")
+
+        with pytest.raises(VerificationError) as exc:
+            verify_renew(
+                RENEW_ENDPOINT, cert_path=CERT_PATH, key_path=KEY_PATH,
+                device_id=DEVICE_ID, http_post=fake_post,
+            )
+        assert "handshake" in str(exc.value).lower()
+
+    def test_non_200_response_raises_verification_error_with_status(self):
+        # The handshake succeeded but the app rejected it (e.g. 403 CN mismatch).
+        # Still a verification failure, surfaced with the status.
+        def fake_post(url, data=None, cert=None):
+            return FakeResponse(403, {"error": "mTLS client certificate required"})
+
+        with pytest.raises(VerificationError) as exc:
+            verify_renew(
+                RENEW_ENDPOINT, cert_path=CERT_PATH, key_path=KEY_PATH,
+                device_id=DEVICE_ID, http_post=fake_post,
+            )
+        assert "403" in str(exc.value)


### PR DESCRIPTION
Ships the **device side of acorn-ca's PKI** (ADR-013/014): a Sentri gets a Device Certificate from acorn-ca and uses it for mTLS, replacing the retired Fleet API Key. Assembled on `feature/device-cert-enrollment` from four TDD slices.

Closes #239, closes #240, closes #241, closes #242.

## What lands
| Slice | Behavior | Live-proven |
|---|---|---|
| #239 | On-Pi keypair + CSR, `CN` = **Pi serial** (was hostname) | unit (pure crypto) |
| #240 | **Operator-mediated enroll** (SigV4, creds never on the Pi) + install `0600` + `device.env`; Fleet API Key dropped | **yes** — real CSR → CA-chained 14-day cert against the live dev CA |
| #241 | Sync presents `cert=(cert,key)` over mTLS, **drops `x-api-key`** | unit (existing sync seam) |
| #242 | Device-side verify via mTLS to `/renew` | unit (live deferred — see below) |

## Design decisions baked in
- **`renew.cloud.acorngenetics.com` is reserved for prod**; dev is domain-free. So #242's **live** mTLS handshake (cert→200 / certless→TLS-reject) is proven at the **prod** deploy. The verify *logic* is fully unit-tested here.
- Enrollment is **operator-mediated over SSH** (the Pi holds no AWS creds, by design). The SSH transport in `scripts/enroll_device.py` / `scripts/verify_device_cert.py` is the integration layer — hardware-only, not CI; the logic it calls is unit-tested.

## New modules
`aq_lib/device_csr.py` · `aq_lib/enroll.py` · `aq_lib/verify.py` (+ `scripts/enroll_device.py`, `scripts/verify_device_cert.py`). `deployment2.sh` derives `DEVICE_ID` from the Pi serial, generates the CSR in-container, and no longer writes `AQ_SYNC_API_KEY`. PRD revised to Rev 2 (six-repo split).

## Tests
**26 green** across the feature (device_csr 6 · enroll 5 · verify 3 · sync 5 · device_id 7). `cryptography` + `botocore` pinned.

## Follow-ups (not in this PR)
- Prod CA deploy → wire the renew domain → prove #242 live (acorn-ca #25; acorn-ca PR #29 documents the reserved-for-prod status).
- Renewal daemon / re-enrollment fallback (next aquilla-main slice).
- Live Sync-to-storage proof — gated on acorn-analytics' Ingest Endpoint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)