### PR TITLE
feat(sync): size-aware Sync + size guard + chunk split (#289)

### DIFF
--- a/aquila_web/local_db.py
+++ b/aquila_web/local_db.py
@@ -115,6 +115,23 @@ def mark_event_quarantined(event_id: int, reason: str) -> None:
         )
 
 
+def requeue_quarantined_event(event_id: int) -> int:
+    """Clear an Event's quarantine so it re-enters the pending queue.
+
+    The recovery seam for the size guard: an event quarantined by a transient
+    misconfiguration (e.g. a too-tight cap) can be returned to the flush path
+    instead of being stuck forever short of manual SQL. Returns the number of
+    rows changed (0 if the event was not quarantined).
+    """
+    with _connect() as connection:
+        cursor = connection.execute(
+            "UPDATE events SET quarantined_at = NULL, quarantine_reason = NULL "
+            "WHERE id = ? AND quarantined_at IS NOT NULL",
+            (event_id,),
+        )
+        return int(cursor.rowcount or 0)
+
+
 def get_quarantined_events() -> list[dict[str, Any]]:
     """Quarantined Events, oldest first -- discoverable for diagnosis."""
     with _connect() as connection:

--- a/aquila_web/local_db.py
+++ b/aquila_web/local_db.py
@@ -42,6 +42,23 @@ def init_local_db() -> None:
             )
             """
         )
+        _add_missing_columns(connection)
+
+
+# Additive quarantine columns for the size guard (#289). Applied as ALTER TABLE
+# so an existing device DB upgrades in place without data loss; idempotent
+# because each column is only added when absent.
+_QUARANTINE_COLUMNS = {
+    "quarantined_at": "TEXT",
+    "quarantine_reason": "TEXT",
+}
+
+
+def _add_missing_columns(connection: sqlite3.Connection) -> None:
+    existing = {row["name"] for row in connection.execute("PRAGMA table_info(events)")}
+    for column, column_type in _QUARANTINE_COLUMNS.items():
+        if column not in existing:
+            connection.execute(f"ALTER TABLE events ADD COLUMN {column} {column_type}")
 
 
 def enqueue_event(event_type: str, payload: dict[str, Any], device_id: str | None = None) -> int:
@@ -63,7 +80,7 @@ def get_pending_events(limit: int = 100) -> list[dict[str, Any]]:
             """
             SELECT id, event_type, payload, device_id, created_at
             FROM events
