### PR TITLE
chore(help): bump help.html version to 2.0.0.0

### DIFF
--- a/aquila_web/static/help.html
+++ b/aquila_web/static/help.html
@@ -278,7 +278,7 @@
 
         <!-- Footer -->
         <div class="help-footer" style="padding-bottom:16px;">
-          <span class="help-footer__meta" id="help-version-info">V 1.2.6.6</span>
+          <span class="help-footer__meta" id="help-version-info">V 2.0.0.0</span>
           <button class="help-exit-btn" onclick="notifyExitForce()">Exit GUI</button>
         </div>
 


### PR DESCRIPTION
Updates the version string in the help footer from `V 1.2.6.6` to `V 2.0.0.0` (`aquila_web/static/help.html:281`).

Note: this string is the **fallback** shown when `/button_status` returns no data. On a live device the footer script replaces it with `Firmware … · Device …`. If the version should persist regardless, that's a follow-up JS change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)