### PR TITLE
#275 Persist running profile so the Run-card header survives a backend restart

### DIFF
--- a/aquila_web/main.py
+++ b/aquila_web/main.py
@@ -52,6 +52,10 @@ if str(BASE_DIR) not in sys.path:
 RESULTS_DIR = BASE_DIR / "logs" / "results"
 PLOTS_DIR = BASE_DIR / "logs" / "plots"
 HISTORY_PATH = BASE_DIR / "logs" / "history.json"
+# Durable run state so the running profile survives a backend restart (#272
+# follow-up). run_name is re-derived from history on startup; selected_profile
+# cannot be, so it is persisted here and restored by _init_selected_profile().
+RUN_STATE_PATH = BASE_DIR / "logs" / "run_state.json"
 DEFAULT_PROFILE_DIR = BASE_DIR / "profiles"
 LOCAL_PROFILE_DIR = MODULE_BASE_DIR / "profiles"
 BUNDLED_PROFILE_DIR = DEFAULT_PROFILE_DIR / "bundled"
@@ -382,6 +386,29 @@ def _init_run_name() -> None:
     global run_name, run_counter
     run_name, run_counter = _next_run_info()
 
+def _persist_selected_profile() -> None:
+    """Write the current selected_profile to disk so it survives a restart."""
+    try:
+        RUN_STATE_PATH.parent.mkdir(parents=True, exist_ok=True)
+        RUN_STATE_PATH.write_text(json.dumps({"selected_profile": selected_profile}))
+    except Exception:
+        logger.warning("Could not persist selected_profile to %s", RUN_STATE_PATH)
+
+def _init_selected_profile() -> None:
+    """Restore selected_profile from disk on startup, mirroring _init_run_name.
+
+    On the device the backend is replaced mid-run (watchtower / container
+    restarts); without this the running profile would be lost and the Run-card
+    header would fall back to the ``"--"`` no-profile sentinel (#272)."""
+    global selected_profile
+    try:
+        if RUN_STATE_PATH.exists():
+            value = json.loads(RUN_STATE_PATH.read_text()).get("selected_profile")
+            if value:
+                selected_profile = value
+    except Exception:
+        logger.warning("Could not restore selected_profile from %s", RUN_STATE_PATH)
+
 def _save_history(entries: list[dict]) -> None:
     HISTORY_PATH.parent.mkdir(parents=True, exist_ok=True)
     with HISTORY_PATH.open("w") as f:
@@ -425,6 +452,7 @@ def _resolve_results_path() -> Path | None:
     return None
 
 _init_run_name()
+_init_selected_profile()
 
 def _next_run_index(profile_name: str) -> int:
     RESULTS_DIR.mkdir(parents=True, exist_ok=True)
@@ -1213,6 +1241,7 @@ async def set_drawer_state(payload: dict):
 async def select_profile(payload: ProfileSelect):
     global selected_profile
     selected_profile = payload.profile
+    _persist_selected_profile()
     logger.info("Selected profile:", selected_profile)
     return {"ok":True}
 
@@ -1221,6 +1250,7 @@ async def run_status_reset():
     global run_requested, selected_profile
     run_requested = False
     selected_profile = None
+    _persist_selected_profile()
     logger.info("Run button reset, profile reset")
     return{"ok":True}
 

--- a/tests/contract/test_run_profile_persistence.py
+++ b/tests/contract/test_run_profile_persistence.py
@@ -1,0 +1,51 @@
+"""
+Contract tests for running-profile durability across a backend restart.
+
+Follow-up to #272: on the device the backend process is replaced mid-run
+(watchtower / container restarts). ``run_name`` survives because it is rebuilt
+from ``history.json`` on startup, but ``selected_profile`` was in-memory only and
+reset to ``None`` — so the Run-card header (which reads it via the ``/ws`` panel's
+``profile_name``) showed the ``"--"`` no-profile sentinel while ``run_name`` still
+showed correctly.
+
+The selected profile must be persisted to disk and restored on startup, mirroring
+``run_name``, so the running profile survives a restart.
+"""
+import pytest
+
+pytestmark = pytest.mark.contract
+
+PROFILE_ID = "local/verification_profile.json"
+
+
+def test_selected_profile_survives_backend_restart(client, tmp_path, monkeypatch):
+    from aquila_web import main as web_main
+
+    # Isolate the persisted-state file so the test never touches real device state.
+    monkeypatch.setattr(web_main, "RUN_STATE_PATH", tmp_path / "run_state.json")
+
+    # Operator selects a profile before starting a run.
+    client.post("/profile/select", json={"profile": PROFILE_ID})
+
+    # Simulate a backend restart: the fresh process loses every in-memory global,
+    # then the startup restore runs (mirrors _init_run_name at module load).
+    web_main.selected_profile = None
+    web_main._init_selected_profile()
+
+    # The restored process still knows which profile is running.
+    assert client.get("/button_status").json()["profile"] == PROFILE_ID
+
+
+def test_run_status_reset_clears_persisted_profile(client, tmp_path, monkeypatch):
+    from aquila_web import main as web_main
+
+    monkeypatch.setattr(web_main, "RUN_STATE_PATH", tmp_path / "run_state.json")
+
+    client.post("/profile/select", json={"profile": PROFILE_ID})
+    client.post("/run_status/reset")
+
+    # A restart after a reset must not resurrect the cleared profile.
+    web_main.selected_profile = None
+    web_main._init_selected_profile()
+
+    assert client.get("/button_status").json()["profile"] in (None, "")


### PR DESCRIPTION
Fixes #275.

## Problem

On the physical device the live Run-card header shows **`--`** instead of the selected profile name, for any profile. The run name still shows correctly. Regression from #272; not reproducible on dev.

## Root cause

#272 made the header source the running profile from the server (`/ws` panel `profile_name = _resolve_profile_display_name(selected_profile)`). That resolver returns `"--"` **only** when `selected_profile` is falsy.

`selected_profile` is an in-memory-only global — set on `/profile/select`, never persisted. The device replaces the backend process mid-run (watchtower / container restarts); the fresh process starts with `selected_profile = None` while the hardware keeps posting `screen=running`, so the header renders `"--"`. `run_name` survives the same restart because it is re-derived from `history.json` on startup — `selected_profile` had no such durability.

## Fix

Give `selected_profile` the same disk durability `run_name` already has:

- `RUN_STATE_PATH = logs/run_state.json` (gitignored, alongside `history.json`).
- `_persist_selected_profile()` on `/profile/select` and `/run_status/reset`.
- `_init_selected_profile()` at module load, next to `_init_run_name()`, restoring the value.

After a restart the `/ws` panel resolves the real profile name again. No UI/HTML/CSS or header-render changes — the #272 panel/header code is untouched.

## Tests

`tests/contract/test_run_profile_persistence.py` (TDD, red→green):
- profile survives a simulated backend restart (observable via `/button_status`);
- `run_status/reset` clears the persisted profile (no stale profile after restart).

Verified live: selecting a profile, killing and restarting uvicorn, then `/button_status` still reports the profile (before the fix it was `None`). Existing `tests/e2e/test_run_header_persist.py` (3) still pass; full contract suite passes except the same 10 pre-existing failures unrelated to this change.

## Note

Side effect: the profile selection now persists across a backend restart until a reset, so the idle dropdown may come back pre-selected to the last profile instead of "Select a profile". Can clear on run completion if undesired.

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)