-            WHERE synced_at IS NULL
+            WHERE synced_at IS NULL AND quarantined_at IS NULL
             ORDER BY id ASC
             LIMIT ?
             """,
@@ -82,6 +99,46 @@ def get_pending_events(limit: int = 100) -> list[dict[str, Any]]:
             }
         )
     return results
+
+
+def mark_event_quarantined(event_id: int, reason: str) -> None:
+    """Quarantine one Event that can't Sync even alone (the #289 size guard).
+
+    The row is retained -- never dropped or truncated -- but excluded from
+    :func:`get_pending_events` so it can't hold a batch slot or be re-fetched
+    every interval. ``reason`` records why for diagnosis.
+    """
+    with _connect() as connection:
+        connection.execute(
+            "UPDATE events SET quarantined_at = ?, quarantine_reason = ? WHERE id = ?",
+            (_utc_now(), reason, event_id),
+        )
+
+
+def get_quarantined_events() -> list[dict[str, Any]]:
+    """Quarantined Events, oldest first -- discoverable for diagnosis."""
+    with _connect() as connection:
+        rows = connection.execute(
+            """
+            SELECT id, event_type, payload, device_id, created_at,
+                   quarantined_at, quarantine_reason
+            FROM events
+            WHERE quarantined_at IS NOT NULL
+            ORDER BY id ASC
+            """
+        ).fetchall()
+    return [
+        {
+            "id": row["id"],
+            "event_type": row["event_type"],
+            "payload": json.loads(row["payload"]),
+            "device_id": row["device_id"],
+            "created_at": row["created_at"],
+            "quarantined_at": row["quarantined_at"],
+            "quarantine_reason": row["quarantine_reason"],
+        }
+        for row in rows
+    ]
 
 
 def mark_event_synced(event_ids: list[int]) -> None:

--- a/aquila_web/sync.py
+++ b/aquila_web/sync.py
@@ -1,12 +1,135 @@
+import base64
+import binascii
 import os
 import logging
 from typing import Any
 
 import requests
 
-from aquila_web.local_db import get_pending_events, mark_event_synced
+from aquila_web.local_db import (
+    get_pending_events,
+    mark_event_quarantined,
+    mark_event_synced,
+)
+from aquila_web.sync_batching import (
+    batch_events,
+    envelope_overhead_bytes,
+    event_size_bytes,
+    partition_oversized,
+    split_log,
+)
 
 logger = logging.getLogger(__name__)
+
+# SQS caps a single message at 256 KB; a batch that serializes past this is
+# silently rejected. Overridable for tuning/tests via AQ_SYNC_MAX_MESSAGE_BYTES.
+_SQS_MESSAGE_CEILING_BYTES = 256 * 1024
+
+# Slack subtracted from a chunk's raw budget to absorb base64 padding and the
+# extra digits chunk_index/chunk_count grow by as the chunk count climbs.
+_CHUNK_SIZING_MARGIN_BYTES = 16
+
+
+def _resolve_device_id() -> str | None:
+    return os.getenv("AQ_SYNC_DEVICE_ID") or os.getenv("DEVICE_ID")
+
+
+def _resolve_cert() -> tuple[str, str] | None:
+    # The Sentri authenticates Sync with its Device Certificate (mTLS), not the
+    # retired Fleet API Key (ADR-013). Cert/key paths are installed into
+    # device.env at enrollment (#240); present them for the TLS handshake.
+    client_cert = os.getenv("AQ_SYNC_CLIENT_CERT")
+    client_key = os.getenv("AQ_SYNC_CLIENT_KEY")
+    if client_cert and client_key:
+        return (client_cert, client_key)
+    return None
+
+
+def _resolve_max_message_bytes(device_id: str | None) -> int:
+    """The per-message byte cap, defaulting to the SQS ceiling.
+
+    A misconfigured ``AQ_SYNC_MAX_MESSAGE_BYTES`` (non-numeric, or too small to
+    hold even the envelope) falls back to the real ceiling with a warning --
+    never crashes the flush, and never drives the cap to a value that leaves no
+    room for any event and would quarantine the whole queue.
+    """
+    raw = os.getenv("AQ_SYNC_MAX_MESSAGE_BYTES")
+    if raw is None:
+        return _SQS_MESSAGE_CEILING_BYTES
+    try:
+        value = int(raw)
+    except ValueError:
+        logger.warning(
+            "AQ_SYNC_MAX_MESSAGE_BYTES=%r is not an integer; using %d",
+            raw, _SQS_MESSAGE_CEILING_BYTES,
+        )
+        return _SQS_MESSAGE_CEILING_BYTES
+    if value <= envelope_overhead_bytes(device_id):
+        logger.warning(
+            "AQ_SYNC_MAX_MESSAGE_BYTES=%d leaves no room for events; using %d",
+            value, _SQS_MESSAGE_CEILING_BYTES,
+        )
+        return _SQS_MESSAGE_CEILING_BYTES
+    return value
+
+
+def _chunk_event(event: dict, descriptor: dict) -> dict:
+    """One chunk Event: the source event with its payload's blob fields replaced
+    by this chunk's ``data_b64`` / ``chunk_index`` / ``chunk_count`` / ``sha256``."""
+    payload = {
+        **(event.get("payload") or {}),
+        "sha256": descriptor["sha256"],
+        "chunk_index": descriptor["chunk_index"],
+        "chunk_count": descriptor["chunk_count"],
+        "data_b64": descriptor["data_b64"],
+    }
+    return {**event, "payload": payload}
+
+
+def _chunk_events(event: dict, cap: int, device_id: str | None) -> list[dict] | None:
+    """Split one oversized Event into chunk Events, or ``None`` if unsplittable.
+
+    Only a gzipped optics log carries a blob (``data_b64`` + ``sha256``) that can
+    be sliced; anything else has nothing to chunk and must be quarantined instead.
+    Each raw slice is sized so its chunk Event fits in a POST alone; if even the
+    non-blob fields already fill a message, or any built chunk still overflows,
+    returns ``None`` so the caller quarantines rather than emit a bad POST.
+    """
+    payload = event.get("payload") or {}
+    data_b64 = payload.get("data_b64")
+    sha256 = payload.get("sha256")
+    if not data_b64 or not sha256:
+        return None
+    try:
+        blob = base64.b64decode(data_b64)
+    except (ValueError, binascii.Error):
+        return None
+
+    fits_alone = cap - envelope_overhead_bytes(device_id)
+    empty = _chunk_event(event, {"sha256": sha256, "chunk_index": 0, "chunk_count": 0, "data_b64": ""})
+    budget_for_b64 = fits_alone - event_size_bytes(empty) - _CHUNK_SIZING_MARGIN_BYTES
+    if budget_for_b64 < 4:
+        return None  # non-blob fields alone already fill a message
+    max_chunk_raw = (budget_for_b64 * 3) // 4
+    if max_chunk_raw < 1:
+        return None
+
+    chunks = [_chunk_event(event, d) for d in split_log(blob, sha256, max_chunk_raw)]
+    # Defence in depth: never emit a chunk that itself exceeds the ceiling.
+    if any(event_size_bytes(c) > fits_alone for c in chunks):
+        return None
+    return chunks
+
+
+def _post_batch(endpoint: str, body: dict[str, Any], cert, timeout: int) -> bool:
+    """POST one batch; True on success, False on network error (caller retries)."""
+    try:
+        response = requests.post(endpoint, json=body, cert=cert, timeout=timeout)
+        response.raise_for_status()
+        return True
+    except requests.exceptions.RequestException as exc:
+        logger.warning("Sync failed (will retry next interval): %s", exc)
+        return False
 
 
 def sync_pending_events(
@@ -19,29 +142,57 @@ def sync_pending_events(
         return 0
     resolved_batch_size = batch_size or int(os.getenv("AQ_SYNC_BATCH_SIZE", "100"))
     resolved_timeout = timeout_seconds or int(os.getenv("AQ_SYNC_TIMEOUT_SECONDS", "10"))
+    device_id = _resolve_device_id()
+    cap = _resolve_max_message_bytes(device_id)
+    cert = _resolve_cert()
+
     pending_events = get_pending_events(resolved_batch_size)
     if not pending_events:
         return 0
-    payload: dict[str, Any] = {
-        "device_id": os.getenv("AQ_SYNC_DEVICE_ID") or os.getenv("DEVICE_ID"),
-        "events": pending_events,
-    }
-    # The Sentri authenticates Sync with its Device Certificate (mTLS), not the
-    # retired Fleet API Key (ADR-013). Cert/key paths are installed into
-    # device.env at enrollment (#240); present them for the TLS handshake.
-    cert = None
-    client_cert = os.getenv("AQ_SYNC_CLIENT_CERT")
-    client_key = os.getenv("AQ_SYNC_CLIENT_KEY")
-    if client_cert and client_key:
-        cert = (client_cert, client_key)
-    try:
-        response = requests.post(
-            resolved_endpoint, json=payload, cert=cert, timeout=resolved_timeout
-        )
-        response.raise_for_status()
-    except requests.exceptions.RequestException as exc:
-        logger.warning("Sync failed (will retry next interval): %s", exc)
-        return 0
-    mark_event_synced([event["id"] for event in pending_events])
-    logger.info("Synced %s events", len(pending_events))
-    return len(pending_events)
+
+    syncable, oversized = partition_oversized(pending_events, cap, device_id)
+
+    # Size guard: an event too large to POST even alone is either split into
+    # chunk events (a gzipped optics log) or, if it has no blob to chunk,
+    # quarantined -- retained and logged loudly, never dropped or truncated, and
+    # never allowed to block the healthy events behind it.
+    split_groups: list[tuple[dict, list[dict]]] = []
+    for event in oversized:
+        chunks = _chunk_events(event, cap, device_id)
+        if chunks is None:
+            reason = f"event {event['id']} exceeds {cap} B and cannot be split"
+            logger.error("Sync size guard: quarantining %s", reason)
+            mark_event_quarantined(event["id"], reason)
+        else:
+            split_groups.append((event, chunks))
+
+    synced = 0
+
+    # Normal events: each byte-capped batch is one POST, marked synced on success.
+    for batch in batch_events(syncable, cap, device_id):
+        body: dict[str, Any] = {"device_id": device_id, "events": batch}
+        if not _post_batch(resolved_endpoint, body, cert, resolved_timeout):
+            # Batches already POSTed stay synced; the rest stay pending. Never
+            # lose or double-mark events.
+            return synced
+        mark_event_synced([event["id"] for event in batch])
+        synced += len(batch)
+
+    # Split events: POST every chunk before marking the source synced, so a
+    # mid-split network drop leaves the source pending to be re-split next flush
+    # rather than half-delivered-and-marked-done.
+    for source, chunks in split_groups:
+        delivered = True
+        for batch in batch_events(chunks, cap, device_id):
+            body = {"device_id": device_id, "events": batch}
+            if not _post_batch(resolved_endpoint, body, cert, resolved_timeout):
+                delivered = False
+                break
+        if not delivered:
+            return synced
+        mark_event_synced([source["id"]])
+        synced += 1
+
+    if synced:
+        logger.info("Synced %s events", synced)
+    return synced

--- a/aquila_web/sync.py
+++ b/aquila_web/sync.py
@@ -29,6 +29,11 @@ _SQS_MESSAGE_CEILING_BYTES = 256 * 1024
 # extra digits chunk_index/chunk_count grow by as the chunk count climbs.
 _CHUNK_SIZING_MARGIN_BYTES = 16
 
+# A configured cap must leave at least this much room beyond the envelope for a
+# real event; a cap barely above the envelope would mark every event oversized
+# and quarantine the whole queue, so such a value is rejected as misconfiguration.
+_MIN_EVENT_BUDGET_BYTES = 512
+
 
 def _resolve_device_id() -> str | None:
     return os.getenv("AQ_SYNC_DEVICE_ID") or os.getenv("DEVICE_ID")
@@ -49,9 +54,9 @@ def _resolve_max_message_bytes(device_id: str | None) -> int:
     """The per-message byte cap, defaulting to the SQS ceiling.
 
     A misconfigured ``AQ_SYNC_MAX_MESSAGE_BYTES`` (non-numeric, or too small to
-    hold even the envelope) falls back to the real ceiling with a warning --
-    never crashes the flush, and never drives the cap to a value that leaves no
-    room for any event and would quarantine the whole queue.
+    leave real room beyond the envelope) falls back to the real ceiling with a
+    warning -- never crashes the flush, and never honours a cap so tight that
+    every event is marked oversized and the whole queue is quarantined.
     """
     raw = os.getenv("AQ_SYNC_MAX_MESSAGE_BYTES")
     if raw is None:
@@ -64,10 +69,11 @@ def _resolve_max_message_bytes(device_id: str | None) -> int:
             raw, _SQS_MESSAGE_CEILING_BYTES,
         )
         return _SQS_MESSAGE_CEILING_BYTES
-    if value <= envelope_overhead_bytes(device_id):
+    minimum = envelope_overhead_bytes(device_id) + _MIN_EVENT_BUDGET_BYTES
+    if value < minimum:
         logger.warning(
-            "AQ_SYNC_MAX_MESSAGE_BYTES=%d leaves no room for events; using %d",
-            value, _SQS_MESSAGE_CEILING_BYTES,
+            "AQ_SYNC_MAX_MESSAGE_BYTES=%d leaves too little room (min %d); using %d",
+            value, minimum, _SQS_MESSAGE_CEILING_BYTES,
         )
         return _SQS_MESSAGE_CEILING_BYTES
     return value

--- a/aquila_web/sync_batching.py
+++ b/aquila_web/sync_batching.py
@@ -1,0 +1,110 @@
+"""
+Size-aware Sync batching (#289).
+
+Pure functions (no IO) that keep every Sync POST under the SQS 256 KB message
+ceiling, so a large optics_readings payload (#288) never gets a batch silently
+rejected. Three complementary defenses, none of which drops or truncates data:
+
+  * byte-capped batching  -- pack pending Events into batches each <= the cap;
+    a large event lands alone in its own POST.
+  * size guard            -- an event too large to fit even alone is partitioned
+    out (the caller quarantines it: left pending, logged loudly, never truncated).
+  * chunk split           -- split_log() slices an over-ceiling gzipped blob into
+    ordered chunks sharing one sha256 (reconstructs to the exact original bytes).
+
+Kept IO-free so the batching math is unit-testable without a DB or network.
+"""
+import base64
+import json
+
+# json.dumps puts ", " between array items by default: 2 bytes per gap. Counted
+# per gap while packing so a maximally-full batch can't serialize past the cap.
+_ITEM_SEPARATOR_BYTES = 2
+
+
+def event_size_bytes(event: dict) -> int:
+    """Bytes one Event contributes to the POST body: its JSON serialization."""
+    return len(json.dumps(event).encode("utf-8"))
+
+
+def envelope_overhead_bytes(device_id: str | None) -> int:
+    """Fixed cost of the ``{"device_id": ..., "events": []}`` POST wrapper.
+
+    Measured (not a guessed constant) and device-aware, so the batch cap
+    reserves exactly the real wrapper size — an event just under the ceiling
+    still fits instead of being needlessly quarantined.
+    """
+    return len(json.dumps({"device_id": device_id, "events": []}).encode("utf-8"))
+
+
+def batch_events(events: list[dict], cap: int, device_id: str | None) -> list[list[dict]]:
+    """Greedily pack Events into ordered batches each <= ``cap`` bytes serialized.
+
+    Reserves the measured envelope and the 2-byte item separator between events,
+    so every returned batch (wrapper + events) stays under the SQS ceiling. A
+    large event ends up alone in its own batch (its own POST). Assumes every
+    event individually fits under the cap -- oversized events must be removed
+    first via :func:`partition_oversized`, which the caller quarantines.
+    """
+    available = cap - envelope_overhead_bytes(device_id)
+    batches: list[list[dict]] = []
+    current: list[dict] = []
+    current_bytes = 0
+    for event in events:
+        size = event_size_bytes(event)
+        separator = _ITEM_SEPARATOR_BYTES if current else 0
+        if current and current_bytes + separator + size > available:
+            batches.append(current)
+            current = []
+            current_bytes = 0
+            separator = 0
+        current.append(event)
+        current_bytes += separator + size
+    if current:
+        batches.append(current)
+    return batches
+
+
+def partition_oversized(
+    events: list[dict], cap: int, device_id: str | None
+) -> tuple[list[dict], list[dict]]:
+    """Split events into ``(syncable, oversized)`` by the size guard.
+
+    An event is *oversized* when it cannot fit in a POST even alone (its own
+    serialization plus the envelope exceeds ``cap``). The caller quarantines
+    those -- never dropped or truncated -- so one poison event can't take the
+    whole flush hostage while healthy events keep syncing. Order is preserved
+    within each list.
+    """
+    fits_alone = cap - envelope_overhead_bytes(device_id)
+    syncable: list[dict] = []
+    oversized: list[dict] = []
+    for event in events:
+        (oversized if event_size_bytes(event) > fits_alone else syncable).append(event)
+    return syncable, oversized
+
+
+def split_log(blob: bytes, sha256: str, max_chunk_bytes: int) -> list[dict]:
+    """Slice a gzipped optics blob into ordered chunks that share one ``sha256``.
+
+    Each chunk carries at most ``max_chunk_bytes`` of the raw blob, base64-encoded
+    in ``data_b64``, tagged with ``chunk_index``/``chunk_count`` for ordering. All
+    chunks share the single ``sha256`` (of the logical file) so the cloud can
+    group and reassemble them; concatenating the decoded chunks in index order
+    reproduces the blob exactly -- never dropped or truncated. A blob within the
+    limit yields exactly one chunk. ``max_chunk_bytes`` bounds the *raw* slice;
+    the caller sizes it to leave room for base64 expansion and the event envelope.
+    """
+    if max_chunk_bytes < 1:
+        raise ValueError("max_chunk_bytes must be positive")
+    slices = [blob[i : i + max_chunk_bytes] for i in range(0, len(blob), max_chunk_bytes)] or [b""]
+    chunk_count = len(slices)
+    return [
+        {
+            "sha256": sha256,
+            "chunk_index": index,
+            "chunk_count": chunk_count,
+            "data_b64": base64.b64encode(piece).decode("ascii"),
+        }
+        for index, piece in enumerate(slices)
+    ]

--- a/tests/unit/test_background_sync.py
+++ b/tests/unit/test_background_sync.py
@@ -136,6 +136,7 @@ class TestMaxMessageBytesValidation:
         ("abc", CEILING),         # non-numeric -> fall back, don't crash int()
         ("0", CEILING),           # zero leaves no room -> fall back
         ("-100", CEILING),        # negative would invert the guard -> fall back
+        ("4096", 4096),           # a sane small cap is honoured
     ])
     def test_falls_back_to_ceiling_on_a_bad_value(self, monkeypatch, raw, expected):
         from aquila_web import sync
