### PR TITLE
Fix OTA auto-reboot: persist reboot sentinel across container swap

### DIFF
--- a/fleet-config/docker-compose.yml
+++ b/fleet-config/docker-compose.yml
@@ -19,7 +19,10 @@ services:
       - /opt/aquila/logs:/opt/aquila/logs
       - /opt/aquila/profiles:/opt/aquila/profiles
       - /opt/aquila/config:/opt/aquila/config
-      - /opt/fleet/.env:/opt/fleet/.env
+      # Mount the whole fleet dir (not just .env) so the OTA reboot sentinel
+      # /opt/fleet/last_update.json is host-backed and survives the Watchtower
+      # container swap. See specs/backend/spec_ota_sentinel_persistent_volume.md.
+      - /opt/fleet:/opt/fleet
     devices:
       - "/dev/ttyUSB0:/dev/ttyUSB0"
       - "/dev/i2c-1:/dev/i2c-1"

--- a/specs/backend/spec_ota_sentinel_persistent_volume.md
+++ b/specs/backend/spec_ota_sentinel_persistent_volume.md
@@ -1,0 +1,110 @@
+# Spec: Persist the OTA Reboot Sentinel Across the Container Swap
+
+**Issue:** bugfix for the auto-reboot shipped in #183 / ADR-018
+**Related:** `specs/backend/spec_ota_auto_reboot_complete.md` (the feature this fixes), ADR-002 (Watchtower OTA), `fleet-config/docker-compose.yml`
+
+## Problem
+
+The OTA auto-reboot never fires on a real device. The completion flow depends on an
+on-disk **sentinel** (`/opt/fleet/last_update.json`) that `/update/apply` writes *before*
+triggering Watchtower, and that the freshly-started container reads on startup to decide
+whether to reboot the host.
+
+The sentinel never survives the swap. Watchtower **destroys the old `aquila-backend`
+container and creates a new one** from the pulled image. But the `backend` service only
+bind-mounts a single file from the fleet directory:
+
+```yaml
+volumes:
+  - /opt/fleet/.env:/opt/fleet/.env      # ← only the .env file, NOT the directory
+```
+
+So `/opt/fleet/last_update.json` is written into the **old container's ephemeral writable
+layer**, which is thrown away when the container is recreated. The new container reads
+`/opt/fleet/last_update.json`, finds nothing, `read_sentinel()` returns `None`,
+`next_startup_action()` returns `"none"`, and it clears and moves on — **no reboot, ever**.
+
+The original feature spec (`spec_ota_auto_reboot_complete.md`, "Backend changes") assumed
+`/opt/fleet/last_update.json` was a "host-volume path, survives container swap per ADR-002."
+That assumption was never true for the `backend` service — the mount was never added.
+
+## Goal
+
+Make the sentinel persist on the host across the Watchtower container swap and the reboot,
+so the two-state sentinel machine (`reboot_pending` → `show_complete` → deleted) works as
+designed. No change to the sentinel state-machine logic — only *where the file lives* must
+be corrected.
+
+---
+
+## Fix
+
+Bind-mount the fleet directory into the `backend` service so the sentinel's directory
+(`/opt/fleet`) is host-backed and survives the container being recreated. Replace the
+narrower `.env`-only file mount with the parent directory (the directory mount still
+exposes `/opt/fleet/.env` to the container):
+
+```yaml
+# fleet-config/docker-compose.yml — services.backend.volumes
+- /opt/fleet:/opt/fleet          # was: /opt/fleet/.env:/opt/fleet/.env
+```
+
+The Python default path (`AQ_UPDATE_SENTINEL_PATH`, default `/opt/fleet/last_update.json`
+in `aquila_web/main.py`) is left unchanged — it becomes correct once the directory is
+mounted. This keeps the fix faithful to the ADR-002 intent that the sentinel lives in the
+host-managed `/opt/fleet` control directory.
+
+Only the `backend` service needs the mount — it is the sole reader/writer of the sentinel
+(`main.py`). The `app` service (`application.py`) does not touch it.
+
+### Why the directory, not the file
+
+A bind mount of a single file (`/opt/fleet/.env`) only persists that one file; any *other*
+path under `/opt/fleet` inside the container is still ephemeral. Mounting the directory
+makes the whole `/opt/fleet` tree host-backed, so `last_update.json` written by the old
+container is visible to the new one.
+
+---
+
+## Rollout note
+
+This is a deploy-config change, so it only takes effect for updates applied **after** a
+device is already running the fixed `docker-compose.yml`. The fleet update path re-fetches
+`docker-compose.yml` from the repo on each update (`scripts/deploy/fleet-update.sh`), so:
+
+- The **first** update that carries this fix still won't auto-reboot (the currently-running
+  container predates the mount).
+- Every update **after** that will, because the device is now running a container that has
+  `/opt/fleet` mounted.
+
+No manual intervention is required beyond the normal update; document this one-cycle delay
+so it isn't mistaken for the fix not working.
+
+---
+
+## Tests
+
+- **Compose config (`tests/fleet_device/test_compose_config.py`, CI-runnable)** — the
+  regression test that would have caught this:
+  - The `backend` service bind-mounts a host source whose target directory contains the
+    OTA sentinel path (`/opt/fleet`), i.e. the sentinel's parent directory is a bind mount,
+    not just the `.env` file.
+  - Asserted structurally by parsing the YAML — no Docker required.
+- **Existing sentinel/state-machine tests** (`tests/unit/test_update_sentinel.py`,
+  `tests/contract/test_update_complete_flow.py`, `tests/unit/test_kiosk_reboot.py`) — must
+  continue to pass unchanged; this fix does not alter that logic.
+- `pytest tests unit_tests -v` passes.
+
+## Files touched
+
+| File | Change |
+|------|--------|
+| `fleet-config/docker-compose.yml` | `backend` service: mount `/opt/fleet` (dir) instead of only `/opt/fleet/.env` |
+| `tests/fleet_device/test_compose_config.py` | New regression test: sentinel's parent dir is bind-mounted into `backend` |
+
+## Out of scope
+
+- The sentinel state machine, TTL, modal, and `/reboot` proxy (all shipped in #183, unchanged).
+- Moving the sentinel to a different persistent location (e.g. `/opt/aquila/...`) — keeping
+  it at `/opt/fleet` per ADR-002 is the minimal, intent-faithful fix.
+- The `app`/`ui`/`watchtower` services — none read the sentinel.

--- a/tests/fleet_device/test_compose_config.py
+++ b/tests/fleet_device/test_compose_config.py
@@ -103,3 +103,28 @@ class TestFleetCompose:
         assert any("8090" in p for p in ports), (
             f"backend service doesn't expose port 8090. Ports: {ports}"
         )
+
+    def test_backend_persists_ota_sentinel_directory(self):
+        """
+        The OTA auto-reboot sentinel (/opt/fleet/last_update.json) must sit on a
+        host-backed bind mount so it survives the Watchtower container swap.
+
+        /update/apply writes the sentinel, then Watchtower DESTROYS the old backend
+        container and creates a new one; the new container reads the sentinel on
+        startup to decide whether to reboot the host. If only /opt/fleet/.env is
+        mounted (not the directory), the sentinel lands in the old container's
+        ephemeral layer and is discarded — the device never auto-reboots.
+
+        Regression guard for the #183 auto-reboot: the sentinel's parent directory
+        (/opt/fleet) must be bind-mounted into the backend service, not just the
+        single .env file.
+        """
+        backend = _load(FLEET_COMPOSE)["services"]["backend"]
+        volumes = backend.get("volumes", [])
+        # host_path:container_path[:opts] — collect the container-side targets.
+        targets = [str(v).split(":")[1] for v in volumes if ":" in str(v)]
+        assert "/opt/fleet" in targets, (
+            "backend service must bind-mount the /opt/fleet directory so the OTA "
+            "reboot sentinel (/opt/fleet/last_update.json) survives the container "
+            f"swap. Mounting only /opt/fleet/.env is not enough. Volumes: {volumes}"
+        )

--- a/tests/fleet_device/test_linux_compatibility.py
+++ b/tests/fleet_device/test_linux_compatibility.py
@@ -107,8 +107,9 @@ class TestLinuxCompatibility:
 
     def test_compose_volumes_use_opt_aquila(self):
         """
-        All host volume mounts must be under /opt/aquila/ — the standard
-        device path. Mounts to /tmp/, relative paths, or developer home dirs
+        All host volume mounts must be under a standard device path — /opt/aquila/
+        (app data) or /opt/fleet/ (fleet control dir: compose, .env, and the OTA
+        reboot sentinel). Mounts to /tmp/, relative paths, or developer home dirs
         indicate a local-dev config that will fail or leak data on device.
         """
         services = _compose()["services"]
@@ -122,9 +123,13 @@ class TestLinuxCompatibility:
                     continue
                 if host_path == "/root/.docker/config.json":
                     continue
-                assert host_path.startswith("/opt/aquila") or host_path.startswith("/root"), (
+                assert (
+                    host_path.startswith("/opt/aquila")
+                    or host_path.startswith("/opt/fleet")
+                    or host_path.startswith("/root")
+                ), (
                     f"Service '{name}' volume '{volume}' mounts from '{host_path}' "
-                    f"— expected /opt/aquila/... path for device deployment"
+                    f"— expected /opt/aquila/... or /opt/fleet/... path for device deployment"
                 )
 
     def test_compose_no_platform_mac(self):


### PR DESCRIPTION
## Problem

The OTA auto-reboot shipped in #183 never fires on a real device. `/update/apply` writes a sentinel to `/opt/fleet/last_update.json` before triggering Watchtower, and the freshly-started container reads it on boot to decide whether to reboot the host.

The sentinel never survives the swap. Watchtower **destroys the old `aquila-backend` container and creates a new one**, but the backend service only bind-mounted a single file — `/opt/fleet/.env` — not the directory. So `/opt/fleet/last_update.json` landed in the old container's ephemeral writable layer and was discarded on recreation. The new container read the path, found nothing, and never rebooted.

The original feature spec assumed `/opt/fleet/last_update.json` was a "host-volume path, survives container swap" — but that mount was never added.

## Fix

One line in `fleet-config/docker-compose.yml` — bind-mount the whole `/opt/fleet` directory into the `backend` service (the dir mount still exposes `.env`):

```yaml
- /opt/fleet:/opt/fleet        # was: /opt/fleet/.env:/opt/fleet/.env
```

No Python change: the code default was already `/opt/fleet/last_update.json`; it just needed a real host-backed location. This keeps the sentinel in the `/opt/fleet` control dir per ADR-002's intent.

## Tests

- **New regression test** (`tests/fleet_device/test_compose_config.py`) — asserts the backend service bind-mounts the sentinel's parent dir (`/opt/fleet`), not just `.env`. Pure YAML parsing, CI-runnable; would have caught this.
- Updated `test_compose_volumes_use_opt_aquila` to allowlist `/opt/fleet` as a standard device path.
- Existing sentinel / state-machine / reboot tests unchanged and passing.

## Rollout note (important)

This is deploy config, so it only takes effect for updates applied **after** a device is running the fixed compose. The **first** update carrying this fix still won't auto-reboot (the running container predates the mount); every update after that will. One-cycle delay is expected, not a regression.

Spec: `specs/backend/spec_ota_sentinel_persistent_volume.md`

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)