### PR TITLE
#262 Load keyboard.js on the structured profile builder page

### DIFF
--- a/aquila_web/static/profiles/builder.html
+++ b/aquila_web/static/profiles/builder.html
@@ -165,5 +165,6 @@
   </div>
   <script src="/static/nav.js?v=1"></script>
   <script src="/static/profiles/builder.js?v=6"></script>
+  <script src="/static/keyboard.js?v=14"></script>
 </body>
 </html>

--- a/tests/e2e/test_keyboard.py
+++ b/tests/e2e/test_keyboard.py
@@ -9,11 +9,20 @@ pytestmark = pytest.mark.e2e
 
 KEYBOARD_SELECTOR = ".onscreen-keyboard"
 RUN_NAME_INPUT = "#run-name-input"
+BUILDER_NAME_INPUT = "#profile-name"
 
 
 def _goto_run(page, base_url):
     try:
         page.goto(f"{base_url}/run", timeout=10_000)
+    except Exception as exc:
+        pytest.skip(f"Backend not reachable at {base_url}: {exc}")
+    page.wait_for_load_state("domcontentloaded")
+
+
+def _goto_builder(page, base_url):
+    try:
+        page.goto(f"{base_url}/profiles/builder", timeout=10_000)
     except Exception as exc:
         pytest.skip(f"Backend not reachable at {base_url}: {exc}")
     page.wait_for_load_state("domcontentloaded")
@@ -58,6 +67,23 @@ def test_keyboard_has_letter_keys(page, base_url):
     for letter in ("a", "q", "z"):
         key_btn = page.locator(f"[data-value='{letter}']")
         assert key_btn.count() >= 1, f"Key '{letter}' not found in keyboard"
+
+
+# ---------------------------------------------------------------------------
+# Structured profile builder (issue #262)
+# ---------------------------------------------------------------------------
+
+def test_clicking_builder_name_shows_keyboard(page, base_url):
+    """Tapping a text field on the structured profile builder shows the keyboard."""
+    _goto_builder(page, base_url)
+    page.locator(BUILDER_NAME_INPUT).click()
+    page.wait_for_function(
+        "() => document.querySelector('.onscreen-keyboard')?.classList.contains('is-visible')",
+        timeout=3_000,
+    )
+    keyboard = page.locator(KEYBOARD_SELECTOR)
+    assert keyboard.count() == 1, "On-screen keyboard element not found on builder page"
+    assert keyboard.is_visible(), "On-screen keyboard not visible after tapping a builder field"
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes #262

## Problem
On the structured profile builder (`aquila_web/static/profiles/builder.html`), tapping any input field did **not** raise the on-screen keyboard. On the touch kiosk (no physical keyboard) this made every field on the page unusable.

## Root cause
`builder.html` only loaded `nav.js` and `builder.js` — it never included `/static/keyboard.js`, which binds the on-screen keyboard to text/number inputs. Every other input-bearing page (run, settings, login, edit, edit_form, …) loads `keyboard.js` right before `</body>`; the builder page was missed when it was added on `updated-profiles`.

## Fix
Add `<script src="/static/keyboard.js?v=14"></script>` to `builder.html`, matching the placement and version used on all other pages. `keyboard.js` binds at the document level on `DOMContentLoaded`, so loading it is the entire fix — no `builder.js` change needed.

## Testing
- Added `test_clicking_builder_name_shows_keyboard` to `tests/e2e/test_keyboard.py`: navigates to `/profiles/builder`, taps the profile-name field, asserts `.onscreen-keyboard` becomes visible.
- This is an e2e test (Playwright + live kiosk backend) and is **not** CI-gated — verified manually against a local simulate-mode backend: tapping builder fields now raises the keyboard.
- Existing CI-runnable contract/unit suites pass (pre-existing `bundled/` fixture failures are unrelated to this change).

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)