@@ -144,6 +145,16 @@ class TestMaxMessageBytesValidation:
         else:
             monkeypatch.setenv("AQ_SYNC_MAX_MESSAGE_BYTES", raw)
         assert sync._resolve_max_message_bytes("sentri-01") == expected
+
+    def test_cap_just_above_the_envelope_falls_back_instead_of_quarantining_all(self, monkeypatch):
+        # A cap only a few bytes above the envelope leaves near-zero room, so
+        # every event would be marked oversized and the whole queue quarantined.
+        # It must fall back to the ceiling, not be honoured.
+        from aquila_web import sync
+        from aquila_web.sync_batching import envelope_overhead_bytes
+        tiny = envelope_overhead_bytes("sentri-01") + 1
+        monkeypatch.setenv("AQ_SYNC_MAX_MESSAGE_BYTES", str(tiny))
+        assert sync._resolve_max_message_bytes("sentri-01") == self.CEILING
 
 
 class TestSizeAwareBatching:

--- a/tests/unit/test_background_sync.py
+++ b/tests/unit/test_background_sync.py
@@ -122,3 +122,171 @@ class TestSyncFlushEndpoint:
         assert response.json()["synced"] == 0
         # event must still be pending — not lost
         assert len(local_db.get_pending_events()) == 1
