### PR TITLE
feat(enroll): enroll.sh wrapper + sudo-aware enrolment + prod URLs

### DIFF
--- a/docs/deployment/enrolling-a-device.md
+++ b/docs/deployment/enrolling-a-device.md
@@ -33,6 +33,8 @@ Pi (deployment2.sh)            Operator workstation (AWS creds)        acorn-ca
     --query "Items[?Name=='EnrollApi'].ApiEndpoint" --output text
   # → https://<id>.execute-api.us-east-2.amazonaws.com   (append /enroll)
   ```
+  Current **prod** value: `https://1x9561i626.execute-api.us-east-2.amazonaws.com/enroll`
+  (the dev CA has its own id — always confirm with the command above).
 - A local checkout of this repo with `botocore` + `cryptography` installed
   (`pip install -r requirements-test.txt` covers both).
 

--- a/scripts/enroll_device.py
+++ b/scripts/enroll_device.py
@@ -8,8 +8,14 @@ issued Device Certificate (``0600``) and updates ``device.env`` on the Pi over
 SSH. AWS credentials never touch the Pi.
 
     python scripts/enroll_device.py --pi sn04 \
-        --endpoint https://rf2f9a0wie.execute-api.us-east-2.amazonaws.com/enroll \
+        --endpoint https://1x9561i626.execute-api.us-east-2.amazonaws.com/enroll \
         --region us-east-2
+
+The ``--endpoint`` is the acorn-ca EnrollApi URL for the target environment (the
+example above is **prod**). Find the current one with:
+
+    aws apigatewayv2 get-apis \
+      --query "Items[?Name=='EnrollApi'].ApiEndpoint" --output text   # append /enroll
 
 The CSR is produced on the Pi during deployment (#239). The Sync client reads
 the installed cert/key paths from ``device.env`` (#241).


### PR DESCRIPTION
Makes device enrolment actually work against a real `sudo`-deployed Sentri, adds a one-shot wrapper, and fixes the stale dev enroll URL.

## The bug
`deployment2.sh` runs under `sudo`, so `/opt/aquila/config` and its files (`device.csr`, `device.key`, `device.env`) are **root-owned**. But `enroll_device.py` wrote `device.crt` / `device.env` over SSH **without sudo** → permission denied on a real device. The verify step likewise couldn't source the `0600 root` `device.env`. (Confirmed live against `sn03`.)

## Changes
- **`enroll_device.py`** — `_ssh_read` uses `sudo cat`, `_ssh_write` uses `sudo tee` + `sudo chmod`. The Pi has passwordless sudo; AWS creds still never touch the Pi (only `cat`/`tee` run there). Docstring uses the prod enroll URL + a discovery command.
- **`scripts/enroll.sh`** (new) — one-shot wrapper: `./scripts/enroll.sh sn03` runs confirm-CSR → enrol → mTLS verify, defaulting to the prod endpoints, host `pi@<sn>`. Endpoints overridable via env for other environments.
- **`enrolling-a-device.md`** — documents the wrapper, the `pi@<sn>` host (bare host fails Tailscale SSH), and the sudo reads/writes + sudo verify; lists the current prod enroll URL.

## Tests
`unit_tests/test_enroll.py` green (5/5). The SSH wrappers are thin subprocess shims (the signed-request + env-rewrite logic in `aq_lib/enroll.py` is what's unit-tested); `enroll.sh` passes `bash -n`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)