### PR TITLE
feat(run): canonical shared run_timestamp on run_complete (#287)

### DIFF
--- a/aq_lib/state_requests.py
+++ b/aq_lib/state_requests.py
@@ -106,9 +106,16 @@ def advance_run_name():
     except requests.exceptions.RequestException as e:
         logger.exception("Error advancing run name: %s", e)
 
-def emit_run_complete(run_name: str, profile: str, results_path: str) -> None:
+def emit_run_complete(
+    run_name: str,
+    profile: str,
+    results_path: str,
+    run_timestamp: str | None = None,
+) -> None:
     url = f"{BACKEND_URL}/events/run_complete"
     payload = {"run_name": run_name, "profile": profile, "results_path": results_path}
+    if run_timestamp is not None:
+        payload["run_timestamp"] = run_timestamp
     try:
         requests.post(url, json=payload, timeout=5)
     except requests.exceptions.RequestException as e:

--- a/aquila_web/main.py
+++ b/aquila_web/main.py
@@ -1,6 +1,6 @@
 from fastapi import FastAPI, Form, Body, HTTPException, Query
 from aq_lib.device_id import inject_hw_serial_env
-from aquila_web.local_db import enqueue_event, init_local_db
+from aquila_web.local_db import enqueue_event, init_local_db, _utc_now
 from aquila_web.profile_assembly import assemble_steps, validate_stages
 from fastapi.responses import FileResponse, RedirectResponse, JSONResponse
 from fastapi.staticfiles import StaticFiles
@@ -606,6 +606,8 @@ async def _simulate_run(profile_name: str) -> None:
     run_in_progress = True
     run_complete_ack = False
     start_time = datetime.now()
+    # Canonical run_timestamp captured once at run start (#287).
+    run_timestamp = _utc_now()
     elapsed_time = 0
     timer_running = True
     current_item.screen = "running"
@@ -676,6 +678,7 @@ async def _simulate_run(profile_name: str) -> None:
             "run_name": run_name,
             "profile": profile_name,
             "result": detected_summary,
+            "run_timestamp": run_timestamp,
             "calls": _calls_from_file(results_file),
         },
     )
@@ -827,6 +830,7 @@ class _RunCompleteEventRequest(BaseModel):
     run_name: str
     profile: str
     results_path: Optional[str] = None
+    run_timestamp: Optional[str] = None
 
 
 @app.post("/events/run_complete")
@@ -834,12 +838,18 @@ async def events_run_complete(req: _RunCompleteEventRequest):
     init_local_db()
     results_file = Path(req.results_path) if req.results_path else None
     result = _summarize_results_from_file(results_file) if results_file else ""
+    # One canonical run_timestamp per Run (#287): the device supplies the value
+    # captured once at run start so run_complete and the forthcoming
+    # optics_readings event derive the same run_id cloud-side. Fall back to
+    # enqueue time only for legacy callers that don't send one.
+    run_timestamp = req.run_timestamp or _utc_now()
     event_id = enqueue_event(
         "run_complete",
         {
             "run_name": req.run_name,
             "profile": req.profile,
             "result": result,
+            "run_timestamp": run_timestamp,
             "calls": _calls_from_file(results_file) if results_file else [],
         },
     )

--- a/state_run_assay.py
+++ b/state_run_assay.py
@@ -11,6 +11,7 @@ import subprocess
 import requests as _requests
 import re
 import os
+from datetime import datetime
 from pathlib import Path
 
 from aq_lib.meerstetter import MeerStetter
@@ -171,7 +172,11 @@ class AssayInterface():
     def run( self ):
         #Run screen
         self._run_index += 1
-        logger.info("RUN START index=%d", self._run_index)
+        # One canonical run_timestamp per Run (#287), captured once at run start.
+        # Shared by run_complete and the forthcoming optics_readings event so the
+        # cloud derives the same run_id = uuid5(device_id : run_timestamp).
+        self.run_timestamp = datetime.utcnow().isoformat(timespec="seconds") + "Z"
+        logger.info("RUN START index=%d run_timestamp=%s", self._run_index, self.run_timestamp)
         sr.change_screen("2")
         time.sleep(1)
         sr.timer_control( status = "start" )
@@ -288,7 +293,10 @@ class AssayInterface():
                     logger.error("Failed to generate plot: %s", e)
                 profile_name = self.thermal_profile.replace("profiles/", "")
                 sr.log_history(profile_name, self.run_name, results_json, graph_path)
