### PR TITLE
fix(enroll): make aq_lib importable when run as a script

### DIFF
--- a/scripts/enroll_device.py
+++ b/scripts/enroll_device.py
@@ -21,12 +21,18 @@ The CSR is produced on the Pi during deployment (#239). The Sync client reads
 the installed cert/key paths from ``device.env`` (#241).
 """
 import argparse
+import os
 import subprocess
 import sys
 
 import botocore.session
 
-from aq_lib.enroll import EnrollmentError, device_env_after_enroll, enroll
+# Make `aq_lib` importable when run as `python scripts/enroll_device.py` from
+# anywhere: only `scripts/` is on sys.path by default, not the repo root that
+# holds `aq_lib/`. Insert the repo root (the parent of this file's dir).
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from aq_lib.enroll import EnrollmentError, device_env_after_enroll, enroll  # noqa: E402
 
 CONFIG_DIR = "/opt/aquila/config"
 CSR_PATH = f"{CONFIG_DIR}/device.csr"


### PR DESCRIPTION
`python scripts/enroll_device.py` only puts scripts/ on sys.path, so `from aq_lib.enroll import ...` failed with ModuleNotFoundError. Insert the repo root (parent of scripts/) onto sys.path so the script resolves aq_lib regardless of cwd or how it's invoked (directly or via enroll.sh).

## What Changed

One or two sentences. What did you build, fix, or change?

## Why

Link to the GitHub issue: Closes #[number]

## Spec

Link to the spec this implements or modifies:
`specs/[type]/[filename].md`

If no spec exists and this is a non-trivial change, explain why.

## Changes Made

- [ ] Source code modified
- [ ] Spec updated to match implementation
- [ ] New tests written
- [ ] Existing tests still pass
- [ ] No secrets or `.env` files in this diff
- [ ] ADR written (if an irreversible architectural decision was made)
- [ ] `docs/debugging/known-issues.md` updated (if new edge cases were found)

## Hardware Testing

- [ ] Tested on physical device
- [ ] Tested in simulation mode only — reason: [why physical not possible]
- [ ] Hardware not relevant to this change

## Reviewer Notes

Anything the reviewer should know: tricky parts, things to focus on, known limitations.