+
+
+class TestMaxMessageBytesValidation:
+    """AQ_SYNC_MAX_MESSAGE_BYTES is validated so a misconfigured value can't
+    crash the flush or drive the cap negative and mass-quarantine every event."""
+
+    CEILING = 256 * 1024
+
+    @pytest.mark.parametrize("raw, expected", [
+        (None, CEILING),          # unset -> the real SQS ceiling
+        ("131072", 131072),       # a valid override is honoured
+        ("abc", CEILING),         # non-numeric -> fall back, don't crash int()
+        ("0", CEILING),           # zero leaves no room -> fall back
+        ("-100", CEILING),        # negative would invert the guard -> fall back
+    ])
+    def test_falls_back_to_ceiling_on_a_bad_value(self, monkeypatch, raw, expected):
+        from aquila_web import sync
+        if raw is None:
+            monkeypatch.delenv("AQ_SYNC_MAX_MESSAGE_BYTES", raising=False)
+        else:
+            monkeypatch.setenv("AQ_SYNC_MAX_MESSAGE_BYTES", raw)
+        assert sync._resolve_max_message_bytes("sentri-01") == expected
+
+
+class TestSizeAwareBatching:
+    """Sync packs events into byte-capped batches under the SQS ceiling (#289)."""
+
+    def _capture_posts(self, monkeypatch):
+        bodies = []
+
+        class _OK:
+            status_code = 200
+            def raise_for_status(self): pass
+
+        def _post(url, json=None, **kw):
+            bodies.append(json)
+            return _OK()
+
+        monkeypatch.setattr("aquila_web.sync.requests.post", _post)
+        return bodies
+
+    def test_events_span_multiple_posts_each_under_the_byte_cap(self, db_client, tmp_path, monkeypatch):
+        import json as _json
+        client, local_db = db_client
+        # Five ~2 KB events with a small cap => several POSTs, not one.
+        for i in range(5):
+            local_db.enqueue_event("optics_readings", {"i": i, "pad": "x" * 2000})
+        monkeypatch.setenv("AQ_SYNC_ENDPOINT", "http://fake-aws/ingest")
+        monkeypatch.setenv("AQ_SYNC_DEVICE_ID", "sentri-01")
+        cap = 4096
+        monkeypatch.setenv("AQ_SYNC_MAX_MESSAGE_BYTES", str(cap))
+        bodies = self._capture_posts(monkeypatch)
+
+        response = client.post("/sync/flush")
+
+        assert response.json()["synced"] == 5
+        assert len(bodies) > 1  # did not cram everything into one oversized POST
+        for body in bodies:
+            assert len(_json.dumps(body).encode("utf-8")) <= cap
+        assert local_db.get_pending_events() == []  # all delivered
+
+    def test_oversized_unsplittable_event_is_quarantined_while_others_flush(self, db_client, tmp_path, monkeypatch):
+        client, local_db = db_client
+        healthy = local_db.enqueue_event("run_complete", {"ok": True})
+        # A run_complete with no gzip blob to chunk, too big to POST even alone.
+        poison = local_db.enqueue_event("run_complete", {"pad": "x" * 8000})
+        monkeypatch.setenv("AQ_SYNC_ENDPOINT", "http://fake-aws/ingest")
+        monkeypatch.setenv("AQ_SYNC_DEVICE_ID", "sentri-01")
+        monkeypatch.setenv("AQ_SYNC_MAX_MESSAGE_BYTES", "4096")
+        bodies = self._capture_posts(monkeypatch)
+
+        response = client.post("/sync/flush")
+
+        # Healthy event delivered; poison never POSTed.
+        assert response.json()["synced"] == 1
+        posted_ids = [e["id"] for b in bodies for e in b["events"]]
+        assert posted_ids == [healthy]
+        # Poison quarantined — retained, loud, out of the flush path (not dropped).
+        assert local_db.get_pending_events() == []
+        quarantined = local_db.get_quarantined_events()
+        assert [e["id"] for e in quarantined] == [poison]
+        assert quarantined[0]["quarantine_reason"]
+
+    def test_network_failure_on_a_later_batch_keeps_earlier_batches_synced(self, db_client, tmp_path, monkeypatch):
+        import requests as _requests
+        client, local_db = db_client
+        ids = [local_db.enqueue_event("optics_readings", {"i": i, "pad": "x" * 2000}) for i in range(5)]
+        monkeypatch.setenv("AQ_SYNC_ENDPOINT", "http://fake-aws/ingest")
+        monkeypatch.setenv("AQ_SYNC_DEVICE_ID", "sentri-01")
+        monkeypatch.setenv("AQ_SYNC_MAX_MESSAGE_BYTES", "4096")
+
+        calls = {"n": 0}
+        posted_ids: list[int] = []
+
+        class _OK:
+            status_code = 200
+            def raise_for_status(self): pass
+
+        def _post(url, json=None, **kw):
+            calls["n"] += 1
+            if calls["n"] == 2:  # second batch: network drops
+                raise _requests.exceptions.ConnectionError("offline")
+            posted_ids.extend(e["id"] for e in json["events"])
+            return _OK()
+
+        monkeypatch.setattr("aquila_web.sync.requests.post", _post)
+        response = client.post("/sync/flush")
+
+        # Only the first batch's events are marked synced; the rest stay pending.
+        synced = response.json()["synced"]
+        assert synced == len(posted_ids)
+        assert 0 < synced < 5
+        still_pending = [e["id"] for e in local_db.get_pending_events()]
+        assert sorted(posted_ids + still_pending) == sorted(ids)  # nothing lost or duplicated
+        assert set(posted_ids).isdisjoint(still_pending)
+
+    def test_oversized_optics_event_is_split_into_reassemblable_chunk_posts(self, db_client, tmp_path, monkeypatch):
+        import base64 as _b64
+        import gzip as _gzip
+        import hashlib as _hashlib
+        import json as _json
+        import os as _os
+
+        client, local_db = db_client
+        # A #288-shaped optics event whose gzipped blob dwarfs the cap.
+        raw = _os.urandom(30000)  # incompressible => stays large after gzip
+        blob = _gzip.compress(raw)
+        sha = _hashlib.sha256(raw).hexdigest()
+        source = local_db.enqueue_event("optics_readings", {
+            "run_timestamp": "2026-07-05T10:00:00Z",
+            "filename": "big.log",
+            "sha256": sha,
+            "raw_bytes": len(raw),
+            "line_count": 500,
+            "expected_lines": 500,
+            "complete": True,
+            "aborted": False,
+            "chunk_index": 0,
+            "chunk_count": 1,
+            "data_b64": _b64.b64encode(blob).decode("ascii"),
+        })
+        monkeypatch.setenv("AQ_SYNC_ENDPOINT", "http://fake-aws/ingest")
+        monkeypatch.setenv("AQ_SYNC_DEVICE_ID", "sentri-01")
+        cap = 4096
+        monkeypatch.setenv("AQ_SYNC_MAX_MESSAGE_BYTES", str(cap))
+        bodies = self._capture_posts(monkeypatch)
+
+        response = client.post("/sync/flush")
+
+        # The source event is accounted for and left neither pending nor quarantined.
+        assert response.json()["synced"] == 1
+        assert local_db.get_pending_events() == []
+        assert local_db.get_quarantined_events() == []
+
+        # Every POST is under the ceiling, and more than one was needed.
+        for body in bodies:
+            assert len(_json.dumps(body).encode("utf-8")) <= cap
+        chunks = [e["payload"] for b in bodies for e in b["events"]]
+        assert len(chunks) > 1
+        # All chunks share one sha256 with contiguous ordering...
+        assert {c["sha256"] for c in chunks} == {sha}
+        assert sorted(c["chunk_index"] for c in chunks) == list(range(len(chunks)))
+        assert all(c["chunk_count"] == len(chunks) for c in chunks)
+        # ...and reassemble to the exact original gzipped blob (no loss/truncation).
+        ordered = sorted(chunks, key=lambda c: c["chunk_index"])
+        reassembled = b"".join(_b64.b64decode(c["data_b64"]) for c in ordered)
+        assert reassembled == blob
+        assert _gzip.decompress(reassembled) == raw