-                sr.emit_run_complete(self.run_name, profile_name, str(results_json))
+                sr.emit_run_complete(
+                    self.run_name, profile_name, str(results_json),
+                    run_timestamp=self.run_timestamp,
+                )
                 sr.advance_run_name()
                 sr.change_screen("3")
 

--- a/tests/unit/test_run_complete_event.py
+++ b/tests/unit/test_run_complete_event.py
@@ -66,6 +66,27 @@ class TestRunCompleteEndpoint:
         assert payload["run_name"] == "Run 2"
         assert payload["profile"] == "hotstart.json"
 
+    def test_payload_carries_supplied_run_timestamp(self, db_client):
+        client, local_db = db_client
+        client.post("/events/run_complete", json={
+            "run_name": "Run 1",
+            "profile": "basic_pcr.json",
+            "results_path": str(DETECTED_RESULTS),
+            "run_timestamp": "2026-07-02T14:03:11Z",
+        })
+        payload = local_db.get_pending_events()[0]["payload"]
+        assert payload["run_timestamp"] == "2026-07-02T14:03:11Z"
+
+    def test_payload_defaults_run_timestamp_when_omitted(self, db_client):
+        client, local_db = db_client
+        client.post("/events/run_complete", json={
+            "run_name": "Run 1",
+            "profile": "basic_pcr.json",
+            "results_path": str(DETECTED_RESULTS),
+        })
+        payload = local_db.get_pending_events()[0]["payload"]
+        assert payload.get("run_timestamp")
+
     def test_event_payload_includes_non_empty_result(self, db_client):
         client, local_db = db_client
         client.post("/events/run_complete", json={
@@ -99,3 +120,22 @@ class TestEmitRunComplete:
         assert calls[0]["json"]["run_name"] == "Run 1"
         assert calls[0]["json"]["profile"] == "basic_pcr.json"
         assert calls[0]["json"]["results_path"] == "/logs/results/run1.json"
+
+    def test_forwards_canonical_run_timestamp(self, monkeypatch):
+        import aq_lib.state_requests as sr
+
+        calls = []
+
+        class _FakeResponse:
+            status_code = 200
+
+        def fake_post(url, json=None, timeout=None):
+            calls.append({"url": url, "json": json})
+            return _FakeResponse()
+
+        monkeypatch.setattr("aq_lib.state_requests.requests.post", fake_post)
+        sr.emit_run_complete(
+            "Run 1", "basic_pcr.json", "/logs/results/run1.json",
+            run_timestamp="2026-07-02T14:03:11Z",
+        )
+        assert calls[0]["json"]["run_timestamp"] == "2026-07-02T14:03:11Z"


### PR DESCRIPTION
Closes #287.

## What

Set one canonical `run_timestamp` per Run, captured once at run start, and carry it on the `run_complete` event payload. Run identity no longer depends on enqueue-time `created_at`; the forthcoming `optics_readings` event can reuse the same value so the cloud derives a single `run_id = uuid5(device_id : run_timestamp)` per Run.

## Changes

- **`state_run_assay.run()`** — compute `self.run_timestamp` once at run start (ISO-8601 UTC), the canonical value for the whole Run.
- **`state_requests.emit_run_complete()`** — new optional `run_timestamp` arg, forwarded in the POST body.
- **`POST /events/run_complete`** — accept optional `run_timestamp`; default to `_utc_now()` only for legacy callers so existing flow/tests stay green.
- **`_simulate_run`** (dev path) — stamp `run_timestamp` on its directly-enqueued event too.

## Acceptance criteria

- [x] A single canonical `run_timestamp` is computed once per Run
- [x] `run_complete` payload carries `run_timestamp`
- [x] Existing `run_complete` flow and tests still pass

## Tests

Built TDD (red→green, one slice at a time). 3 new tests in `tests/unit/test_run_complete_event.py`:
- `emit_run_complete` forwards `run_timestamp`
- endpoint carries a supplied `run_timestamp`
- endpoint defaults `run_timestamp` when omitted (backward-compat)

All 7 `run_complete` tests pass. The device-layer capture in `state_run_assay.py` is hardware-coupled (`RPi.GPIO`) and not CI-testable; its behavior is verified at the `emit_run_complete` boundary.

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)
