### PR TITLE
#267 History shows profile name instead of file-path id

### DIFF
--- a/aquila_web/main.py
+++ b/aquila_web/main.py
@@ -103,6 +103,46 @@ def _profile_rox_unavailable(profile_name: str | None) -> bool:
             continue
     return False
 
+def _resolve_profile_display_name(profile_ref: str | None) -> str:
+    """Resolve a profile reference to its human-readable display name.
+
+    ``profile_ref`` is normally the id stored by ``/profile/select`` — the
+    relative path emitted by ``GET /profiles`` (e.g. ``local/A3_Invalid_Temp.json``).
+    History must show the profile's ``name`` (e.g. ``A3 Invalid Temp``), never the
+    ``local/`` prefix, the ``.json`` extension, or the filename's underscores
+    (issue #267). Idempotent when given a value that is already a display name.
+    See specs/backend/spec_history_profile_display_name.md.
+    """
+    if not profile_ref:
+        return "--"
+    profile_dir = resolve_profile_dir()
+    # 1. Normal path: treat the ref as the relative-path id and read its JSON name.
+    try:
+        candidate = profile_dir / profile_ref
+        if candidate.is_file():
+            data = json.loads(candidate.read_text())
+            name = data.get("name") or data.get("title")
+            if name:
+                return str(name)
+    except Exception:
+        pass
+    # 2. Otherwise match by name/stem/filename/id across the profile tree.
+    try:
+        if profile_dir.exists():
+            for path in profile_dir.rglob("*.json"):
+                try:
+                    data = json.loads(path.read_text())
+                except Exception:
+                    continue
+                name = data.get("name") or data.get("title") or path.stem
+                rel = str(path.relative_to(profile_dir))
+                if profile_ref in (name, path.stem, path.name, rel):
+                    return str(name)
+    except Exception:
+        pass
+    # 3. Fallback: strip directory and extension so a path is never shown.
+    return Path(profile_ref).stem
+
 def _all_bundled_filenames() -> set[str]:
     profile_groups_path = BASE_DIR / "config_files" / "profile_groups.json"
     try:
