### PR TITLE
Rename ABBA profile to Beer Spoilers - Bacteria; restrict sn04 to breweries group

### DIFF
--- a/config_files/device_profiles.json
+++ b/config_files/device_profiles.json
@@ -9,7 +9,7 @@
         "profile_group": "classic"
     },
     "sn04": {
-        "profile_group": "classic"
+        "profile_group": "breweries"
     },
     "sn05": {
         "profile_group": "duke"

--- a/config_files/profile_groups.json
+++ b/config_files/profile_groups.json
@@ -1,16 +1,19 @@
 {
     "all": null,
     "classic": [
-        "ABBA_ramp1.75_EA30.json",
+        "Beer_Spoilers_Bacteria.json",
         "Hygiena_ramp1.75_EA30.json",
         "ryan_thermal_tests.json",
         "verification_profile.json"
     ],
     "duke": [
-        "ABBA_ramp1.75_EA30.json",
+        "Beer_Spoilers_Bacteria.json",
         "O157__ESBL_full.json",
         "ryan_thermal_tests.json",
         "STEC_and_EPEC_Hygiena1.75_no37Cstep.json",
         "verification_profile.json"
+    ],
+    "breweries": [
+        "Beer_Spoilers_Bacteria.json"
     ]
 }

--- a/profiles/bundled/Beer_Spoilers_Bacteria.json
+++ b/profiles/bundled/Beer_Spoilers_Bacteria.json
@@ -1,7 +1,7 @@
 {
 "output_dir": "pcr_data",
 "post_in_gui": "True",
-"title": "ABBA_ramp1.75_EA30",
+"title": "Beer Spoilers - Bacteria",
 "time_unavailable": false,
 "estimated_completion_seconds": 4080,
 "steps": [


### PR DESCRIPTION
## Summary
- Renames the bundled profile `ABBA_ramp1.75_EA30.json` → `Beer_Spoilers_Bacteria.json` and sets its `title` to **Beer Spoilers - Bacteria**. PCR steps are unchanged.
- Updates the `classic` and `duke` groups to reference the new filename so devices already on those groups keep the profile.
- Adds a new **`breweries`** profile group containing only Beer Spoilers - Bacteria.
- Assigns **sn04** to the `breweries` group, so sn04 sees only that one profile.

## Notes
- Filtering is by filename, so an underscore filename (`Beer_Spoilers_Bacteria.json`) is used to avoid spaces in the profile `id`/URL path; the human-readable name lives in the `title` field.
- Per `specs/backend/per_device_profile_filtering.md`, changes take effect on the fleet once merged to `main` → CI builds the image → Watchtower delivers (~5 min).

## Verification
- All three JSON files validated with `python -m json.tool`.
- No stale `ABBA_ramp1.75_EA30.json` references remain in `config_files/` or `profiles/bundled/`.

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)