### PR TITLE
#252 address PR #218 review concerns 1-4

### DIFF
--- a/aquila_web/main.py
+++ b/aquila_web/main.py
@@ -1464,9 +1464,12 @@ async def save_profile(payload: ProfileSave):
     elif requested_title:
         sanitized_title = sanitize_name(requested_title)
         if sanitized_title and profile_path.stem != sanitized_title:
-            candidate_path = profile_dir / f"{sanitized_title}.json"
+            # Rename within the profile's own directory (e.g. local/) rather than
+            # the profiles root, so editing+renaming doesn't relocate the file (#218 review).
+            rename_dir = profile_path.parent
+            candidate_path = rename_dir / f"{sanitized_title}.json"
             if candidate_path.exists() and candidate_path != profile_path:
-                candidate_path = profile_dir / f"{sanitized_title}_{int(datetime.now().timestamp())}.json"
+                candidate_path = rename_dir / f"{sanitized_title}_{int(datetime.now().timestamp())}.json"
             profile_path = candidate_path
 
     # Structured profiles (issue #213) get the full canonical key order; legacy

--- a/aquila_web/static/profiles/builder.html
+++ b/aquila_web/static/profiles/builder.html
@@ -164,6 +164,6 @@
     </main>
   </div>
   <script src="/static/nav.js?v=1"></script>
-  <script src="/static/profiles/builder.js?v=5"></script>
+  <script src="/static/profiles/builder.js?v=6"></script>
 </body>
 </html>

--- a/aquila_web/static/profiles/builder.js
+++ b/aquila_web/static/profiles/builder.js
@@ -8,11 +8,10 @@
   // Stages with an enable checkbox. Amplification is always present (no toggle).
   var OPTIONAL_STAGES = ["incubation", "denaturation", "finalhold"];
 