--- a/tests/unit/test_local_db_quarantine.py
+++ b/tests/unit/test_local_db_quarantine.py
@@ -1,0 +1,69 @@
+"""
+Unit tests for the Event quarantine seam (#289).
+
+The size guard quarantines an Event too large to Sync even alone: it is left in
+the local queue (never dropped or truncated), excluded from the flush path so it
+can't take a batch slot or be re-fetched every interval, and kept discoverable
+for diagnosis. Additive, idempotent migration so existing device DBs upgrade in
+place without data loss.
+"""
+import pytest
+
+
+@pytest.fixture
+def local_db(tmp_path, monkeypatch):
+    monkeypatch.setenv("AQ_LOCAL_DB_PATH", str(tmp_path / "quarantine.db"))
+    from aquila_web import local_db as db
+    db.init_local_db()
+    return db
+
+
+def test_quarantined_event_is_excluded_from_pending_but_retained(local_db):
+    kept = local_db.enqueue_event("run_complete", {"ok": True})
+    poison = local_db.enqueue_event("optics_readings", {"line_count": 1})
+
+    local_db.mark_event_quarantined(poison, reason="exceeds SQS ceiling alone")
+
+    # Excluded from the flush path -- no batch slot, not re-fetched every interval.
+    assert [e["id"] for e in local_db.get_pending_events()] == [kept]
+    # Retained and discoverable -- fail loud, never silently dropped.
+    quarantined = local_db.get_quarantined_events()
+    assert [e["id"] for e in quarantined] == [poison]
+    assert quarantined[0]["quarantine_reason"] == "exceeds SQS ceiling alone"
+
+
+def test_migration_upgrades_a_pre_quarantine_db_without_data_loss(tmp_path, monkeypatch):
+    import sqlite3
+
+    db_path = tmp_path / "legacy.db"
+    monkeypatch.setenv("AQ_LOCAL_DB_PATH", str(db_path))
+    # A device DB created before #289: events table without quarantine columns.
+    with sqlite3.connect(db_path) as legacy:
+        legacy.execute(
+            """
+            CREATE TABLE events (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                event_type TEXT NOT NULL,
+                payload TEXT NOT NULL,
+                device_id TEXT,
+                created_at TEXT NOT NULL,
+                synced_at TEXT
+            )
+            """
+        )
+        legacy.execute(
+            "INSERT INTO events (event_type, payload, created_at) VALUES (?, ?, ?)",
+            ("run_complete", '{"ok": true}', "2026-01-01T00:00:00Z"),
+        )
+
+    from aquila_web import local_db as db
+    db.init_local_db()   # migrate in place
+    db.init_local_db()   # idempotent: running again must not error
+
+    # The pre-existing event survived the migration and is still pending...
+    pending = db.get_pending_events()
+    assert [e["event_type"] for e in pending] == ["run_complete"]
+    # ...and the new quarantine seam now works on the upgraded table.
+    db.mark_event_quarantined(pending[0]["id"], reason="legacy poison")
+    assert db.get_pending_events() == []
+    assert [e["quarantine_reason"] for e in db.get_quarantined_events()] == ["legacy poison"]

