### PR TITLE
Keep running profile in header for the whole run; clear it on completion (#275)

### DIFF
--- a/aq_lib/state_requests.py
+++ b/aq_lib/state_requests.py
@@ -171,9 +171,12 @@ def wait_for_button(include_run_complete_ack: bool = False):
             profile_id = data.get("profile")
             logger.info("Requests profile selected: %s" % (profile_id))
             try:
-                requests.post(f"{BACKEND_URL}/run_status/reset", timeout=5)
+                # Consume only the run-request edge — must NOT clear the selected
+                # profile, or the Run-card header goes blank ("--") for the whole
+                # run (#275). /run_status/reset would wipe the profile too.
+                requests.post(f"{BACKEND_URL}/run_requested/ack", timeout=5)
             except Exception as e:
-                logger.warning("Error resetting button", e)
+                logger.warning("Error acknowledging run request", e)
             return data
         elif data.get("drawer_open_status"):
             logger.info("Drawer open button pressed")

--- a/aquila_web/main.py
+++ b/aquila_web/main.py
@@ -1254,6 +1254,21 @@ async def run_status_reset():
     logger.info("Run button reset, profile reset")
     return{"ok":True}
 
+@app.post("/run_requested/ack")
+async def run_requested_ack():
+    """Consume the run-request edge WITHOUT clearing the selected profile.
+
+    The device state loop (aq_lib/state_requests.wait_for_button) calls this
+    once it has picked up a run press, so the press is not handled twice. Unlike
+    /run_status/reset it must NOT clear selected_profile: the profile has to
+    survive for the whole run so the Run-card header keeps showing its name
+    instead of the "--" no-profile sentinel (#275). Clearing it here was the
+    root cause — the header went blank the moment a run started."""
+    global run_requested
+    run_requested = False
+    logger.info("Run request acknowledged (profile preserved)")
+    return {"ok": True}
+
 def resolve_device_profiles() -> "set[str] | None":
     import socket
     hostname = os.getenv("DEVICE_HOSTNAME") or socket.gethostname()

--- a/aquila_web/main.py
+++ b/aquila_web/main.py
@@ -394,6 +394,15 @@ def _persist_selected_profile() -> None:
     except Exception:
         logger.warning("Could not persist selected_profile to %s", RUN_STATE_PATH)
 
+def _set_selected_profile(value: "str | None") -> None:
+    """Single entry point for changing the selected profile + persisting it.
+
+    Every mutation of selected_profile goes through here so the durable copy on
+    disk (RUN_STATE_PATH) can never drift from memory."""
+    global selected_profile
+    selected_profile = value
+    _persist_selected_profile()
+
 def _init_selected_profile() -> None:
     """Restore selected_profile from disk on startup, mirroring _init_run_name.
 
@@ -802,6 +811,9 @@ async def clear_results():
 async def acknowledge_run_complete():
     global run_complete_ack
     run_complete_ack = True
+    # Run is done and dismissed — clear the selection so the ready screen resets
+    # to "Select a profile" for the next run (no manual reset needed, #275).
+    _set_selected_profile(None)
     return {"ok": True}
 
 @app.post("/run/complete/ack/reset")
@@ -1239,18 +1251,15 @@ async def set_drawer_state(payload: dict):
 
 @app.post("/profile/select")
 async def select_profile(payload: ProfileSelect):
-    global selected_profile
-    selected_profile = payload.profile
-    _persist_selected_profile()
+    _set_selected_profile(payload.profile)
     logger.info("Selected profile:", selected_profile)
     return {"ok":True}
 
 @app.post("/run_status/reset")
 async def run_status_reset():
-    global run_requested, selected_profile
+    global run_requested
     run_requested = False
-    selected_profile = None
-    _persist_selected_profile()
+    _set_selected_profile(None)
     logger.info("Run button reset, profile reset")
     return{"ok":True}
 

--- a/tests/contract/test_run_complete_clears_profile.py
+++ b/tests/contract/test_run_complete_clears_profile.py
@@ -1,0 +1,36 @@
+"""
+Contract tests: a completed run clears the selected profile (#275 follow-up).
+
+After the fix that keeps selected_profile alive for the whole run, it must be
+cleared once the run completes so the ready screen returns to "Select a profile"
+for the next run — without the operator pressing reset. The completion signal is
+POST /run/complete/ack (frontend script.js; the device reads run_complete_ack).
+"""
+import pytest
+
+pytestmark = pytest.mark.contract
+
+PROFILE_ID = "local/verification_profile.json"
+
+
+def test_run_complete_ack_clears_selected_profile(client):
+    client.post("/profile/select", json={"profile": PROFILE_ID})
+
+    client.post("/run/complete/ack")
+
+    assert client.get("/button_status").json()["profile"] in (None, "")
+
+
+def test_cleared_profile_stays_cleared_after_restart(client, tmp_path, monkeypatch):
+    from aquila_web import main as web_main
+
+    monkeypatch.setattr(web_main, "RUN_STATE_PATH", tmp_path / "run_state.json")
+
+    client.post("/profile/select", json={"profile": PROFILE_ID})
+    client.post("/run/complete/ack")
+
+    # A backend restart after completion must not resurrect the cleared profile.
+    web_main.selected_profile = None
+    web_main._init_selected_profile()
+
+    assert client.get("/button_status").json()["profile"] in (None, "")

--- a/tests/contract/test_run_request_ack.py
+++ b/tests/contract/test_run_request_ack.py
@@ -1,0 +1,51 @@
+"""
+Contract tests for /run_requested/ack — the run-request edge-ack that must
+preserve the selected profile (#275).
+
+Root cause of #275: the device state loop consumed the run press by calling
+/run_status/reset, which also cleared selected_profile. The Run-card header
+sources profile_name from selected_profile via the /ws panel, so it fell back
+to the "--" no-profile sentinel the instant a run started (device only — dev's
+DEV_SIMULATE path never calls this).
+
+/run_requested/ack must clear only run_requested and leave selected_profile
+intact, while /run_status/reset keeps its full-reset semantics.
+"""
+import pytest
+
+pytestmark = pytest.mark.contract
+
+PROFILE_ID = "local/verification_profile.json"
+
+
+def test_ack_preserves_selected_profile(client):
+    # Operator selects a profile, then presses Run.
+    client.post("/profile/select", json={"profile": PROFILE_ID})
+
+    # The device loop consumes the run-press edge.
+    resp = client.post("/run_requested/ack")
+    assert resp.status_code == 200
+    assert resp.json()["ok"] is True
+
+    # The profile must survive so the header keeps showing it during the run.
+    assert client.get("/button_status").json()["profile"] == PROFILE_ID
+
+
+def test_ack_clears_run_requested_flag(client):
+    from aquila_web import main as web_main
+
+    client.post("/profile/select", json={"profile": PROFILE_ID})
+    web_main.run_requested = True
+
+    client.post("/run_requested/ack")
+
+    # The run-press edge is consumed so it is not handled twice.
+    assert web_main.run_requested is False
+
+
+def test_run_status_reset_still_clears_profile(client):
+    # /run_status/reset keeps its full-reset semantics (used for test isolation
+    # and a genuine cancel/reset).
+    client.post("/profile/select", json={"profile": PROFILE_ID})
+    client.post("/run_status/reset")
+    assert client.get("/button_status").json()["profile"] in (None, "")


### PR DESCRIPTION
Fixes #275. Follow-up to #276, which was necessary but **not sufficient**.

## Real root cause
The header goes to `--` the instant a run starts — not on a backend restart.

1. Select profile → `selected_profile = "local/foo.json"`.
2. Press Run → `/button/run` sets `run_requested = True` (passes the profile check, so the run does start).
3. The device state loop `wait_for_button()` (`aq_lib/state_requests.py`) sees `run_requested`, grabs the `profile` from `/button_status`, then calls **`/run_status/reset`** to consume the button-press edge.
4. But `/run_status/reset` also does `selected_profile = None` (and #276 now persists that `None`).
5. The run proceeds (`run_name` untouched), but the `/ws` panel renders `_resolve_profile_display_name(selected_profile)` → **`"--"`**.

Device-only, which is why it never reproduced on dev — `DEV_SIMULATE` uses `_simulate_run` and never calls `wait_for_button`. Disk persistence (#276) can't help: the wipe happens on **every** run start and writes `None` to disk.

## Fix
`/run_status/reset` conflated two concerns. Split them, and add a deliberate reset at the *right* moment (completion, not run start):

- **New `POST /run_requested/ack`** — clears only `run_requested`, leaves `selected_profile` intact. The device loop now calls this. → profile survives the whole run.
- **`POST /run/complete/ack` now clears `selected_profile`** — once the run is done and dismissed, the ready screen resets to "Select a profile" for the next run, with no manual reset. The clear is persisted, so a restart just after completion won't resurrect it.
- `/run_status/reset` keeps its full-reset semantics (used by test conftests for isolation and any genuine cancel).
- All `selected_profile` mutations now go through a single `_set_selected_profile()` helper so memory and the on-disk copy can't drift.

## Lifecycle
| Moment | selected_profile | Header |
|---|---|---|
| Select profile | set (+persisted) | profile name |
| Press Run / device acks run edge | **preserved** | profile name |
| Mid-run backend restart | restored from disk (#276) | profile name |
| Run completes & acknowledged | **cleared** (+persisted) | "Select a profile" |
| Next run | pick again → replaces | new profile |

Running two tests back-to-back: after test 1 finishes the dropdown resets; picking profile 2 takes over cleanly (no reset press).

## Files
- `aquila_web/main.py` — `/run_requested/ack`; `/run/complete/ack` clears the profile; `_set_selected_profile()` helper.
- `aq_lib/state_requests.py` — `wait_for_button` posts to `/run_requested/ack` instead of `/run_status/reset`.
- `tests/contract/test_run_request_ack.py` — ack preserves the profile; ack clears `run_requested`; `/run_status/reset` still clears the profile.
- `tests/contract/test_run_complete_clears_profile.py` — completion clears the profile; the clear survives a restart.

## Tests
- New contract tests pass, incl. #276's persistence tests.
- 69 button/run-flow/state contract+state tests pass — no regressions.
- **Not run on physical hardware**; the contract tests reproduce the exact edge-ack and completion paths. Worth one device confirmation before merge.

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)