-  // When the URL carries ?id= (or ?profile=) the builder is editing an existing
-  // structured Profile: it repopulates from `stages` and saves in place (#203).
-  var editId =
-    new URLSearchParams(window.location.search).get("id") ||
-    new URLSearchParams(window.location.search).get("profile");
+  // When the URL carries ?id= the builder is editing an existing structured
+  // Profile: it repopulates from `stages` and saves in place (#203). The list
+  // always links with ?id=, and loadForEdit looks up by id, so that's the only key.
+  var editId = new URLSearchParams(window.location.search).get("id");
 
   function valueInputs(card) {
     // Every editable value field in the card (temp/time) — never the checkbox.
@@ -184,6 +183,12 @@
   function validateForm() {
     var valid = setEstimatedValid(validEstimated());
 
+    // Profile name is required — a blank name would otherwise save as "profile.json"
+    // with an empty title (#218 review). Flag it like any other field.
+    var nameInput = document.getElementById("profile-name");
+    var nameOk = !!nameInput && nameInput.value.trim() !== "";
+    valid = setFieldValid("profile-name", nameOk, "Enter a profile name") && valid;
+
     OPTIONAL_STAGES.forEach(function (key) {
       var box = document.getElementById("stage-" + key + "-enabled");
       var enabled = !box || box.checked;
@@ -287,10 +292,11 @@
       '</div>' +
       '</div>' +
       '</div>' +
-      '<button id="amp-remove-substage" class="amp-substage__remove" type="button" aria-label="Remove sub-stage">&times;</button>';
+      '<button class="amp-substage__remove" type="button" aria-label="Remove sub-stage">&times;</button>';
     // Set the name as text (never innerHTML) so it can't inject markup.
     row.querySelector(".amp-substage__name").textContent = name;
-    row.querySelector("#amp-remove-substage").addEventListener("click", removeSubstage);
+    // Query by class (not a per-row id) so additional removable rows can't collide.
+    row.querySelector(".amp-substage__remove").addEventListener("click", removeSubstage);
     return row;
   }
 

--- a/tests/contract/test_profile_endpoints.py
+++ b/tests/contract/test_profile_endpoints.py
@@ -534,6 +534,27 @@ def test_nonfinite_in_disabled_stage_rejected_not_persisted(client):
 
 
 @pytest.mark.contract
+def test_edit_rename_keeps_structured_profile_in_local(client):
+    """Renaming a structured profile on edit keeps it under local/, not the
+    profiles root (concern #2 from the #218 review)."""
+    created = client.post("/profiles", json={
+        "name": "Rename Me", "fam_label": "FAM", "rox_label": "ROX", "stages": SAMPLE_STAGES,
+    }).json()["id"]
+    assert created.replace("\\", "/").startswith("local/")
+    resp = client.post("/profiles", json={
+        "name": "Renamed Profile", "profile_id": created,
+        "fam_label": "FAM", "rox_label": "ROX", "stages": SAMPLE_STAGES,
+    })
+    assert resp.status_code == 200, resp.text
+    new_id = resp.json()["id"]
+    try:
+        assert new_id.replace("\\", "/").startswith("local/"), f"renamed left local/: {new_id}"
+    finally:
+        _delete_profile(client, new_id)
+        _delete_profile(client, created)
+
+
+@pytest.mark.contract
 def test_structured_profile_keys_in_canonical_order(client):
     """A saved structured profile writes its top-level keys in canonical order:
     output_dir, post_in_gui, title, countdown fields, labels, stages, steps."""

--- a/tests/e2e/test_profile_builder.py
+++ b/tests/e2e/test_profile_builder.py
@@ -160,6 +160,36 @@ def test_valid_save_posts_stages_and_redirects(page, base_url):
         page.request.post(f"{base_url}/profiles/delete", data={"profiles": stale})
 
 
+def test_blank_name_blocks_save_and_flags_field(page, base_url):
+    """A blank profile name is required: it's flagged and blocks save even when
+    every Stage field is valid (concern #1 from the #218 review)."""
+    _goto_builder(page, base_url)
+    # All stage fields valid; name left blank.
+    page.locator("#stage-incubation-temp").fill("37")
+    page.locator("#stage-incubation-time").fill("600")
+    page.locator("#stage-denaturation-temp").fill("95")
+    page.locator("#stage-denaturation-time").fill("120")
+    page.locator("#stage-amp-cycles").fill("40")
+    page.locator("#stage-amp-sub-0-temp").fill("95")
+    page.locator("#stage-amp-sub-0-time").fill("11")
+    page.locator("#stage-amp-sub-1-temp").fill("60")
+    page.locator("#stage-amp-sub-1-time").fill("38")
+    page.locator("#stage-finalhold-temp").fill("25")
+    page.locator("#stage-finalhold-time").fill("60")
+
+    page.locator("#save-profile-button").click()
+    try:
+        # Blocked: still on the builder, name field flagged invalid.
+        assert page.url.rstrip("/").endswith("/profiles/builder")
+        assert "is-invalid" in (page.locator("#profile-name").get_attribute("class") or "")
+    finally:
+        # Defensive: a pre-fix run would have saved a blank-name profile.
+        listing = page.request.get(f"{base_url}/profiles").json()
+        stale = [p["id"] for p in listing if (p.get("id", "").replace("\\", "/") in ("local/profile.json",))]
+        if stale:
+            page.request.post(f"{base_url}/profiles/delete", data={"profiles": stale})
+
+
 # ---------------------------------------------------------------------------
 # Amplification Sub-stages — add/remove + rename + cycles (issue #202, B2)
 # ---------------------------------------------------------------------------
@@ -181,7 +211,7 @@ def test_amplification_starts_two_step_with_add_tab(page, base_url):
 
     # The add tab is shown; there is no remove control until a third exists.
     assert page.locator("#amp-add-substage").is_visible(), "add tab should show at two"
-    assert page.locator("#amp-remove-substage").count() == 0, "no X at two Sub-stages"
+    assert page.locator(".amp-substage__remove").count() == 0, "no X at two Sub-stages"
 
 
 def test_adding_third_substage_renames_appends_and_hides_add_tab(page, base_url):
@@ -200,7 +230,7 @@ def test_adding_third_substage_renames_appends_and_hides_add_tab(page, base_url)
 
     # At three: the add tab is hidden and the Extension row carries the X.
     assert not page.locator("#amp-add-substage").is_visible(), "add tab hidden at three"
-    assert page.locator("#amp-remove-substage").is_visible(), "Extension X should show"
+    assert page.locator(".amp-substage__remove").is_visible(), "Extension X should show"
 
 
 def test_removing_third_substage_via_x_reverts_to_two_step(page, base_url):
@@ -211,7 +241,7 @@ def test_removing_third_substage_via_x_reverts_to_two_step(page, base_url):
     page.locator("#amp-add-substage").click()      # 2 -> 3
     assert page.locator(".amp-substage").count() == 3
 
-    page.locator("#amp-remove-substage").click()   # X on the Extension row, 3 -> 2
+    page.locator(".amp-substage__remove").click()   # X on the Extension row, 3 -> 2
 
     assert page.locator(".amp-substage").count() == 2
     assert page.locator("#stage-amp-sub-2-name").count() == 0, "third row should be gone"
@@ -219,7 +249,7 @@ def test_removing_third_substage_via_x_reverts_to_two_step(page, base_url):
 
     # Back at two: the add tab returns and the X is gone.
     assert page.locator("#amp-add-substage").is_visible(), "add tab should return"
-    assert page.locator("#amp-remove-substage").count() == 0, "X should be gone at two"
+    assert page.locator(".amp-substage__remove").count() == 0, "X should be gone at two"
 
 
 def test_three_step_save_posts_three_substages(page, base_url):


### PR DESCRIPTION
Closes #252 — the four non-blocking cleanups from the #218 promotion review. Targets `updated-profiles`, so it flows into the promotion PR.

## Fixes
1. **Name required** (`builder.js`) — a blank profile name now flags the field red ("Enter a profile name") and blocks save, instead of saving as `profile.json` with an empty title.
2. **Rename keeps `local/` placement** (`main.py`) — editing+renaming a structured profile now renames within the file's own directory (`profile_path.parent`) instead of moving it to the profiles root. Fixes inconsistent on-disk placement.
3. **Remove ✕ wired by class** (`builder.js`) — the injected sub-stage remove button uses `.amp-substage__remove` rather than a per-row `id`, so additional removable rows can't collide on a duplicate id.
4. **Dead `?profile=` fallback removed** (`builder.js`) — the builder only ever uses `?id=` (and `loadForEdit` looks up by id), so the vestigial fallback is gone.

(Concern 5 — hand-edited sub-stage names normalized on a builder save — is by design per ADR-018; no change.)

## Tests
- Contract: `test_edit_rename_keeps_structured_profile_in_local` (rename stays under `local/`).
- e2e: `test_blank_name_blocks_save_and_flags_field`; existing sub-stage add/remove e2e updated to the `.amp-substage__remove` class selector.
- Backend **227 passed** / 16 pre-existing; **e2e 26 passed** (builder + legacy) against the real backend. `builder.js?v=6`.

## Scope
Backend = the rename-path one-liner; frontend = `builder.js` + cache-bust. No behavior change beyond the four items above.

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)
