### PR TITLE
fix(sync): fall back to the enrolled cert path when device.env lacks it

### DIFF
--- a/aquila_web/sync.py
+++ b/aquila_web/sync.py
@@ -47,6 +47,15 @@ def _resolve_cert() -> tuple[str, str] | None:
     client_key = os.getenv("AQ_SYNC_CLIENT_KEY")
     if client_cert and client_key:
         return (client_cert, client_key)
+    # Fallback: if device.env is missing the cert vars (e.g. an enrollment that
+    # predates #241, or a device.env rewrite that dropped them), present the cert
+    # from its standard enrolled location. Without this, Sync silently POSTs
+    # unauthenticated and the mTLS ingest edge resets the connection every flush.
+    config_dir = os.getenv("CONFIG_DIR", "/opt/aquila/config")
+    fallback_cert = os.path.join(config_dir, "device.crt")
+    fallback_key = os.path.join(config_dir, "device.key")
+    if os.path.exists(fallback_cert) and os.path.exists(fallback_key):
+        return (fallback_cert, fallback_key)
     return None
 
 

--- a/tests/unit/test_background_sync.py
+++ b/tests/unit/test_background_sync.py
@@ -82,6 +82,66 @@ class TestClientCertificate:
 
         assert "x-api-key" not in captured.get("headers", {})
 
+    def test_falls_back_to_enrolled_cert_when_env_vars_missing(self, db_client, tmp_path, monkeypatch):
+        # If device.env lacks AQ_SYNC_CLIENT_CERT/KEY (enrollment predating #241, or
+        # a device.env rewrite that dropped them), Sync must still present the cert
+        # from its standard enrolled location — not POST unauthenticated and get
+        # TLS-reset by the mTLS ingest edge.
+        client, local_db = db_client
+        _seed_event(local_db, tmp_path)
+        config_dir = tmp_path / "config"
+        config_dir.mkdir()
+        (config_dir / "device.crt").write_text("cert-pem")
+        (config_dir / "device.key").write_text("key-pem")
+        monkeypatch.setenv("AQ_SYNC_ENDPOINT", "http://fake-aws/ingest")
+        monkeypatch.delenv("AQ_SYNC_CLIENT_CERT", raising=False)
+        monkeypatch.delenv("AQ_SYNC_CLIENT_KEY", raising=False)
+        monkeypatch.setenv("CONFIG_DIR", str(config_dir))
+
+        captured = {}
+
+        class _OK:
+            status_code = 200
+            def raise_for_status(self): pass
+
+        def _capture(*a, **kw):
+            captured.update(kw)
+            return _OK()
+
+        monkeypatch.setattr("aquila_web.sync.requests.post", _capture)
+        client.post("/sync/flush")
+
+        assert captured["cert"] == (
+            str(config_dir / "device.crt"),
+            str(config_dir / "device.key"),
+        )
+
+    def test_no_cert_when_env_unset_and_no_enrolled_cert_on_disk(self, db_client, tmp_path, monkeypatch):
+        # With neither the env vars nor an on-disk cert, Sync presents no cert
+        # (cert=None) rather than crashing — the POST still fails at the mTLS edge,
+        # but the flush degrades gracefully.
+        client, local_db = db_client
+        _seed_event(local_db, tmp_path)
+        monkeypatch.setenv("AQ_SYNC_ENDPOINT", "http://fake-aws/ingest")
+        monkeypatch.delenv("AQ_SYNC_CLIENT_CERT", raising=False)
+        monkeypatch.delenv("AQ_SYNC_CLIENT_KEY", raising=False)
+        monkeypatch.setenv("CONFIG_DIR", str(tmp_path / "empty-config"))
+
+        captured = {}
+
+        class _OK:
+            status_code = 200
+            def raise_for_status(self): pass
+
+        def _capture(*a, **kw):
+            captured.update(kw)
+            return _OK()
+
+        monkeypatch.setattr("aquila_web.sync.requests.post", _capture)
+        client.post("/sync/flush")
+
+        assert captured["cert"] is None
+
 
 class TestSyncFlushEndpoint:
     """POST /sync/flush behaviour."""


### PR DESCRIPTION
## Problem

sn03 ran a test today: optics was captured and **queued** (`run_complete` + `optics_readings` sitting in the local SQLite queue), and the 15-min background sync **was** firing — but every flush failed:

```
POST /events/optics_readings 200 OK
Sync failed (will retry next interval): ('Connection aborted.', RemoteDisconnected('Remote end closed connection without response'))
```

Root cause: `_resolve_cert()` presents the Device Certificate **only if both `AQ_SYNC_CLIENT_CERT` and `AQ_SYNC_CLIENT_KEY` are set** in `device.env`. On sn03 those vars are absent (the enrollment that wrote `device.env` on July 1 predates #241, which is what makes `device_env_after_enroll` write them). So Sync POSTed to the **mTLS** ingest edge with **no client cert**, the edge reset the TLS connection, and nothing ever reached the cloud (the ingest Lambda hasn't been invoked since July 2).

Verified against the live prod endpoint:

```
POST without client cert → curl: (56) Connection reset by peer   (what Sync does today)
POST WITH device cert    → http=202 Accepted                     (what it should do)
```

## Fix

When the env vars are missing, fall back to the **standard enrolled location** `${CONFIG_DIR}/device.crt` + `device.key` (guarded by `os.path.exists`), so Sync presents the cert regardless of how `device.env` was written. Explicit env vars still take precedence and are used as-is (no existence check) — current behavior preserved.

This is intentionally robust to *which* path left `device.env` short (old enrollment, a rewrite, etc.) rather than depending on identifying it.

## Tests

`tests/unit/test_background_sync.py` — added:
- fallback presents the on-disk enrolled cert when env vars are unset;
- no cert (`None`, no crash) when neither env vars nor on-disk cert exist.

`python3 -m pytest tests/unit/test_background_sync.py` → **18 passed**.

## Follow-ups (not in this PR)

- **`deployment2.sh` latent clobber:** its `device.env` heredoc (line 336, `cat >`) omits `AQ_SYNC_CLIENT_CERT/KEY`, so re-running it on an enrolled device would wipe them. Worth adding the two vars to the heredoc (preserving existing values). Not confirmed as sn03's cause (mtimes point at enrollment, not a later `deployment2.sh` run), but a real hardening.
- **Ephemeral/unshared queue:** `/opt/aquila/data` (the SQLite queue) isn't a mounted volume in `fleet-config/docker-compose.yml`, so a Watchtower image swap wipes queued-but-unsynced events and splits the queue across `aquila-app`/`aquila-backend`. Separate robustness fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)