### PR TITLE
fix(deploy): make Phase 9 keypair/CSR generation idempotent (orphaned-cert bug)

### DIFF
--- a/scripts/deploy/deployment2.sh
+++ b/scripts/deploy/deployment2.sh
@@ -600,11 +600,22 @@ chmod +x /opt/fleet/update.sh
 # is later submitted to acorn-ca /enroll (#240). Runs in the app image, which
 # carries the crypto deps; the host does not. The container reads the same
 # /proc/cpuinfo serial, so its CN matches DEVICE_ID written above.
-docker run --rm \
-    -v /opt/aquila/config:/config \
-    -v /proc/cpuinfo:/proc/cpuinfo:ro \
-    "ghcr.io/${GHCR_REPO}-api:${IMAGE_TAG}" \
-    python -m aq_lib.device_csr /config
+#
+# IDEMPOTENT: only generate on first provisioning. Re-running deployment2.sh must
+# NOT regenerate the keypair — doing so overwrites device.key while the already
+# enrolled device.crt stays put, orphaning the cert (cert/key mismatch → mTLS,
+# Sync and renewal all break, requiring re-enrollment). If a key already exists,
+# keep it (and its matching cert). To intentionally re-key, delete device.key +
+# device.crt first, then re-run and re-enroll.
+if [[ -s /opt/aquila/config/device.key ]]; then
+    echo "  ℹ device.key already present — keeping existing keypair/CSR (not regenerating)."
+else
+    docker run --rm \
+        -v /opt/aquila/config:/config \
+        -v /proc/cpuinfo:/proc/cpuinfo:ro \
+        "ghcr.io/${GHCR_REPO}-api:${IMAGE_TAG}" \
+        python -m aq_lib.device_csr /config
+fi
 
 run_test "docker-compose.yml downloaded"   "test -f /opt/fleet/docker-compose.yml"
 run_test "compose file non-empty"          "test -s /opt/fleet/docker-compose.yml"
@@ -613,6 +624,10 @@ run_test "ui image pulled"                 "docker images | grep -q 'aquilla-mai
 run_test "update.sh exists and executable" "test -x /opt/fleet/update.sh"
 run_test "device CSR generated"            "test -s /opt/aquila/config/device.csr"
 run_test "device key owner-only (0600)"    "test \"\$(stat -c '%a' /opt/aquila/config/device.key)\" = 600"
+# If a cert is already installed (device previously enrolled), it MUST still match
+# the key — catches the orphaned-cert failure a non-idempotent keygen would cause.
+run_test "device cert/key match (if enrolled)" \
+    "! test -s /opt/aquila/config/device.crt || diff -q <(openssl x509 -in /opt/aquila/config/device.crt -noout -pubkey) <(openssl pkey -in /opt/aquila/config/device.key -pubout)"
 
 phase_pass "docker-compose.yml downloaded, all images pulled"
 


### PR DESCRIPTION
## The bug (observed live on sn03)

Re-running `deployment2.sh` on an **already-enrolled** device re-ran Phase 9, which **unconditionally regenerated the device keypair + CSR**, overwriting `device.key`. But `deployment2.sh` never enrolls, so `device.crt` stayed the previously-issued cert — now locked to a key that no longer exists.

Result: `device.crt` and `device.key` no longer match → mTLS fails with `KEY_VALUES_MISMATCH` → the device **cannot Sync or renew** until it is re-enrolled.

Evidence from sn03:
- `device.crt` mtime **Jun 30** (original enrollment), pubkey `cb6808…`
- `device.key` + `device.csr` mtime **Jul 1 13:38** (regenerated by a re-deploy), pubkey `dd65ae…`
- `curl` mTLS to `/renew` → `unable to set private key file … HTTP 000`

## The fix

- **Idempotent keygen:** guard the `python -m aq_lib.device_csr /config` run — skip if `device.key` already exists, so a re-run keeps the existing key (and its matching cert). First-time provisioning is unchanged.
- **Loud validation:** a new `run_test` fails the deploy if an installed `device.crt` and `device.key` are ever mismatched — catches the orphaned-cert state directly.

Verified: `bash -n` parses; simulated locally — matching pair passes, an orphaned cert is detected, and the guard skips regeneration when a key is present.

## Scope / follow-ups

- This **prevents** the problem going forward. It does **not** repair devices already in the mismatched state — those need re-enrollment (`./scripts/enroll.sh <sn>`). sn03 specifically needs re-enrolling.
- Reinforces that the cert-renewal timer (#280) should be delivered via `fleet-update.sh`, **not** by re-running `deployment2.sh` on live devices — this incident is exactly that hazard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)