--- a/tests/unit/test_local_db_quarantine.py
+++ b/tests/unit/test_local_db_quarantine.py
@@ -32,6 +32,26 @@ def test_quarantined_event_is_excluded_from_pending_but_retained(local_db):
     assert quarantined[0]["quarantine_reason"] == "exceeds SQS ceiling alone"
 
 
+def test_requeue_returns_a_quarantined_event_to_the_pending_queue(local_db):
+    # A recovery seam so an event quarantined by transient misconfiguration is
+    # not stuck forever short of manual SQL.
+    event = local_db.enqueue_event("optics_readings", {"line_count": 1})
+    local_db.mark_event_quarantined(event, reason="cap misconfigured")
+    assert local_db.get_pending_events() == []
+
+    changed = local_db.requeue_quarantined_event(event)
+
+    assert changed == 1
+    assert [e["id"] for e in local_db.get_pending_events()] == [event]  # back in the queue
+    assert local_db.get_quarantined_events() == []                      # no longer quarantined
+
+
+def test_requeue_is_a_noop_for_an_event_that_is_not_quarantined(local_db):
+    event = local_db.enqueue_event("run_complete", {"ok": True})
+    assert local_db.requeue_quarantined_event(event) == 0     # nothing to clear
+    assert [e["id"] for e in local_db.get_pending_events()] == [event]
+
+
 def test_migration_upgrades_a_pre_quarantine_db_without_data_loss(tmp_path, monkeypatch):
     import sqlite3
 

