### PR TITLE
Profiles heading rename + reworded lock banner + lock sn04

### DIFF
--- a/aquila_web/main.py
+++ b/aquila_web/main.py
@@ -1278,7 +1278,7 @@ def _guard_profile_editing() -> None:
     if resolve_profile_editing_disabled():
         raise HTTPException(
             status_code=403,
-            detail="Profile editing is disabled on this device. Contact administrator for this feature.",
+            detail="Profile editing is disabled on this device. Contact administrator for profile management.",
         )
 
 

--- a/aquila_web/static/profiles/index.html
+++ b/aquila_web/static/profiles/index.html
@@ -10,7 +10,7 @@
   <div class="app-shell">
     <main class="main run-main">
       <header class="run-header">
-        <h1 class="run-header__title">Saved Profiles</h1>
+        <h1 class="run-header__title">Profiles</h1>
         <nav class="run-header__nav">
           <a class="run-nav-link" href="/run">Run</a>
           <a class="run-nav-link" href="/history">History</a>
@@ -56,6 +56,6 @@
   </div>
   <script src="/static/nav.js?v=1"></script>
   <script src="/static/confirm-modal.js?v=1"></script>
-  <script src="/static/profiles/profiles.js?v=9"></script>
+  <script src="/static/profiles/profiles.js?v=10"></script>
 </body>
 </html>

--- a/aquila_web/static/profiles/profiles.js
+++ b/aquila_web/static/profiles/profiles.js
@@ -39,7 +39,7 @@
     if (toolbar && !document.querySelector(".profiles-locked-banner")) {
       const banner = document.createElement("div");
       banner.className = "profiles-locked-banner";
-      banner.textContent = "Contact administrator for this feature.";
+      banner.textContent = "Contact administrator for profile management";
       toolbar.parentNode.insertBefore(banner, toolbar.nextSibling);
     }
   };

--- a/config_files/device_profiles.json
+++ b/config_files/device_profiles.json
@@ -10,7 +10,8 @@
         "profile_editing_disabled": true
     },
     "sn04": {
-        "profile_group": "breweries"
+        "profile_group": "breweries",
+        "profile_editing_disabled": true
     },
     "sn05": {
         "profile_group": "duke"


### PR DESCRIPTION
Follow-up to #273 (merged).

## Changes
- Rename the Profiles page heading **"Saved Profiles" → "Profiles"**.
- Reword the editing-lock message to **"Contact administrator for profile management"** — both the greyed-out banner (`profiles.js`) and the backend 403 detail (`main.py`) so they match.
- Lock profile editing on **sn04** (`profile_editing_disabled: true`), alongside sn03.

## Notes
- Bumped `profiles.js` cache-bust version so devices pick up the new banner text.
- Existing per-device profile-editing lock tests still pass (16/16).
- Diff is only the two commits not included in #273 (which merged at an earlier commit).

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)