### PR TITLE
fix(ui): remove app-level cursor hiding so the mouse is visible in dev (#285)

### DIFF
--- a/aquila_web/static/complete.html
+++ b/aquila_web/static/complete.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=768, height=1024, initial-scale=1" />
   <title>Ready Screen</title>
-  <link rel="stylesheet" href="static/styles.css?v=235" />
+  <link rel="stylesheet" href="static/styles.css?v=237" />
 </head>
 <body class="app-body">
   <div class="app-shell">

--- a/aquila_web/static/help.html
+++ b/aquila_web/static/help.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=768, height=1024, initial-scale=1" />
   <title>Help</title>
-  <link rel="stylesheet" href="/static/styles.css?v=235" />
+  <link rel="stylesheet" href="/static/styles.css?v=237" />
   <link rel="stylesheet" href="/static/icon-colors.css?v=1" />
   <style>
     .help-sub {

--- a/aquila_web/static/history.html
+++ b/aquila_web/static/history.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=768, height=1024, initial-scale=1" />
   <title>Run History</title>
-  <link rel="stylesheet" href="static/styles.css?v=235" />
+  <link rel="stylesheet" href="static/styles.css?v=237" />
 </head>
 <body class="app-body">
   <div class="app-shell">

--- a/aquila_web/static/history_detail.html
+++ b/aquila_web/static/history_detail.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=768, height=1024, initial-scale=1" />
   <title>Run Detail</title>
-  <link rel="stylesheet" href="/static/styles.css?v=235" />
+  <link rel="stylesheet" href="/static/styles.css?v=237" />
 </head>
 <body class="app-body">
   <div class="app-shell">

--- a/aquila_web/static/index.html
+++ b/aquila_web/static/index.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=768, height=1024, initial-scale=1" />
   <title>Ready Screen</title>
-  <link rel="stylesheet" href="static/styles.css?v=233" />
+  <link rel="stylesheet" href="static/styles.css?v=237" />
 </head>
 <body class="app-body">
   <div class="screen">

--- a/aquila_web/static/login.html
+++ b/aquila_web/static/login.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=768, height=1024, initial-scale=1" />
   <title>Login</title>
-  <link rel="stylesheet" href="static/styles.css?v=233" />
+  <link rel="stylesheet" href="static/styles.css?v=237" />
 </head>
 <body class="app-body">
   <div class="login-shell">

--- a/aquila_web/static/profiles.html
+++ b/aquila_web/static/profiles.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=768, height=1024, initial-scale=1" />
   <title>Run Profiles</title>
-  <link rel="stylesheet" href="static/styles.css?v=233" />
+  <link rel="stylesheet" href="static/styles.css?v=237" />
 </head>
 <body class="app-body">
   <div class="app-shell">

--- a/aquila_web/static/profiles/builder.html
+++ b/aquila_web/static/profiles/builder.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=768, height=1024, initial-scale=1" />
   <title>Create Profile</title>
-  <link rel="stylesheet" href="/static/styles.css?v=235" />
+  <link rel="stylesheet" href="/static/styles.css?v=237" />
 </head>
 <body class="app-body">
   <div class="app-shell">

--- a/aquila_web/static/profiles/edit.html
+++ b/aquila_web/static/profiles/edit.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=768, height=1024, initial-scale=1" />
   <title>Edit Profile</title>
-  <link rel="stylesheet" href="/static/styles.css?v=233" />
+  <link rel="stylesheet" href="/static/styles.css?v=237" />
 </head>
 <body class="app-body">
   <div class="app-shell">

--- a/aquila_web/static/profiles/edit_form.html
+++ b/aquila_web/static/profiles/edit_form.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=768, height=1024, initial-scale=1" />
   <title>Edit Profile</title>
-  <link rel="stylesheet" href="/static/styles.css?v=235" />
+  <link rel="stylesheet" href="/static/styles.css?v=237" />
   <script>
     // Apply read-only before first paint so the editable editor never flashes
     // when a Legacy Profile opens via ?view=1 (issue #211). edit.js still runs

--- a/aquila_web/static/profiles/index.html
+++ b/aquila_web/static/profiles/index.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>Run Profiles</title>
-  <link rel="stylesheet" href="/static/styles.css?v=236" />
+  <link rel="stylesheet" href="/static/styles.css?v=237" />
 </head>
 <body class="app-body">
   <div class="app-shell">

--- a/aquila_web/static/ready.html
+++ b/aquila_web/static/ready.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=768, height=1024, initial-scale=1" />
   <title>Ready Screen</title>
-  <link rel="stylesheet" href="static/styles.css?v=233" />
+  <link rel="stylesheet" href="static/styles.css?v=237" />
 </head>
 <body class="app-body">
   <div class="app-shell">

--- a/aquila_web/static/run.html
+++ b/aquila_web/static/run.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=768, height=1024, initial-scale=1" />
   <title>Run</title>
-  <link rel="stylesheet" href="static/styles.css?v=235" />
+  <link rel="stylesheet" href="static/styles.css?v=237" />
 </head>
 <body class="app-body">
   <div class="app-shell">

--- a/aquila_web/static/settings.html
+++ b/aquila_web/static/settings.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=768, height=1024, initial-scale=1" />
   <title>Settings</title>
-  <link rel="stylesheet" href="/static/styles.css?v=235" />
+  <link rel="stylesheet" href="/static/styles.css?v=237" />
   <link rel="stylesheet" href="/static/icon-colors.css?v=1" />
   <style>
     .settings-sub {

--- a/aquila_web/static/splash.html
+++ b/aquila_web/static/splash.html
@@ -6,7 +6,6 @@
   <title>Aquila — Starting</title>
   <style>
     *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
-    * { cursor: none !important; }
 
     html, body {
       width: 100%; height: 100%;

--- a/aquila_web/static/styles.css
+++ b/aquila_web/static/styles.css
@@ -1,7 +1,7 @@
 @import url("icon-colors.css?v=1");
 
-/* Hide cursor in kiosk mode */
-* { cursor: none !important; }
+/* Do not hide the cursor in app CSS — the kiosk suppresses the pointer at the
+   X-server level (X -nocursor, PR #153). Hiding it here breaks dev (#285). */
 
 html,
 body {

--- a/specs/frontend/spec_dev_cursor_visible.md
+++ b/specs/frontend/spec_dev_cursor_visible.md
@@ -1,0 +1,112 @@
+# Frontend / UI Spec: Dev-Only Mouse Cursor Restore
+
+**Status:** Active
+**Author:** Jack Hu
+**Last updated:** 2026-07-01
+**GitHub issue:** #285
+**Affected screens:** All UI pages + boot splash
+**Source file(s):** `aquila_web/static/styles.css`, `aquila_web/static/splash.html`
+
+---
+
+## 1. Overview
+
+The kiosk cursor-removal work suppressed the pointer at two layers:
+
+1. **X-server level** (PR #153, `specs/hardware/mouse-cursor-removal.md`):
+   `xserver-command=X -nocursor` in the LightDM config plus an
+   `xsetroot -cursor_name none` backup, written by the deploy scripts. The pointer
+   sprite is never rendered on the device.
+2. **In-page CSS** (PR #126): `* { cursor: none !important; }` in
+   `aquila_web/static/styles.css` and inline in `splash.html`, added as
+   defence-in-depth before the X-server fix existed.
+
+Layer 2 applied to *any* browser rendering the pages — including the dev environment
+(backend run locally with `AQ_DEV_SIMULATE=1`, viewed in a desktop browser) — making
+the cursor invisible while developing.
+
+**Resolution: remove layer 2 entirely.** The cursor becomes visible in dev (with the
+correct contextual cursors — `pointer` on buttons, `not-allowed` on disabled controls —
+already defined in `styles.css`), and the device keeps hiding it via the X server.
+
+---
+
+## 2. Fleet Assumption (load-bearing)
+
+This change is safe **only because every deployed SENTRI has been provisioned with the
+wave-2 X-server fix** (confirmed by the maintainer, 2026-07-01). The CSS rule was those
+devices' only cursor suppression prior to that, since OTA container updates do not
+rewrite host-level LightDM config.
+
+Consequences:
+
+- Cursor hiding on the device is now **exclusively** X-server-level. The deploy scripts
+  self-test it (`run_test "cursor disabled (-nocursor)"`), which is the guard for
+  future/re-imaged units.
+- App CSS and pages must never reintroduce `cursor: none` — that is pinned by
+  `unit_tests/test_dev_cursor_static.py`.
+
+## 3. Change
+
+| File | Change |
+|------|--------|
+| `styles.css` | Removed `* { cursor: none !important; }`; comment documents why it must not return |
+| `splash.html` | Removed the identical inline rule |
+| All pages pinning `styles.css` | Cache-buster bumped to a uniform `?v=237` so cached copies of the old CSS are not served |
+
+An interim design (a `dev-cursor.js` shim toggling the rule via a `dev-cursor` class on
+`<html>`, keyed off `/button_status.dev_simulate`) was implemented and then removed in
+favour of this simpler rollback once the fleet assumption was confirmed. No trace of it
+remains; a regression test asserts that.
+
+Not changed: deploy scripts, X-server config, `xsetroot` backup, and the unrelated
+work bundled in PRs #125/#126 (Plymouth logo rotation, Chromium `--hide-scrollbars`).
+
+---
+
+## 4. Behaviour Matrix
+
+| Environment | Cursor |
+|---|---|
+| Physical SENTRI (provisioned with PR #153) | hidden — X server never renders the sprite |
+| Dev browser (`AQ_DEV_SIMULATE=1` or not) | visible, contextual (`pointer`, `not-allowed`, …) |
+| Mis-provisioned / pre-wave-2 device | **visible** — accepted risk; caught by deploy-script `run_test` |
+
+---
+
+## 5. Testing
+
+CI runs no pytest — verify locally: `pytest tests unit_tests -v`.
+
+**Unit seam (`unit_tests/test_dev_cursor_static.py`):**
+
+- [x] No shipped stylesheet sets `cursor: none`
+- [x] No HTML page (splash included) sets `cursor: none` inline
+- [x] The interim `dev-cursor.js` shim and all references to it are gone
+
+**Contract seam (`tests/contract/test_button_endpoints.py`):**
+
+- [x] `GET /button_status` includes boolean `dev_simulate` reflecting `AQ_DEV_SIMULATE`
+      (still used by `script.js` dev behavior; unrelated to cursor after the rollback)
+
+**Manual / hardware:**
+
+- [ ] Dev browser: cursor visible, `pointer` over buttons
+- [ ] Physical SENTRI: cursor absent (X-server `-nocursor`)
+
+---
+
+## 6. Acceptance Criteria
+
+- [ ] Cursor is visible on all UI pages in a desktop browser (dev)
+- [ ] Physical SENTRI shows no cursor (X-server layer, unchanged)
+- [ ] No app CSS/HTML reintroduces `cursor: none` (regression-tested)
+- [ ] Full suite passes locally: `pytest tests unit_tests -v`
+
+---
+
+## 7. Related
+
+- Original cursor removal (X-server layer): `specs/hardware/mouse-cursor-removal.md`
+- CSS rule origin: PR #126; X-server fix: issue #152 / PR #153
+- GitHub issue: #285

--- a/tests/contract/test_button_endpoints.py
+++ b/tests/contract/test_button_endpoints.py
@@ -157,6 +157,26 @@ def test_button_status_has_required_keys(client):
     assert not missing, f"Missing keys in /button_status: {missing}"
 
 
+@pytest.mark.contract
+def test_button_status_reports_dev_simulate_flag(client):
+    """GET /button_status exposes dev_simulate reflecting the AQ_DEV_SIMULATE flag.
+
+    Frontend dev-mode behavior (script.js) keys off this field, so it must
+    track the module flag in both states.
+    """
+    from aquila_web import main as web_main
+
+    original = web_main.DEV_SIMULATE
+    try:
+        web_main.DEV_SIMULATE = True
+        assert client.get("/button_status").json()["dev_simulate"] is True
+
+        web_main.DEV_SIMULATE = False
+        assert client.get("/button_status").json()["dev_simulate"] is False
+    finally:
+        web_main.DEV_SIMULATE = original
+
+
 # ---------------------------------------------------------------------------
 # Reset endpoints
 # ---------------------------------------------------------------------------

--- a/unit_tests/test_dev_cursor_static.py
+++ b/unit_tests/test_dev_cursor_static.py
@@ -1,0 +1,59 @@
+"""
+Unit tests: the app layer must never hide the mouse cursor (#285).
+
+Cursor hiding on the physical SENTRI is handled entirely at the X-server level
+(`xserver-command=X -nocursor`, PR #153 / specs/hardware/mouse-cursor-removal.md).
+The in-page CSS rule from PR #126 (`* { cursor: none !important; }`) was removed
+because it also hid the cursor in the dev environment; every fleet device has
+been provisioned with the X-server fix, so the CSS layer is redundant.
+
+These tests pin that invariant: no app CSS or page may reintroduce
+`cursor: none`, and the interim dev-cursor.js shim must stay gone.
+
+Spec: specs/frontend/spec_dev_cursor_visible.md
+"""
+import re
+from pathlib import Path
+
+STATIC_DIR = Path(__file__).parent.parent / "aquila_web" / "static"
+
+CURSOR_NONE_RE = re.compile(r"cursor\s*:\s*none")
+
+
+def test_app_stylesheets_never_hide_the_cursor():
+    """No shipped stylesheet may set cursor: none — device hiding is X-server-level."""
+    offenders = [
+        str(p.relative_to(STATIC_DIR))
+        for p in STATIC_DIR.rglob("*.css")
+        if CURSOR_NONE_RE.search(p.read_text(encoding="utf-8"))
+    ]
+    assert not offenders, (
+        f"stylesheets hide the cursor (breaks dev; device uses X -nocursor): {offenders}"
+    )
+
+
+def test_no_page_hides_the_cursor_inline():
+    """No HTML page (splash included) may set cursor: none in inline styles."""
+    offenders = [
+        str(p.relative_to(STATIC_DIR))
+        for p in STATIC_DIR.rglob("*.html")
+        if CURSOR_NONE_RE.search(p.read_text(encoding="utf-8"))
+    ]
+    assert not offenders, (
+        f"pages hide the cursor inline (breaks dev; device uses X -nocursor): {offenders}"
+    )
+
+
+def test_dev_cursor_shim_is_fully_removed():
+    """The interim dev-cursor.js shim and all references to it are gone.
+
+    It existed only to undo the CSS hiding rule in dev; with the rule removed
+    it is dead weight, and a stale <script> include would 404 on every page.
+    """
+    assert not (STATIC_DIR / "dev-cursor.js").exists(), "dev-cursor.js must be deleted"
+    referencing = [
+        str(p.relative_to(STATIC_DIR))
+        for p in STATIC_DIR.rglob("*.html")
+        if "dev-cursor.js" in p.read_text(encoding="utf-8")
+    ]
+    assert not referencing, f"pages still reference dev-cursor.js: {referencing}"


### PR DESCRIPTION
Closes #285

## Problem

The wave-1 CSS rule `* { cursor: none !important; }` (`styles.css:4` + inline in `splash.html`, from PR #126) hides the mouse cursor in **every** browser that renders the UI — including the dev environment — making the app painful to develop against.

## Why removal is safe

Device cursor suppression is handled entirely at the X-server level (`xserver-command=X -nocursor` + `xsetroot` backup, issue #152 / PR #153), and **all fleet devices have been provisioned with that fix** (maintainer-confirmed). The CSS layer was therefore redundant on devices while actively breaking dev. The deploy scripts self-test the X-server config (`run_test "cursor disabled (-nocursor)"`), which guards future/re-imaged units.

## Changes

- **`styles.css` / `splash.html`** — removed the cursor-hiding rules (the entire functional change: two CSS declarations); a comment in `styles.css` documents why they must not return
- **14 HTML pages** — stylesheet cache-buster bumped to a uniform `?v=237` so cached copies of the old CSS are refreshed (also fixes the pre-existing 235/236 divergence that failed `test_stylesheet_cache_buster_is_uniform_across_live_pages`)
- **`unit_tests/test_dev_cursor_static.py`** (new) — regression tests: no stylesheet or page may reintroduce `cursor: none`; the interim dev-cursor.js shim is fully gone
- **`tests/contract/test_button_endpoints.py`** — locks `/button_status.dev_simulate` (still consumed by `script.js`)
- **`specs/frontend/spec_dev_cursor_visible.md`** (new) — records the approach and the load-bearing fleet assumption

Untouched: deploy scripts, X-server config, and the unrelated work bundled in PRs #125/#126 (Plymouth logo rotation, `--hide-scrollbars`).

## Testing

- `pytest unit_tests/test_dev_cursor_static.py tests/contract/test_button_endpoints.py tests/contract/test_settings_nav.py` — 68 passed (CI runs no pytest; verified locally)
- Live-verified with `AQ_DEV_SIMULATE=1` on `:8090`: served CSS contains no cursor hiding; cursor visible in dev browser
- Physical-device check (cursor still absent via X `-nocursor`) recommended before merge

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)