--- a/tests/unit/test_sync_batching.py
+++ b/tests/unit/test_sync_batching.py
@@ -1,0 +1,144 @@
+"""
+Unit tests for size-aware Sync batching (#289).
+
+Pure logic (no IO): pack pending Events into byte-capped batches under the SQS
+256 KB ceiling, partition events too large to fit even alone, and split an
+over-ceiling gzipped optics log into ordered chunks sharing one sha256.
+
+Behaviors are asserted through the public interface of aquila_web.sync_batching
+so they survive internal refactors.
+"""
+import base64
+import json
+
+from aquila_web.sync_batching import (
+    batch_events,
+    envelope_overhead_bytes,
+    event_size_bytes,
+    partition_oversized,
+    split_log,
+)
+
+
+def _reassemble(chunks: list[dict]) -> bytes:
+    ordered = sorted(chunks, key=lambda c: c["chunk_index"])
+    return b"".join(base64.b64decode(c["data_b64"]) for c in ordered)
+
+
+def _event(event_id: int, payload: dict) -> dict:
+    return {
+        "id": event_id,
+        "event_type": "optics_readings",
+        "payload": payload,
+        "device_id": "sentri-01",
+        "created_at": "2026-07-05T10:00:00Z",
+    }
+
+
+class TestEventSizeBytes:
+    def test_measures_the_serialized_json_byte_length_of_one_event(self):
+        event = _event(1, {"line_count": 960})
+        # The event contributes exactly its JSON serialization to the POST body.
+        assert event_size_bytes(event) == len(json.dumps(event).encode("utf-8"))
+
+
+class TestEnvelopeOverheadBytes:
+    def test_measures_the_empty_wrapper_around_the_events_array(self):
+        # The POST body is {"device_id": ..., "events": [...]}; the wrapper's
+        # fixed cost must be reserved from the cap so a full batch + wrapper fits.
+        wrapper = {"device_id": "sentri-01", "events": []}
+        assert envelope_overhead_bytes("sentri-01") == len(
+            json.dumps(wrapper).encode("utf-8")
+        )
+
+    def test_is_device_aware(self):
+        # A longer device_id means a larger wrapper -> less room for events.
+        assert envelope_overhead_bytes("a-much-longer-device-id") > envelope_overhead_bytes("x")
+
+
+class TestBatchEvents:
+    def test_events_that_fit_pack_into_one_ordered_batch(self):
+        # Well under the cap: everything rides in a single POST, order preserved.
+        events = [_event(i, {"n": i}) for i in range(1, 6)]
+        batches = batch_events(events, cap=256 * 1024, device_id="sentri-01")
+        assert len(batches) == 1
+        assert [e["id"] for e in batches[0]] == [1, 2, 3, 4, 5]
+
+    def test_events_spill_into_multiple_ordered_batches_each_under_cap(self):
+        device = "sentri-01"
+        events = [_event(i, {"n": i}) for i in range(1, 7)]  # uniform size (1 digit)
+        per = event_size_bytes(events[0])
+        # Cap leaves room for ~2 events per batch beyond the wrapper.
+        cap = envelope_overhead_bytes(device) + 2 * per + 4
+        batches = batch_events(events, cap=cap, device_id=device)
+        assert len(batches) > 1
+        # Every batch, serialized as a real POST body, stays under the cap.
+        for batch in batches:
+            body = json.dumps({"device_id": device, "events": batch}).encode("utf-8")
+            assert len(body) <= cap
+        # No event is dropped or reordered across the spill.
+        assert [e["id"] for b in batches for e in b] == [1, 2, 3, 4, 5, 6]
+
+    def test_maximally_packed_batch_never_serializes_past_the_cap(self):
+        # Regression: json.dumps inserts a 2-byte ", " between array items. With
+        # many small events in one batch those separators add up; if they are not
+        # reserved, a full batch serializes past the SQS ceiling and SQS silently
+        # rejects the message. Every produced batch must fit as a real POST body.
+        device = "sentri-01"
+        cap = 256 * 1024
+        events = [_event(i, {"n": i, "pad": "x" * 100}) for i in range(2000)]
+        batches = batch_events(events, cap=cap, device_id=device)
+        assert len(batches) > 1  # enough events to fill more than one batch
+        for batch in batches:
+            body = json.dumps({"device_id": device, "events": batch}).encode("utf-8")
+            assert len(body) <= cap
+
+
+class TestPartitionOversized:
+    def test_event_too_large_to_fit_even_alone_is_separated_out(self):
+        device = "sentri-01"
+        cap = 1024
+        small = [_event(1, {"n": 1}), _event(2, {"n": 2})]
+        huge = _event(3, {"blob": "x" * 4000})  # exceeds cap even by itself
+        assert event_size_bytes(huge) + envelope_overhead_bytes(device) > cap
+
+        syncable, oversized = partition_oversized(small + [huge], cap=cap, device_id=device)
+
+        assert [e["id"] for e in syncable] == [1, 2]
+        assert [e["id"] for e in oversized] == [3]
+
+    def test_all_events_syncable_when_none_exceeds_the_cap(self):
+        device = "sentri-01"
+        events = [_event(i, {"n": i}) for i in range(1, 4)]
+        syncable, oversized = partition_oversized(events, cap=256 * 1024, device_id=device)
+        assert [e["id"] for e in syncable] == [1, 2, 3]
+        assert oversized == []
+
+
+class TestSplitLog:
+    SHA = "1c5e37c5e8207b2d5efa2f8a9a3b411914393853220a1d476d97890c0032b023"
+
+    def test_blob_within_the_limit_stays_a_single_chunk(self):
+        blob = b"gzipped-optics-bytes"
+        chunks = split_log(blob, sha256=self.SHA, max_chunk_bytes=1024)
+        assert len(chunks) == 1
+        assert chunks[0]["chunk_index"] == 0
+        assert chunks[0]["chunk_count"] == 1
+        assert chunks[0]["sha256"] == self.SHA
+        assert _reassemble(chunks) == blob
+
+    def test_over_limit_blob_splits_into_ordered_chunks_sharing_one_sha256(self):
+        blob = bytes(range(256)) * 40  # 10_240 bytes of varied content
+        max_chunk = 1000
+        chunks = split_log(blob, sha256=self.SHA, max_chunk_bytes=max_chunk)
+
+        assert len(chunks) == 11  # ceil(10240 / 1000)
+        # Contiguous, zero-based ordering and a consistent chunk_count.
+        assert [c["chunk_index"] for c in chunks] == list(range(11))
+        assert all(c["chunk_count"] == 11 for c in chunks)
+        # One sha256 shared across every chunk (the logical-file identity).
+        assert {c["sha256"] for c in chunks} == {self.SHA}
+        # No raw slice exceeds the limit.
+        assert all(len(base64.b64decode(c["data_b64"])) <= max_chunk for c in chunks)
+        # Reassembling the chunks in order reproduces the blob byte-for-byte.
+        assert _reassemble(chunks) == blob


