### PR TITLE
Add --force / AQ_RENEW_AT override to trigger cert renewal on demand

### DIFF
--- a/aq_lib/renew.py
+++ b/aq_lib/renew.py
@@ -130,12 +130,16 @@ def _read_env(config_dir):
     return values
 
 
-def run_renewal(config_dir, *, now: dt.datetime = None, http_post=None):
+def run_renewal(config_dir, *, now: dt.datetime = None, http_post=None, renew_at=None):
     """On-device entrypoint: renew the installed cert using ``device.env`` config.
 
     Reads ``DEVICE_ID`` and the renew endpoint (``AQ_RENEW_ENDPOINT``, else the
     prod default) from ``config_dir/device.env`` and renews the installed cert in
     place. Returns the new cert PEM, or ``None`` if renewal was not yet due.
+
+    ``renew_at`` overrides the due-threshold fraction (``--force`` passes ``1.0``,
+    which makes every run due); when ``None`` it falls back to ``AQ_RENEW_AT`` in
+    device.env, then the default.
     """
     if now is None:
         now = dt.datetime.now(dt.timezone.utc)
@@ -144,19 +148,28 @@ def run_renewal(config_dir, *, now: dt.datetime = None, http_post=None):
     if not device_id:
         raise RenewalError(f"no DEVICE_ID in {config_dir}/{ENV_FILENAME}")
     endpoint = env.get("AQ_RENEW_ENDPOINT") or DEFAULT_RENEW_ENDPOINT
+    if renew_at is None:
+        renew_at = float(env["AQ_RENEW_AT"]) if env.get("AQ_RENEW_AT") else DEFAULT_RENEW_AT
 
     return renew_device_cert(
         endpoint, config_dir=config_dir, device_id=device_id,
-        now=now, http_post=http_post,
+        now=now, http_post=http_post, renew_at=renew_at,
     )
 
 
 def main(argv=None):  # pragma: no cover - thin container/systemd entrypoint
+    import argparse
     import sys
 
-    config_dir = (argv or sys.argv[1:] or ["/config"])[0]
+    p = argparse.ArgumentParser(description="Renew this device's Device Certificate.")
+    p.add_argument("config_dir", nargs="?", default="/config",
+                   help="config dir holding device.crt/key/env (default /config)")
+    p.add_argument("--force", action="store_true",
+                   help="renew now even if the cert is not yet due (for testing/ops)")
+    args = p.parse_args(sys.argv[1:] if argv is None else argv)
+
     try:
-        new_cert = run_renewal(config_dir)
+        new_cert = run_renewal(args.config_dir, renew_at=1.0 if args.force else None)
     except RenewalError as e:
         # Fail this run loudly so systemd records it; the next timer tick retries.
         # The installed cert is untouched, so the device keeps working until then.
@@ -165,7 +178,7 @@ def main(argv=None):  # pragma: no cover - thin container/systemd entrypoint
     if new_cert is None:
         print("certificate not yet due for renewal — no action")
     else:
-        print(f"renewed: installed new certificate at {config_dir}/{CERT_FILENAME}")
+        print(f"renewed: installed new certificate at {args.config_dir}/{CERT_FILENAME}")
     return 0
 
 

--- a/unit_tests/test_renew.py
+++ b/unit_tests/test_renew.py
@@ -283,3 +283,44 @@ class TestRunRenewal:
         assert post.seen["url"] == "https://renew.example/renew"
         assert result == post.seen["issued"]
         assert (config / "device.crt").read_bytes().decode() == post.seen["issued"]
+
+    def test_force_renews_a_cert_that_is_not_yet_due(self, tmp_path):
+        # Testing/ops override: with renew_at=1.0 (what --force maps to) a cert
+        # nowhere near expiry is renewed anyway, so a renewal can be triggered on
+        # demand instead of waiting until it naturally ages.
+        now = dt.datetime(2026, 7, 2, tzinfo=dt.timezone.utc)
+        config = tmp_path / "config"
+        fresh = make_cert_pem(
+            not_before=now - dt.timedelta(days=1),
+            not_after=now + dt.timedelta(days=13),   # ~13/14 left: normally NOT due
+        )
+        write_config(config, fresh)
+        (config / "device.env").write_text(
+            f"DEVICE_ID={DEVICE_ID}\nAQ_RENEW_ENDPOINT=https://renew.example/renew\n"
+        )
+        post = issuing_post(now)
+
+        result = run_renewal(str(config), now=now, http_post=post, renew_at=1.0)
+
+        assert result == post.seen["issued"]
+        assert (config / "device.crt").read_bytes().decode() == post.seen["issued"]
+
+    def test_reads_renew_at_override_from_device_env(self, tmp_path):
+        # AQ_RENEW_AT in device.env tunes the threshold without a code change;
+        # 1.0 makes every run due (the env equivalent of --force).
+        now = dt.datetime(2026, 7, 2, tzinfo=dt.timezone.utc)
+        config = tmp_path / "config"
+        write_config(config, make_cert_pem(
+            not_before=now - dt.timedelta(days=1),
+            not_after=now + dt.timedelta(days=13),
+        ))
+        (config / "device.env").write_text(
+            f"DEVICE_ID={DEVICE_ID}\n"
+            "AQ_RENEW_ENDPOINT=https://renew.example/renew\n"
+            "AQ_RENEW_AT=1.0\n"
+        )
+        post = issuing_post(now)
+
+        result = run_renewal(str(config), now=now, http_post=post)
+
+        assert result == post.seen["issued"]


### PR DESCRIPTION
Follow-up to #280. `renewal_due()` correctly no-ops until a cert is ~2/3 through its life, which makes the renewer awkward to test — on a freshly-enrolled device you'd wait ~10 days to see a real rotation. This adds an on-demand override.

## What this adds
- **`python -m aq_lib.renew --force /config`** — renews now regardless of due-ness (maps to `renew_at=1.0`).
- **`AQ_RENEW_AT`** in `device.env` — tunes the threshold without a code change; `1.0` is the env equivalent of `--force`.
- Precedence: explicit `renew_at` arg → `AQ_RENEW_AT` env → default (`1/3`).
- 2 unit tests (force path + env override); 107 unit tests pass.

## Heads-up: this rides the next image build
`--force` is code the container runs (`python -m aq_lib.renew`), so it only exists once a **new api image** is built with this change. The image published from #280 has the renewer but **not** `--force`.

**You do not need `--force` to prove rotation works today** — `renew_device_cert` already takes `renew_at`, so the non-destructive test (`renew_at=1.0` into a throwaway dir) works against the current published image. `--force` is the ergonomic way to trigger the same thing through the `systemctl`/timer path on a test device.

## Testing this override on a device (after the new image ships)
```bash
sudo docker run --rm -v /opt/aquila/config:/config \
  ghcr.io/${GHCR_REPO}-api:${IMAGE_TAG} python -m aq_lib.renew --force /config
sudo openssl x509 -in /opt/aquila/config/device.crt -noout -dates -serial   # notBefore advanced, new serial
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)