@@ -546,7 +586,7 @@ async def _simulate_run(profile_name: str) -> None:
     history = _load_history()
     history.append({
         "timestamp": datetime.now().strftime("%Y-%m-%d %H:%M"),
-        "profile": profile_name,
+        "profile": _resolve_profile_display_name(profile_name),
         "run_name": run_name,
         "result": detected_summary,
         "graph_path": f"/plots/{plot_filename}",
@@ -849,7 +889,7 @@ async def advance_run_name():
 async def append_history(payload: dict):
     global results_path, results_cleared
     path_value = payload.get("results_path")
-    profile = payload.get("profile") or "--"
+    profile = _resolve_profile_display_name(payload.get("profile"))
     run_label = payload.get("run_name") or "--"
     graph_path = payload.get("graph_path")
     result_path = None

--- a/aquila_web/main.py
+++ b/aquila_web/main.py
@@ -140,8 +140,9 @@ def _resolve_profile_display_name(profile_ref: str | None) -> str:
                     return str(name)
     except Exception:
         pass
-    # 3. Fallback: strip directory and extension so a path is never shown.
-    return Path(profile_ref).stem
+    # 3. Fallback: strip the directory and a trailing .json so a path is never
+    #    shown, while preserving dots that are part of the name (e.g. "Cycle 2.5").
+    return Path(profile_ref).name.removesuffix(".json")
 
 def _all_bundled_filenames() -> set[str]:
     profile_groups_path = BASE_DIR / "config_files" / "profile_groups.json"

--- a/specs/backend/spec_history_profile_display_name.md
+++ b/specs/backend/spec_history_profile_display_name.md
@@ -25,7 +25,7 @@ A new helper `_resolve_profile_display_name(profile_ref: str | None) -> str`:
 1. If `profile_ref` is falsy → return `"--"`.
 2. **Treat it as a relative-path id:** if `resolve_profile_dir() / profile_ref` is a file, read its JSON and return `name` (falling back to `title`) when present. This is the normal path — the id stored by `/profile/select`.
 3. **Otherwise match by name/stem/filename/id** across `resolve_profile_dir().rglob("*.json")` (handles a bare name being passed) and return the matched profile's `name`/`title`.
-4. **Fallback:** return `Path(profile_ref).stem` — strips the directory and `.json` so the user never sees a path even if the profile file is missing.
+4. **Fallback:** return `Path(profile_ref).name.removesuffix(".json")` — strips the directory and a trailing `.json` so the user never sees a path even if the profile file is missing, while preserving dots that are part of the name (e.g. `Cycle 2.5`). (Using `Path.stem` would wrongly truncate `Sample 3.2 Panel` → `Sample 3`.)
 
 The helper is **idempotent** for a value that is already a display name: passing `"A3 Invalid Temp"` returns `"A3 Invalid Temp"` (matched in step 3, or returned unchanged by the step-4 fallback).
 
@@ -47,7 +47,8 @@ The helper is **idempotent** for a value that is already a display name: passing
 - Result contains no path separator, no `.json`, and no underscore-for-space artifact.
 - Passing the already-resolved name `"A3 Invalid Temp"` returns it unchanged (idempotent).
 - `None`/empty → `"--"`.
-- Missing file (`local/ghost.json`) → falls back to stem `"ghost"` (no path, no extension).
+- Missing file (`local/ghost.json`) → falls back to `"ghost"` (no path, no extension).
+- Fallback preserves dots: an unmatched `"Sample 3.2 Panel"` returns unchanged; `"local/Cycle 2.5.json"` → `"Cycle 2.5"`.
 
 **Contract** — `tests/contract/test_history_endpoints.py`:
 - `POST /history/append` with `profile` set to a saved profile's id stores the profile's `name`, not the id (no `\\`, `/`, or `.json` in the stored `profile`).

--- a/specs/backend/spec_history_profile_display_name.md
+++ b/specs/backend/spec_history_profile_display_name.md
@@ -1,0 +1,63 @@
+# Backend Spec: History stores the profile display name, not its file-path id — issue #267
+
+**Status:** Draft
+**Author:** Aquila Engineering Team
+**Last updated:** 2026-06-30
+**GitHub issue:** #267
+**Source file(s):** `aquila_web/main.py`, `unit_tests/test_history_profile_name.py`, `tests/contract/test_history_endpoints.py`
+
+---
+
+## 1. Overview
+
+On the **History** page, the **Profile** column shows the profile's file-path id (e.g. `local\A3_Invalid_Temp.json`) instead of the profile's human-readable name (`A3 Invalid Temp`). The user should only ever see the name — never the `local/` directory prefix, the `.json` extension, or the underscores the filename uses in place of spaces.
+
+`POST /profile/select` stores the profile **id** — the relative path emitted by `GET /profiles` (`str(path.relative_to(profile_dir))`, e.g. `local/A3_Invalid_Temp.json`) — in the module-level `selected_profile`. When a run finishes, `_simulate_run` writes that id verbatim into the history entry's `profile` field (`aquila_web/main.py:585`), and `static/history.js` renders `entry.profile` directly. The profile's real display name lives in the profile JSON's `name` field (the same value `GET /profiles` exposes as `name`).
+
+This change resolves the id to the display name when the history entry is built. Purely a stored-value correction — no new endpoints, no schema change.
+
+---
+
+## 2. Behaviour
+
+A new helper `_resolve_profile_display_name(profile_ref: str | None) -> str`:
+
+1. If `profile_ref` is falsy → return `"--"`.
+2. **Treat it as a relative-path id:** if `resolve_profile_dir() / profile_ref` is a file, read its JSON and return `name` (falling back to `title`) when present. This is the normal path — the id stored by `/profile/select`.
+3. **Otherwise match by name/stem/filename/id** across `resolve_profile_dir().rglob("*.json")` (handles a bare name being passed) and return the matched profile's `name`/`title`.
+4. **Fallback:** return `Path(profile_ref).stem` — strips the directory and `.json` so the user never sees a path even if the profile file is missing.
+
+The helper is **idempotent** for a value that is already a display name: passing `"A3 Invalid Temp"` returns `"A3 Invalid Temp"` (matched in step 3, or returned unchanged by the step-4 fallback).
+
+---
+
+## 3. Implementation
+
+- Add `_resolve_profile_display_name` to `main.py` (near `_load_profile_labels`, which already does name/stem/filename matching).
+- In `_simulate_run`, set the history entry's `"profile"` to `_resolve_profile_display_name(profile_name)` instead of the raw `profile_name` (`aquila_web/main.py:585`). The results-filename slug, `_load_profile_labels`, and `_profile_rox_unavailable` continue to use the raw id — unchanged.
+- In `append_history` (`POST /history/append`), resolve the incoming `profile` the same way before storing — defensive and idempotent.
+- The `run_complete` event payload's `profile` is left as-is (out of scope).
+
+---
+
+## 4. Tests
+
+**Unit** — `unit_tests/test_history_profile_name.py` (pure logic, marked `unit`; monkeypatch `resolve_profile_dir` to a tmp dir):
+- A profile file at `local/A3_Invalid_Temp.json` with `{"name": "A3 Invalid Temp", ...}` → id `local/A3_Invalid_Temp.json` resolves to `"A3 Invalid Temp"`.
+- Result contains no path separator, no `.json`, and no underscore-for-space artifact.
+- Passing the already-resolved name `"A3 Invalid Temp"` returns it unchanged (idempotent).
+- `None`/empty → `"--"`.
+- Missing file (`local/ghost.json`) → falls back to stem `"ghost"` (no path, no extension).
+
+**Contract** — `tests/contract/test_history_endpoints.py`:
+- `POST /history/append` with `profile` set to a saved profile's id stores the profile's `name`, not the id (no `\\`, `/`, or `.json` in the stored `profile`).
+
+Run: `pytest unit_tests/test_history_profile_name.py tests/contract/test_history_endpoints.py -v`
+
+---
+
+## Out of Scope
+
+- History entries already written with the old path value — only new runs are corrected (existing files are not rewritten).
+- The `run_complete` event payload's `profile` field.
+- Any change to `GET /profiles`, profile ids, or on-disk filenames.

--- a/tests/contract/test_history_endpoints.py
+++ b/tests/contract/test_history_endpoints.py
@@ -75,6 +75,32 @@ def test_history_append_stores_all_fields(client):
 
 
 @pytest.mark.contract
+def test_history_append_stores_profile_name_not_path_id(client):
+    """A path-like profile id is stored as the profile's display name (issue #267)."""
+    _clear(client)
+    # Save a profile whose name has spaces; its id is a path with underscores
+    # (e.g. local/A3_Invalid_Temp.json) — the exact shape that leaked into History.
+    resp = client.post(
+        "/profiles",
+        json={"name": "A3 Invalid Temp", "steps": [{"setpoint": 95, "duration": 1}]},
+    )
+    profile_id = resp.json()["id"]
+    try:
+        # sanity: the id really is a path/slug, not a clean name
+        assert (".json" in profile_id) and ("_" in profile_id)
+
+        client.post("/history/append", json={**HISTORY_ENTRY, "profile": profile_id})
+        entry = client.get("/history/data").json()[-1]
+
+        assert entry["profile"] == "A3 Invalid Temp"
+        assert "/" not in entry["profile"] and "\\" not in entry["profile"]
+        assert ".json" not in entry["profile"]
+    finally:
+        client.post("/profiles/delete", json={"profiles": [profile_id]})
+        _clear(client)
+
+
+@pytest.mark.contract
 def test_history_entry_has_expected_keys(client):
     """History entry contains: timestamp, profile, run_name, results_path, graph_path, tube_names."""
     _clear(client)

--- a/unit_tests/test_history_profile_name.py
+++ b/unit_tests/test_history_profile_name.py
@@ -1,0 +1,86 @@
+"""
+Unit tests for aquila_web.main._resolve_profile_display_name — History must
+store the profile's display name (the JSON ``name`` field), not its file-path
+id (issue #267).
+
+Pure logic over the resolved profile dir. Marked ``unit``.
+Spec: specs/backend/spec_history_profile_display_name.md.
+"""
+import json
+import os
+import sys
+import types
+from pathlib import Path
+
+import pytest
+
+pytestmark = pytest.mark.unit
+
+# Stub heavy hardware deps before importing main (same approach as the other
+# unit test modules so importing aquila_web.main works on a dev machine / CI).
+for _mod in ("RPi", "RPi.GPIO"):
+    sys.modules.setdefault(_mod, types.ModuleType(_mod))
+
+if "serial" not in sys.modules:
+    _s = types.ModuleType("serial")
+    _st = types.ModuleType("serial.tools")
+    _lp = types.ModuleType("serial.tools.list_ports")
+    _lp.comports = lambda: []
+    _s.tools = _st
+    _st.list_ports = _lp
+    sys.modules.update({"serial": _s, "serial.tools": _st, "serial.tools.list_ports": _lp})
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(REPO_ROOT))
+sys.path.insert(0, str(REPO_ROOT / "aquila_web"))
+os.environ.setdefault("AQ_DEV_SIMULATE", "1")
+
+from aquila_web import main as web_main
+
+
+def _write_profile(profile_dir: Path, rel_path: str, data: dict) -> None:
+    target = profile_dir / rel_path
+    target.parent.mkdir(parents=True, exist_ok=True)
+    target.write_text(json.dumps(data))
+
+
+def test_resolves_path_id_to_profile_name(tmp_path, monkeypatch):
+    """A relative-path id resolves to the profile JSON's ``name`` field."""
+    _write_profile(tmp_path, "local/A3_Invalid_Temp.json", {"name": "A3 Invalid Temp"})
+    monkeypatch.setattr(web_main, "resolve_profile_dir", lambda: tmp_path)
+
+    assert web_main._resolve_profile_display_name("local/A3_Invalid_Temp.json") == "A3 Invalid Temp"
+
+
+def test_resolved_name_has_no_path_or_extension_artifacts(tmp_path, monkeypatch):
+    """The resolved value shows no path separator, no .json, no underscore-for-space."""
+    _write_profile(tmp_path, "local/A3_Invalid_Temp.json", {"name": "A3 Invalid Temp"})
+    monkeypatch.setattr(web_main, "resolve_profile_dir", lambda: tmp_path)
+
+    resolved = web_main._resolve_profile_display_name("local/A3_Invalid_Temp.json")
+    assert "/" not in resolved and "\\" not in resolved
+    assert ".json" not in resolved
+    assert "_" not in resolved
+
+
+def test_idempotent_for_already_resolved_name(tmp_path, monkeypatch):
+    """Passing a value that is already the display name returns it unchanged."""
+    _write_profile(tmp_path, "local/A3_Invalid_Temp.json", {"name": "A3 Invalid Temp"})
+    monkeypatch.setattr(web_main, "resolve_profile_dir", lambda: tmp_path)
+
+    assert web_main._resolve_profile_display_name("A3 Invalid Temp") == "A3 Invalid Temp"
+
+
+def test_empty_or_none_returns_placeholder(tmp_path, monkeypatch):
+    """A falsy reference resolves to the '--' placeholder."""
+    monkeypatch.setattr(web_main, "resolve_profile_dir", lambda: tmp_path)
+
+    assert web_main._resolve_profile_display_name(None) == "--"
+    assert web_main._resolve_profile_display_name("") == "--"
+
+
+def test_missing_file_falls_back_to_stem(tmp_path, monkeypatch):
+    """An unresolvable id never shows a path/extension — falls back to the stem."""
+    monkeypatch.setattr(web_main, "resolve_profile_dir", lambda: tmp_path)
+
+    assert web_main._resolve_profile_display_name("local/ghost.json") == "ghost"

--- a/unit_tests/test_history_profile_name.py
+++ b/unit_tests/test_history_profile_name.py
@@ -84,3 +84,13 @@ def test_missing_file_falls_back_to_stem(tmp_path, monkeypatch):
     monkeypatch.setattr(web_main, "resolve_profile_dir", lambda: tmp_path)
 
     assert web_main._resolve_profile_display_name("local/ghost.json") == "ghost"
+
+
+def test_fallback_preserves_dots_in_name(tmp_path, monkeypatch):
+    """A dotted name with no matching file keeps its dots (only .json is stripped)."""
+    monkeypatch.setattr(web_main, "resolve_profile_dir", lambda: tmp_path)
+
+    # Bare display name with a dot — nothing on disk matches it.
+    assert web_main._resolve_profile_display_name("Sample 3.2 Panel") == "Sample 3.2 Panel"
+    # Path-like id with a dotted stem — strip the dir and .json, keep the dot.
+    assert web_main._resolve_profile_display_name("local/Cycle 2.5.json") == "Cycle 2.5"


### PR DESCRIPTION
Closes #267

## Problem
On the **History** page, the **Profile** column showed the profile's file-path id (e.g. `local\A3_Invalid_Temp.json`) instead of the profile's name (`A3 Invalid Temp`) — leaking the `local/` directory, the `.json` extension, and the filename's underscores-for-spaces.

## Root cause
`POST /profile/select` stores the profile **id** (the relative path emitted by `GET /profiles`) in `selected_profile`. On run completion, `_simulate_run` wrote that id verbatim into the history entry's `profile` field, and `static/history.js` renders it directly.

## Fix
- New `_resolve_profile_display_name(profile_ref)` helper in `aquila_web/main.py` — resolves an id to the profile JSON's `name` (falling back to `title`, then a path-free stem). Idempotent for values already equal to a display name.
- Used it in `_simulate_run` (the buggy write path) and `append_history` (defensive).
- Production change is **+42 / −2 lines**; the rest is tests + spec.

## Tests
- `unit_tests/test_history_profile_name.py` — 5 unit tests (path-id → name, no path/extension/underscore artifacts, idempotency, empty → `--`, missing-file fallback).
- `tests/contract/test_history_endpoints.py` — new contract test that reproduced the exact bug before the fix and now asserts `A3 Invalid Temp`.
- All 16 pass. Full suite introduces no new failures (pre-existing wifi/optics env failures are unrelated).

Run: `pytest unit_tests/test_history_profile_name.py tests/contract/test_history_endpoints.py -v`

## Out of scope
- History entries written **before** this fix keep their old value (only new writes are corrected).
- The `run_complete` event payload's `profile` field.

Spec: `specs/backend/spec_history_profile_display_name.md`

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)