### PR DESCRIPTION
Closes #289. Stacked on `feat/288-optics-readings-capture` (base #288) — re-point to `main` once #288 merges.

> Context: #289 was previously built and merged as #290, then reverted (#291) as an accidental merge. This is the deliberate TDD rebuild on top of #288's optics_readings capture.

## What & why

Makes Sync **size-aware** so a large `optics_readings` payload (#288, ~230 KB gzipped) never pushes a POST past the **SQS 256 KB message limit**, where it would be silently rejected. Three complementary defenses, none of which drops or truncates data:

| Mechanism | What it does |
|---|---|
| **Byte-capped batching** | Pack pending events into batches each ≤ the cap; one POST per batch. A large optics event lands **alone** in its own POST. Reserves the measured envelope + the 2-byte JSON item separator so a maximally-packed batch can't overflow. |
| **Size guard** | A single event that can't fit even alone is **quarantined** — retained in SQLite (additive, idempotent migration), excluded from the flush path, logged loudly, never truncated. Healthy events keep flowing. |
| **Chunk split** | `split_log()` slices an over-limit gzipped blob into ordered chunks sharing one `sha256`. **Wired at flush:** an oversized splittable optics event is split into chunk POSTs; the source is marked synced only after **every** chunk lands (a mid-split drop re-splits next flush rather than half-delivering). Dormant until a log exceeds 256 KB. |

## Changes

- **New** `aquila_web/sync_batching.py` — pure, no IO: `event_size_bytes`, `envelope_overhead_bytes`, `batch_events`, `partition_oversized`, `split_log`.
- `aquila_web/sync.py` — `sync_pending_events()` is now a per-batch POST loop: partition oversized → split-or-quarantine, byte-capped batches, mark-synced **per batch**, stop on network error so earlier batches stay synced and later ones stay pending. New validated `AQ_SYNC_MAX_MESSAGE_BYTES` knob. mTLS cert handling (ADR-013) unchanged.
- `aquila_web/local_db.py` — additive `quarantined_at`/`quarantine_reason` columns (idempotent ALTER migration; existing device DBs upgrade in place), `mark_event_quarantined`, `get_quarantined_events`; `get_pending_events` excludes quarantined rows.

## Acceptance criteria

- [x] An optics event is sent alone / in a byte-capped batch under the SQS limit
- [x] An oversized single event fails loudly (quarantined — no silent drop or truncation)
- [x] Above the inline limit, the log splits into ordered chunks sharing one `sha256`
- [x] Sync tests for batching, the size guard, and the split

## Testing

Built test-first (15 red→green cycles). **26 new tests, all green:**
- `tests/unit/test_sync_batching.py` — pure batching/split logic (incl. the separator-overflow regression)
- `tests/unit/test_local_db_quarantine.py` — quarantine seam + migration idempotency
- `tests/unit/test_background_sync.py` — flush: multi-batch, quarantine, partial-sync, split reconstruction, knob validation

Full non-e2e suite: **704 passed**. The 41 failures are pre-existing/environmental in untouched modules (`analysis/*` missing a `sample_run.log` fixture; `wifi_helpers` exhausted OS mocks) — none import `sync`/`sync_batching`/`local_db`.

## Reviewer notes

- **Split is wired at flush, dormant today.** Nothing currently exceeds 256 KB, so the split branch is exercised only by tests until a longer protocol lands. It relies on the cloud reassembling chunk events by `sha256` + `chunk_index` — #288's frozen payload already reserves those fields, but confirm `acorn-analytics` consumes multi-chunk events before relying on it in production.
- No spec doc added (the original #290 shipped `specs/backend/spec_size_aware_sync.md`); say the word if the team wants it recreated.

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)