### PR TITLE
Per-device profile-editing lock (closes #271)

### DIFF
--- a/aquila_web/main.py
+++ b/aquila_web/main.py
@@ -1240,6 +1240,28 @@ def resolve_device_profiles() -> "set[str] | None":
     return set(allowed)
 
 
+def resolve_profile_editing_disabled() -> bool:
+    """True when profile building (edit/new) is disabled for the running device.
+
+    Reads the `profile_editing_disabled` flag from the device's entry in
+    config_files/device_profiles.json. Fails OPEN (returns False) on unknown
+    hostname, missing flag, or unreadable config so editing stays enabled by
+    default — matching the fail-open behavior of resolve_device_profiles().
+    """
+    import socket
+    hostname = os.getenv("DEVICE_HOSTNAME") or socket.gethostname()
+    device_profiles_path = BASE_DIR / "config_files" / "device_profiles.json"
+    try:
+        device_profiles = json.loads(device_profiles_path.read_text())
+    except Exception:
+        logger.warning("Could not load device_profiles.json; profile editing enabled")
+        return False
+    device_entry = device_profiles.get(hostname)
+    if not isinstance(device_entry, dict):
+        return False
+    return bool(device_entry.get("profile_editing_disabled", False))
+
+
 @app.get("/profiles")
 async def list_profiles():
     profiles = []

--- a/aquila_web/main.py
+++ b/aquila_web/main.py
@@ -979,6 +979,7 @@ async def profiles_page():
 
 @app.get("/profiles/edit")
 async def profiles_edit_page():
+    _guard_profile_editing()
     return FileResponse(
         static_dir / "profiles/edit_form.html",
         headers={"Cache-Control": "no-store"}
@@ -986,6 +987,7 @@ async def profiles_edit_page():
 
 @app.get("/profiles/edit-form")
 async def profiles_edit_form_page():
+    _guard_profile_editing()
     return FileResponse(
         static_dir / "profiles/edit_form.html",
         headers={"Cache-Control": "no-store"}
@@ -995,10 +997,17 @@ async def profiles_edit_form_page():
 async def profiles_builder_page():
     # Structured profile editor (issue #197). Serves the shell; the Stage UI,
     # validation, and save wiring are layered on in the frontend route (B1/B2/B3).
+    _guard_profile_editing()
     return FileResponse(
         static_dir / "profiles/builder.html",
         headers={"Cache-Control": "no-store"}
     )
+
+@app.get("/profiles/permissions")
+async def profiles_permissions():
+    """Report whether profile building is disabled for this device so the
+    frontend can render the greyed-out 'contact administrator' state."""
+    return {"editing_disabled": resolve_profile_editing_disabled()}
 
 @app.get("/history")
 async def history_page():
@@ -1262,6 +1271,15 @@ def resolve_profile_editing_disabled() -> bool:
     return bool(device_entry.get("profile_editing_disabled", False))
 
 
+def _guard_profile_editing() -> None:
+    """Raise 403 if profile building is disabled for this device."""
+    if resolve_profile_editing_disabled():
+        raise HTTPException(
+            status_code=403,
+            detail="Profile editing is disabled on this device. Contact administrator for this feature.",
+        )
+
+
 @app.get("/profiles")
 async def list_profiles():
     profiles = []
@@ -1443,6 +1461,7 @@ def _convert_run_config_to_steps(configuration: dict) -> list:
 
 @app.post("/profiles")
 async def save_profile(payload: ProfileSave):
+    _guard_profile_editing()
     profile_dir = resolve_profile_dir()
     profile_dir.mkdir(parents=True, exist_ok=True)
     def sanitize_name(value: str) -> str:
@@ -1570,6 +1589,7 @@ async def save_profile(payload: ProfileSave):
 
 @app.post("/profiles/delete")
 async def delete_profiles(payload: ProfileDelete):
+    _guard_profile_editing()
     profile_dir = resolve_profile_dir()
     deleted = []
     missing = []

--- a/aquila_web/main.py
+++ b/aquila_web/main.py
@@ -978,16 +978,18 @@ async def profiles_page():
     return FileResponse(static_dir / "profiles/index.html")
 
 @app.get("/profiles/edit")
-async def profiles_edit_page():
-    _guard_profile_editing()
+async def profiles_edit_page(view: str | None = Query(default=None), mode: str | None = Query(default=None)):
+    if not _is_view_mode(view, mode):
+        _guard_profile_editing()
     return FileResponse(
         static_dir / "profiles/edit_form.html",
         headers={"Cache-Control": "no-store"}
     )
 
 @app.get("/profiles/edit-form")
-async def profiles_edit_form_page():
-    _guard_profile_editing()
+async def profiles_edit_form_page(view: str | None = Query(default=None), mode: str | None = Query(default=None)):
+    if not _is_view_mode(view, mode):
+        _guard_profile_editing()
     return FileResponse(
         static_dir / "profiles/edit_form.html",
         headers={"Cache-Control": "no-store"}
@@ -1278,6 +1280,15 @@ def _guard_profile_editing() -> None:
             status_code=403,
             detail="Profile editing is disabled on this device. Contact administrator for this feature.",
         )
+
+
+def _is_view_mode(view: "str | None", mode: "str | None") -> bool:
+    """True when an edit-form request is a read-only view (legacy profiles).
+
+    Read-only viewing stays available even when editing is disabled; only the
+    editor/builder surfaces are gated.
+    """
+    return (view or "").lower() in ("1", "true", "yes") or (mode or "").lower() == "view"
 
 
 @app.get("/profiles")

--- a/aquila_web/static/profiles/index.html
+++ b/aquila_web/static/profiles/index.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>Run Profiles</title>
-  <link rel="stylesheet" href="/static/styles.css?v=235" />
+  <link rel="stylesheet" href="/static/styles.css?v=236" />
 </head>
 <body class="app-body">
   <div class="app-shell">
@@ -56,6 +56,6 @@
   </div>
   <script src="/static/nav.js?v=1"></script>
   <script src="/static/confirm-modal.js?v=1"></script>
-  <script src="/static/profiles/profiles.js?v=8"></script>
+  <script src="/static/profiles/profiles.js?v=9"></script>
 </body>
 </html>

--- a/aquila_web/static/profiles/profiles.js
+++ b/aquila_web/static/profiles/profiles.js
@@ -4,6 +4,46 @@
   const selectAllCheckbox = document.getElementById("profiles-select-all");
   if (!tableBody) return;
 
+  let editingDisabled = false;
+
+  const fetchEditingDisabled = async () => {
+    try {
+      const response = await fetch("/profiles/permissions");
+      if (!response.ok) return false;
+      const data = await response.json();
+      return Boolean(data.editing_disabled);
+    } catch (error) {
+      // Fail open: if we can't tell, leave editing enabled.
+      return false;
+    }
+  };
+
+  const applyEditingLock = () => {
+    if (!editingDisabled) return;
+    const shell = document.querySelector(".profiles-shell");
+    if (shell) shell.classList.add("profiles-shell--locked");
+
+    // Disable build affordances in the toolbar.
+    const newProfileLink = document.querySelector('.profiles-actions a[href="/profiles/builder"]');
+    if (newProfileLink) {
+      newProfileLink.classList.add("is-disabled");
+      newProfileLink.setAttribute("aria-disabled", "true");
+      newProfileLink.removeAttribute("href");
+      newProfileLink.addEventListener("click", (event) => event.preventDefault());
+    }
+    if (deleteButton) deleteButton.disabled = true;
+    if (selectAllCheckbox) selectAllCheckbox.disabled = true;
+
+    // Banner explaining why building is unavailable.
+    const toolbar = document.querySelector(".profiles-toolbar");
+    if (toolbar && !document.querySelector(".profiles-locked-banner")) {
+      const banner = document.createElement("div");
+      banner.className = "profiles-locked-banner";
+      banner.textContent = "Contact administrator for this feature.";
+      toolbar.parentNode.insertBefore(banner, toolbar.nextSibling);
+    }
+  };
+
   const formatDuration = (seconds) => {
     if (!Number.isFinite(seconds) || seconds <= 0) return "--:--:--";
     const total = Math.round(seconds);
@@ -129,10 +169,14 @@
     if (!isBundled) {
       const idParam = encodeURIComponent(profile.id || "");
       if (profile.structured) {
-        // Structured Profiles edit in the guided builder.
-        editCell.appendChild(createActionLink("Edit", `/profiles/builder?id=${idParam}`));
+        // Structured Profiles edit in the guided builder — hidden when editing
+        // is disabled for this device.
+        if (!editingDisabled) {
+          editCell.appendChild(createActionLink("Edit", `/profiles/builder?id=${idParam}`));
+        }
       } else {
-        // Legacy Profiles are read-only in-app — open the viewer (?view=1).
+        // Legacy Profiles are read-only in-app — the viewer (?view=1) stays
+        // available even when editing is disabled.
         editCell.appendChild(createActionLink("View", `/profiles/edit-form?id=${idParam}&view=1`));
       }
     }
@@ -252,7 +296,11 @@
     });
   }
 
-  loadProfiles();
+  (async () => {
+    editingDisabled = await fetchEditingDisabled();
+    applyEditingLock();
+    await loadProfiles();
+  })();
 
   tableBody.addEventListener("change", (event) => {
     if (event.target && event.target.classList.contains("profile-checkbox")) {

--- a/aquila_web/static/styles.css
+++ b/aquila_web/static/styles.css
@@ -2284,6 +2284,31 @@ a:active {
   margin-bottom: 24px;
 }
 
+/* Per-device profile-editing lock: grey out building, show admin message. */
+.profiles-locked-banner {
+  margin: 0 0 16px;
+  padding: 12px 16px;
+  border-radius: 12px;
+  background-color: #f1f1f1;
+  border: 1px solid #d9d9d9;
+  color: #555;
+  font-size: 15px;
+  text-align: center;
+}
+
+.profiles-shell--locked .profiles-table-wrapper {
+  opacity: 0.5;
+  filter: grayscale(0.4);
+}
+
+.run-secondary-btn.is-disabled,
+.run-secondary-btn:disabled,
+.profiles-action-btn.is-disabled {
+  opacity: 0.5;
+  pointer-events: none;
+  cursor: not-allowed;
+}
+
 .profiles-toolbar h1 {
   margin: 0;
   font-size: 28px;

--- a/config_files/device_profiles.json
+++ b/config_files/device_profiles.json
@@ -6,7 +6,8 @@
         "profile_group": "duke"
     },
     "sn03": {
-        "profile_group": "classic"
+        "profile_group": "classic",
+        "profile_editing_disabled": true
     },
     "sn04": {
         "profile_group": "breweries"

--- a/tests/contract/test_profile_editing_lock.py
+++ b/tests/contract/test_profile_editing_lock.py
@@ -42,16 +42,29 @@ def client(monkeypatch, tmp_path):
         yield c
 
 
+def test_locked_device_blocks_builder_page(monkeypatch, client):
+    monkeypatch.setenv("DEVICE_HOSTNAME", "locked-device")
+    resp = client.get("/profiles/builder")
+    assert resp.status_code == 403
+
+
 def test_locked_device_blocks_edit_page(monkeypatch, client):
     monkeypatch.setenv("DEVICE_HOSTNAME", "locked-device")
     resp = client.get("/profiles/edit")
     assert resp.status_code == 403
 
 
-def test_locked_device_blocks_edit_form_page(monkeypatch, client):
+def test_locked_device_blocks_edit_form_editing(monkeypatch, client):
     monkeypatch.setenv("DEVICE_HOSTNAME", "locked-device")
     resp = client.get("/profiles/edit-form")
     assert resp.status_code == 403
+
+
+def test_locked_device_allows_read_only_view(monkeypatch, client):
+    # Legacy profiles open read-only via ?view=1 — viewing stays enabled.
+    monkeypatch.setenv("DEVICE_HOSTNAME", "locked-device")
+    resp = client.get("/profiles/edit-form?id=verification_profile.json&view=1")
+    assert resp.status_code == 200
 
 
 def test_locked_device_blocks_save_profile(monkeypatch, client):

--- a/tests/contract/test_profile_editing_lock.py
+++ b/tests/contract/test_profile_editing_lock.py
@@ -1,0 +1,98 @@
+"""
+Contract tests for per-device profile-editing lock.
+
+A device flagged `profile_editing_disabled: true` in device_profiles.json must
+have the profile build/edit surfaces blocked (403), while viewing and selecting
+profiles for a run stay enabled. Devices without the flag behave as before.
+"""
+import json
+import os
+import sys
+from pathlib import Path
+
+import pytest
+from fastapi.testclient import TestClient
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+os.environ.setdefault("AQ_SRC_BASEDIR", str(REPO_ROOT))
+sys.path.insert(0, str(REPO_ROOT))
+
+
+@pytest.fixture
+def client(monkeypatch, tmp_path):
+    cfg = tmp_path / "config_files"
+    cfg.mkdir()
+    (cfg / "device_profiles.json").write_text(json.dumps({
+        "locked-device": {"profile_group": "all", "profile_editing_disabled": True},
+        "open-device": {"profile_group": "all"},
+    }))
+    (cfg / "profile_groups.json").write_text(json.dumps({"all": None}))
+
+    bundled = tmp_path / "profiles" / "bundled"
+    bundled.mkdir(parents=True)
+    (bundled / "verification_profile.json").write_text(json.dumps({
+        "title": "verification_profile",
+        "post_in_gui": "True",
+        "steps": [{"setpoint": 95, "duration": 1, "description": "step"}],
+    }))
+
+    from aquila_web import main as web_main
+    monkeypatch.setattr(web_main, "BASE_DIR", tmp_path)
+    with TestClient(web_main.app) as c:
+        yield c
+
+
+def test_locked_device_blocks_edit_page(monkeypatch, client):
+    monkeypatch.setenv("DEVICE_HOSTNAME", "locked-device")
+    resp = client.get("/profiles/edit")
+    assert resp.status_code == 403
+
+
+def test_locked_device_blocks_edit_form_page(monkeypatch, client):
+    monkeypatch.setenv("DEVICE_HOSTNAME", "locked-device")
+    resp = client.get("/profiles/edit-form")
+    assert resp.status_code == 403
+
+
+def test_locked_device_blocks_save_profile(monkeypatch, client):
+    monkeypatch.setenv("DEVICE_HOSTNAME", "locked-device")
+    resp = client.post("/profiles", json={"name": "New", "steps": []})
+    assert resp.status_code == 403
+
+
+def test_locked_device_blocks_delete_profile(monkeypatch, client):
+    monkeypatch.setenv("DEVICE_HOSTNAME", "locked-device")
+    resp = client.post("/profiles/delete", json={"profiles": ["local/foo.json"]})
+    assert resp.status_code == 403
+
+
+def test_locked_device_can_still_list_profiles(monkeypatch, client):
+    monkeypatch.setenv("DEVICE_HOSTNAME", "locked-device")
+    resp = client.get("/profiles")
+    assert resp.status_code == 200
+
+
+def test_locked_device_can_still_select_profile(monkeypatch, client):
+    monkeypatch.setenv("DEVICE_HOSTNAME", "locked-device")
+    resp = client.post("/profile/select", json={"profile": "verification_profile"})
+    assert resp.status_code == 200
+
+
+def test_open_device_can_access_edit(monkeypatch, client):
+    monkeypatch.setenv("DEVICE_HOSTNAME", "open-device")
+    resp = client.get("/profiles/edit")
+    assert resp.status_code == 200
+
+
+def test_permissions_endpoint_reflects_locked_device(monkeypatch, client):
+    monkeypatch.setenv("DEVICE_HOSTNAME", "locked-device")
+    resp = client.get("/profiles/permissions")
+    assert resp.status_code == 200
+    assert resp.json()["editing_disabled"] is True
+
+
+def test_permissions_endpoint_reflects_open_device(monkeypatch, client):
+    monkeypatch.setenv("DEVICE_HOSTNAME", "open-device")
+    resp = client.get("/profiles/permissions")
+    assert resp.status_code == 200
+    assert resp.json()["editing_disabled"] is False

--- a/unit_tests/test_profile_editing_lock.py
+++ b/unit_tests/test_profile_editing_lock.py
@@ -1,0 +1,53 @@
+"""
+Unit tests for resolve_profile_editing_disabled() in aquila_web/main.py.
+
+A per-device flag (`profile_editing_disabled` in config_files/device_profiles.json)
+locks profile building (edit/new) on chosen devices. Resolution fails OPEN:
+unknown hostname, missing flag, or unreadable config => editing stays enabled.
+"""
+import json
+import os
+import sys
+import types
+from pathlib import Path
+
+import pytest
+
+# Stub heavy hardware deps before importing main
+for mod in ("RPi", "RPi.GPIO"):
+    if mod not in sys.modules:
+        sys.modules[mod] = types.ModuleType(mod)
+
+if "serial" not in sys.modules:
+    _s = types.ModuleType("serial")
+    _st = types.ModuleType("serial.tools")
+    _lp = types.ModuleType("serial.tools.list_ports")
+    _lp.comports = lambda: []
+    _s.tools = _st
+    _st.list_ports = _lp
+    sys.modules.update({"serial": _s, "serial.tools": _st, "serial.tools.list_ports": _lp})
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(REPO_ROOT))
+sys.path.insert(0, str(REPO_ROOT / "aquila_web"))
+os.environ.setdefault("AQ_SRC_BASEDIR", str(REPO_ROOT))
+
+
+@pytest.fixture
+def base_dir(monkeypatch, tmp_path):
+    cfg = tmp_path / "config_files"
+    cfg.mkdir()
+    (cfg / "device_profiles.json").write_text(json.dumps({
+        "locked-device": {"profile_group": "all", "profile_editing_disabled": True},
+        "unlocked-device": {"profile_group": "all", "profile_editing_disabled": False},
+        "default-device": {"profile_group": "all"},
+    }))
+    import aquila_web.main as web_main
+    monkeypatch.setattr(web_main, "BASE_DIR", tmp_path)
+    return tmp_path
+
+
+def test_flag_true_disables_editing(monkeypatch, base_dir):
+    monkeypatch.setenv("DEVICE_HOSTNAME", "locked-device")
+    import aquila_web.main as web_main
+    assert web_main.resolve_profile_editing_disabled() is True

--- a/unit_tests/test_profile_editing_lock.py
+++ b/unit_tests/test_profile_editing_lock.py
@@ -51,3 +51,28 @@ def test_flag_true_disables_editing(monkeypatch, base_dir):
     monkeypatch.setenv("DEVICE_HOSTNAME", "locked-device")
     import aquila_web.main as web_main
     assert web_main.resolve_profile_editing_disabled() is True
+
+
+def test_flag_false_keeps_editing_enabled(monkeypatch, base_dir):
+    monkeypatch.setenv("DEVICE_HOSTNAME", "unlocked-device")
+    import aquila_web.main as web_main
+    assert web_main.resolve_profile_editing_disabled() is False
+
+
+def test_missing_flag_keeps_editing_enabled(monkeypatch, base_dir):
+    monkeypatch.setenv("DEVICE_HOSTNAME", "default-device")
+    import aquila_web.main as web_main
+    assert web_main.resolve_profile_editing_disabled() is False
+
+
+def test_unknown_hostname_keeps_editing_enabled(monkeypatch, base_dir):
+    monkeypatch.setenv("DEVICE_HOSTNAME", "not-in-config")
+    import aquila_web.main as web_main
+    assert web_main.resolve_profile_editing_disabled() is False
+
+
+def test_missing_config_keeps_editing_enabled(monkeypatch, base_dir):
+    (base_dir / "config_files" / "device_profiles.json").unlink()
+    monkeypatch.setenv("DEVICE_HOSTNAME", "locked-device")
+    import aquila_web.main as web_main
+    assert web_main.resolve_profile_editing_disabled() is False


### PR DESCRIPTION
Closes #271.

## Summary
Adds a per-device toggle to disable profile **building** (edit / new / delete) on chosen devices, reusing the existing per-device config pattern. On a locked device the Profiles screen is greyed out with a *"Contact administrator for this feature"* banner, the build/edit pages are blocked server-side (403), and the write endpoints reject. Viewing and selecting profiles for a run stay enabled.

## Configuration
Set `profile_editing_disabled: true` on a device entry in `config_files/device_profiles.json`:
```json
"sn03": { "profile_group": "classic", "profile_editing_disabled": true }
```
Resolution fails **open** — unknown hostname, missing flag, or unreadable config leaves editing enabled. This PR flags **sn03** (sn04 is already restricted to the `breweries` group from #270).

## Backend (`aquila_web/main.py`)
- `resolve_profile_editing_disabled() -> bool` — mirrors `resolve_device_profiles()`, fail-open.
- `_guard_profile_editing()` → 403 with admin message.
- Gated: `GET /profiles/builder` (the editor, #197), `POST /profiles`, `POST /profiles/delete`.
- `GET /profiles/edit` & `/profiles/edit-form` are gated **only when not a read-only `?view=1`/`?mode=view` request**, so legacy profile viewing stays available.
- `GET /profiles/permissions` → `{"editing_disabled": bool}` for the frontend.
- Untouched: `GET /profiles`, `GET /profiles/details`, `POST /profile/select`.

## Frontend (`aquila_web/static/profiles/`)
- On lock: greys out the table, disables **New profile** / **Delete** / select-all, hides per-row **Edit** links, and inserts a *"Contact administrator for this feature."* banner. "Start" (run) and legacy "View" stay active. Fails open if `/profiles/permissions` can't be fetched.

## Tests (TDD)
- `unit_tests/test_profile_editing_lock.py` — resolver: flag true/false, missing flag, unknown host, missing config (5).
- `tests/contract/test_profile_editing_lock.py` — builder/edit/edit-form/save/delete 403 on locked device; read-only view + list + select still 200; open device 200; permissions endpoint reflects flag (11).
- All 16 new tests pass, plus existing profile endpoint/resolver tests.

> Note: 4 failures in `tests/contract/test_profile_device_filtering.py` are **pre-existing on `main`** (that test monkeypatches `BASE_DIR`, but `resolve_profile_dir()` reads `DEFAULT_PROFILE_DIR`); unrelated to this change.

## Deployment
Edit `device_profiles.json` → merge to `main` → CI builds image → Watchtower delivers (~5 min), per `specs/backend/per_device_profile_filtering.md`.

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)