### PR TITLE
Device: emit the summary call_evidence event at Run completion (#297)

### DIFF
--- a/aq_curve/curve.py
+++ b/aq_curve/curve.py
@@ -11,6 +11,80 @@ from config import get_src_basedir
 
 logger = logging.getLogger("aquila")
 
+# Opaque algo_version stamped onto the call_evidence event (#297). Its real
+# derivation (the algo git-subtree sha vs a semantic tag) is deliberately
+# deferred to #298; for #297 we only need the field to be present and stable.
+ALGO_VERSION = "0.0.0-dev"
+
+_ROX_UNAVAILABLE = "ROX Unavailable"
+
+# ADR-017: the engine's internal verdicts ("detected"/"undetected"/
+# "inconclusive") must be mapped to the canonical Call vocabulary before they
+# leave the device. In particular "undetected" is NEVER emitted -> "Not Detected".
+_CANONICAL_CALL = {
+    "detected": "Detected",
+    "undetected": "Not Detected",
+    "inconclusive": "Inconclusive",
+}
+
+# Values that are already canonical pass through unchanged (idempotent).
+_CANONICAL_VALUES = frozenset(
+    {"Detected", "Not Detected", "Inconclusive", "ROX Unavailable"}
+)
+
+
+def canonical_call(status):
+    """Map an engine curve status to the canonical Call vocabulary (ADR-017).
+
+    ``evaluate_curve`` returns the raw engine status; the frozen call_evidence
+    contract (acorn-analytics#61) only accepts "Detected"/"Not Detected"/
+    "Inconclusive". Already-canonical values (incl. the ROX-Unavailable sentinel)
+    pass through unchanged, so this is safe to apply idempotently. Any *other*
+    engine status maps to "Inconclusive" — preserving the original resolve_status
+    catch-all (anything not detected/undetected is Inconclusive).
+    """
+    if status in _CANONICAL_CALL:
+        return _CANONICAL_CALL[status]
+    if status in _CANONICAL_VALUES:
+        return status
+    return "Inconclusive"
+
+
+def summarize_call_evidence(fam_status, rox_status, rox_raw_status, rox_unavailable):
+    """Build the summary call_evidence records for one Run (#297).
+
+    One record per EVALUATED Call (Well x Channel), each carrying both the
+    per-curve engine verdict (``raw_status``) and the final post-suppression
+    ``call``. All values are canonical (never "undetected").
+
+    - fam has no suppression step, so raw_status == call for every fam record.
+    - rox raw_status is the verdict *before* ROX suppression; ``call`` is the
+      final rox status. They diverge exactly where suppression fired (raw
+      "Detected" -> call "Not Detected").
+    - A ROX-Unavailable channel ran no curve, so it produces NO record and no
+      record is ever emitted whose call is "ROX Unavailable".
+    """
+    evidence = []
+    for well in sorted(fam_status):
+        call = fam_status[well]
+        evidence.append(
+            {"well": well, "channel": "fam", "raw_status": call, "call": call}
+        )
+    if not rox_unavailable:
+        for well in sorted(rox_status):
+            call = rox_status[well]
+            if call == _ROX_UNAVAILABLE:
+                continue
+            evidence.append(
+                {
+                    "well": well,
+                    "channel": "rox",
+                    "raw_status": rox_raw_status[well],
+                    "call": call,
+                }
+            )
+    return evidence
+
 
 class Curve:
     """
@@ -219,12 +293,9 @@ class Curve:
 
         def resolve_status(_, dye_name, well):
             evaluation = evaluate_curve(self, src, dye_name, well)
-            status = evaluation["status"]
-            if status == "detected":
-                return "Detected"
-            if status == "undetected":
-                return "Not Detected"
-            return "Inconclusive"
+            # ADR-017: canonicalize once here so the engine's "undetected" never
+            # escapes to either the results file or the call_evidence summary.
+            return canonical_call(evaluation["status"])
 
         def resolve_cq(dye_name, well):
             xdata, y_corrected, _ = get_curve_data(self, src, dye_name, well)
@@ -235,7 +306,6 @@ class Curve:
                 return None
             return round(float(cq), 2)
 
-        _ROX_UNAVAILABLE = "ROX Unavailable"
         _WELLS = [1, 2, 3, 4]
 
         fam_status = {w: resolve_status(0, "fam", w) for w in _WELLS}
@@ -244,9 +314,15 @@ class Curve:
         if rox_unavailable:
             rox_status = {w: _ROX_UNAVAILABLE for w in _WELLS}
             rox_cq = {w: None for w in _WELLS}
+            rox_raw_status = dict(rox_status)
         else:
             rox_status = {w: resolve_status(1, "rox", w) for w in _WELLS}
             rox_cq = {w: resolve_cq("rox", w) for w in _WELLS}
+
+            # Per-curve engine verdict captured BEFORE ROX suppression, so the
+            # call_evidence summary can report the raw_status the evaluator saw
+            # even where suppression later flips the final call (#297).
+            rox_raw_status = dict(rox_status)
 
             # FAM undetected + late ROX Cq → suppress ROX.
             # A late-rising ROX with no FAM signal is non-specific; treat as undetected.
@@ -265,6 +341,13 @@ class Curve:
                 "1": {str(w): fam_cq[w] for w in _WELLS},
                 "2": {str(w): rox_cq[w] for w in _WELLS},
             },
+            # Summary call_evidence records (#297): one per evaluated Call,
+            # carrying raw_status (pre-suppression) and the final call. The
+            # device-side emit reads this back off the results file, mirroring
+            # how run_complete derives its "calls".
+            "evidence": summarize_call_evidence(
+                fam_status, rox_status, rox_raw_status, rox_unavailable
+            ),
         }
 
         base_dir = Path(self.src_basedir).resolve()

--- a/aquila_web/main.py
+++ b/aquila_web/main.py
@@ -2,6 +2,7 @@ from fastapi import FastAPI, Form, Body, HTTPException, Query
 from aq_lib.device_id import inject_hw_serial_env
 from aquila_web.local_db import enqueue_event, init_local_db, _utc_now
 from aquila_web.optics_readings import build_optics_readings, count_data_lines
+from aq_curve.curve import ALGO_VERSION
 from aquila_web.profile_assembly import assemble_steps, validate_stages
 from fastapi.responses import FileResponse, RedirectResponse, JSONResponse
 from fastapi.staticfiles import StaticFiles
@@ -561,6 +562,45 @@ def _calls_from_file(path: Path) -> list[dict]:
     return calls
 
 
+def _evidence_from_file(path: Path) -> list[dict]:
+    """Read the summary call_evidence records the analysis wrote (#297).
+
+    ``Curve.results_to_json`` stamps one summary record per evaluated Call onto
+    the results file (raw_status + final call, ROX-Unavailable channels omitted).
+    The device emit reads them straight back rather than re-deriving them, so the
+    raw-vs-call divergence computed during suppression is preserved verbatim.
+    """
+    try:
+        with path.open() as f:
+            data = json.load(f)
+    except Exception:
+        return []
+    evidence = data.get("evidence")
+    return evidence if isinstance(evidence, list) else []
+
+
+def _emit_call_evidence(results_file: Path, run_timestamp: str) -> None:
+    """Enqueue the summary call_evidence event alongside run_complete (#297).
+
+    A separate event type sharing the Run's run_timestamp (as optics_readings
+    is separate from run_complete). Skipped when the Run evaluated no Calls, so
+    a run with no evidence enqueues no empty event (mirrors optics_readings).
+    """
+    evidence = _evidence_from_file(results_file) if results_file else []
+    if not evidence:
+        return
+    enqueue_event(
+        "call_evidence",
+        {
+            "run_timestamp": run_timestamp,
+            # #298 will derive algo_version from the algo subtree; a placeholder
+            # for now so the frozen contract field is always present.
+            "algo_version": ALGO_VERSION,
+            "evidence": evidence,
+        },
+    )
+
+
 def _plot_filename(profile_slug: str, run_slug: str) -> str:
     return f"{profile_slug}_{run_slug}.png"
 
@@ -691,6 +731,9 @@ async def _simulate_run(profile_name: str) -> None:
             "calls": _calls_from_file(results_file),
         },
     )
+
+    # Summary call_evidence rides alongside run_complete on the same run_id (#297).
+    _emit_call_evidence(results_file, run_timestamp)
 
     # Capture the exact optics file process_run() just consumed onto the same
     # outbox, sharing run_timestamp (#288). The simulated run consumes a complete
@@ -874,6 +917,8 @@ async def events_run_complete(req: _RunCompleteEventRequest):
             "calls": _calls_from_file(results_file) if results_file else [],
         },
     )
+    # Summary call_evidence rides alongside run_complete on the same run_id (#297).
+    _emit_call_evidence(results_file, run_timestamp)
     return {"ok": True, "event_id": event_id}
 
 

--- a/tests/unit/test_call_evidence.py
+++ b/tests/unit/test_call_evidence.py
@@ -1,0 +1,80 @@
+"""
+Unit tests for the summary call_evidence derivation (#297).
+
+Behaviors tested (pure logic — no hardware, no optics logs):
+  1. canonical_call maps the engine's "undetected" -> "Not Detected" (ADR-017)
+     and never lets "undetected" escape.
+  2. summarize_call_evidence emits one record per evaluated Call, with
+     raw_status == call for fam (no suppression runs on fam).
+  3. A ROX-suppressed Call shows a divergent raw_status ("Detected") vs
+     call ("Not Detected").
+  4. A ROX-Unavailable Run emits fam records only — no rox record, and never a
+     record whose call is "ROX Unavailable".
+"""
+import pytest
+
+from aq_curve.curve import canonical_call, summarize_call_evidence
+
+pytestmark = pytest.mark.unit
+
+
+class TestCanonicalCall:
+    def test_undetected_maps_to_not_detected(self):
+        # ADR-017: the engine's "undetected" must never be emitted.
+        assert canonical_call("undetected") == "Not Detected"
+
+    def test_detected_and_inconclusive_map_to_canonical(self):
+        assert canonical_call("detected") == "Detected"
+        assert canonical_call("inconclusive") == "Inconclusive"
+
+    def test_already_canonical_values_pass_through(self):
+        # Idempotent: safe to apply to values that are already canonical.
+        assert canonical_call("Not Detected") == "Not Detected"
+        assert canonical_call("ROX Unavailable") == "ROX Unavailable"
+
+
+class TestSummarizeCallEvidence:
+    def test_one_record_per_evaluated_call(self):
+        fam = {1: "Detected", 2: "Not Detected", 3: "Inconclusive", 4: "Not Detected"}
+        rox = {1: "Detected", 2: "Not Detected", 3: "Not Detected", 4: "Not Detected"}
+        evidence = summarize_call_evidence(fam, rox, dict(rox), rox_unavailable=False)
+        # 4 fam + 4 rox curves were evaluated -> 8 summary records.
+        assert len(evidence) == 8
+        assert {(r["well"], r["channel"]) for r in evidence} == {
+            (w, ch) for ch in ("fam", "rox") for w in (1, 2, 3, 4)
+        }
+        # Never emit the engine's internal "undetected".
+        assert all(r["raw_status"] != "undetected" for r in evidence)
+        assert all(r["call"] != "undetected" for r in evidence)
+
+    def test_fam_raw_status_equals_call(self):
+        # No suppression runs on fam, so raw_status and call always agree.
+        fam = {1: "Detected", 2: "Inconclusive", 3: "Not Detected", 4: "Not Detected"}
+        rox = {1: "Not Detected", 2: "Not Detected", 3: "Not Detected", 4: "Not Detected"}
+        evidence = summarize_call_evidence(fam, rox, dict(rox), rox_unavailable=False)
+        fam_records = [r for r in evidence if r["channel"] == "fam"]
+        assert all(r["raw_status"] == r["call"] for r in fam_records)
+        assert {r["well"]: r["call"] for r in fam_records} == fam
+
+    def test_rox_suppressed_call_diverges_from_raw_status(self):
+        # ROX suppression fired on well 1: the curve evaluated as Detected but the
+        # final call became Not Detected. Both must be captured.
+        fam = {1: "Not Detected", 2: "Not Detected", 3: "Not Detected", 4: "Not Detected"}
+        rox_raw = {1: "Detected", 2: "Not Detected", 3: "Not Detected", 4: "Not Detected"}
+        rox_final = {1: "Not Detected", 2: "Not Detected", 3: "Not Detected", 4: "Not Detected"}
+        evidence = summarize_call_evidence(fam, rox_final, rox_raw, rox_unavailable=False)
+        rox1 = next(r for r in evidence if r["channel"] == "rox" and r["well"] == 1)
+        assert rox1["raw_status"] == "Detected"
+        assert rox1["call"] == "Not Detected"
+        # An untouched rox curve keeps raw_status == call.
+        rox2 = next(r for r in evidence if r["channel"] == "rox" and r["well"] == 2)
+        assert rox2["raw_status"] == rox2["call"] == "Not Detected"
+
+    def test_rox_unavailable_emits_no_rox_record(self):
+        fam = {1: "Detected", 2: "Not Detected", 3: "Not Detected", 4: "Not Detected"}
+        rox = {1: "ROX Unavailable", 2: "ROX Unavailable", 3: "ROX Unavailable", 4: "ROX Unavailable"}
+        evidence = summarize_call_evidence(fam, rox, dict(rox), rox_unavailable=True)
+        assert {r["channel"] for r in evidence} == {"fam"}
+        assert len(evidence) == 4
+        # The ROX-Unavailable sentinel must never appear as a call.
+        assert all(r["call"] != "ROX Unavailable" for r in evidence)

--- a/tests/unit/test_call_evidence_event.py
+++ b/tests/unit/test_call_evidence_event.py
@@ -1,0 +1,165 @@
+"""
+Unit tests for the summary call_evidence event emission (#297).
+
+A call_evidence event is enqueued at Run completion ALONGSIDE run_complete (a
+separate event type, as optics_readings is separate from run_complete), sharing
+the Run's run_timestamp so both derive the same run_id cloud-side.
+
+Behaviors tested:
+  1. POST /events/run_complete enqueues a call_evidence event carrying the
+     summary evidence records the analysis wrote to the results file.
+  2. call_evidence.run_timestamp matches the run_complete run_timestamp.
+  3. call_evidence carries an algo_version.
+  4. A ROX-Unavailable results file yields fam-only evidence (no rox record).
+"""
+import json
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock
+
+# serial is hardware-only; stub so aq_lib.state_requests imports without a device.
+for _hw_mod in ("serial", "serial.tools", "serial.tools.list_ports"):
+    sys.modules.setdefault(_hw_mod, MagicMock())
+sys.modules.setdefault("aq_lib.config_module", MagicMock())
+
+import pytest
+from fastapi.testclient import TestClient
+
+pytestmark = pytest.mark.unit
+
+
+# A results file exactly as Curve.results_to_json writes it: the "evidence" block
+# holds the summary records, including a rox curve (well 1) whose engine verdict
+# was Detected but whose final call was suppressed to Not Detected.
+_RESULTS_WITH_EVIDENCE = {
+    "1": {"1": "Detected", "2": "Not Detected", "3": "Not Detected", "4": "Not Detected"},
+    "2": {"1": "Not Detected", "2": "Not Detected", "3": "Not Detected", "4": "Not Detected"},
+    "cq": {"1": {"1": 22.5, "2": None, "3": None, "4": None},
+           "2": {"1": None, "2": None, "3": None, "4": None}},
+    "evidence": [
+        {"well": 1, "channel": "fam", "raw_status": "Detected", "call": "Detected"},
+        {"well": 2, "channel": "fam", "raw_status": "Not Detected", "call": "Not Detected"},
+        {"well": 3, "channel": "fam", "raw_status": "Not Detected", "call": "Not Detected"},
+        {"well": 4, "channel": "fam", "raw_status": "Not Detected", "call": "Not Detected"},
+        {"well": 1, "channel": "rox", "raw_status": "Detected", "call": "Not Detected"},
+        {"well": 2, "channel": "rox", "raw_status": "Not Detected", "call": "Not Detected"},
+        {"well": 3, "channel": "rox", "raw_status": "Not Detected", "call": "Not Detected"},
+        {"well": 4, "channel": "rox", "raw_status": "Not Detected", "call": "Not Detected"},
+    ],
+}
+
+# A ROX-Unavailable run: only the fam channel ran a curve.
+_RESULTS_ROX_UNAVAILABLE = {
+    "1": {"1": "Detected", "2": "Not Detected", "3": "Not Detected", "4": "Not Detected"},
+    "2": {"1": "ROX Unavailable", "2": "ROX Unavailable", "3": "ROX Unavailable", "4": "ROX Unavailable"},
+    "cq": {"1": {"1": 22.5, "2": None, "3": None, "4": None},
+           "2": {"1": None, "2": None, "3": None, "4": None}},
+    "evidence": [
+        {"well": 1, "channel": "fam", "raw_status": "Detected", "call": "Detected"},
+        {"well": 2, "channel": "fam", "raw_status": "Not Detected", "call": "Not Detected"},
+        {"well": 3, "channel": "fam", "raw_status": "Not Detected", "call": "Not Detected"},
+        {"well": 4, "channel": "fam", "raw_status": "Not Detected", "call": "Not Detected"},
+    ],
+}
+
+
+@pytest.fixture
+def db_client(tmp_path, monkeypatch):
+    """TestClient backed by an isolated, temporary SQLite DB."""
+    monkeypatch.setenv("AQ_LOCAL_DB_PATH", str(tmp_path / "test_events.db"))
+    from aquila_web import local_db, main as web_main
+    local_db.init_local_db()
+    with TestClient(web_main.app) as c:
+        yield c, local_db
+
+
+def _write_results(tmp_path, data) -> Path:
+    path = tmp_path / "results.json"
+    path.write_text(json.dumps(data))
+    return path
+
+
+def _events_of_type(local_db, event_type):
+    return [e for e in local_db.get_pending_events() if e["event_type"] == event_type]
+
+
+class TestCallEvidenceEmission:
+    def test_run_completion_enqueues_a_call_evidence_event(self, db_client, tmp_path):
+        client, local_db = db_client
+        results = _write_results(tmp_path, _RESULTS_WITH_EVIDENCE)
+        client.post("/events/run_complete", json={
+            "run_name": "Run 1",
+            "profile": "basic_pcr.json",
+            "results_path": str(results),
+        })
+        call_evidence = _events_of_type(local_db, "call_evidence")
+        assert len(call_evidence) == 1
+        payload = call_evidence[0]["payload"]
+        # One summary record per evaluated Call (4 fam + 4 rox).
+        assert len(payload["evidence"]) == 8
+        assert all(r["call"] != "undetected" for r in payload["evidence"])
+
+    def test_call_evidence_captures_rox_suppression_divergence(self, db_client, tmp_path):
+        client, local_db = db_client
+        results = _write_results(tmp_path, _RESULTS_WITH_EVIDENCE)
+        client.post("/events/run_complete", json={
+            "run_name": "Run 1",
+            "profile": "basic_pcr.json",
+            "results_path": str(results),
+        })
+        payload = _events_of_type(local_db, "call_evidence")[0]["payload"]
+        rox1 = next(r for r in payload["evidence"]
+                    if r["channel"] == "rox" and r["well"] == 1)
+        assert rox1["raw_status"] == "Detected"
+        assert rox1["call"] == "Not Detected"
+
+    def test_call_evidence_run_timestamp_matches_run_complete(self, db_client, tmp_path):
+        client, local_db = db_client
+        results = _write_results(tmp_path, _RESULTS_WITH_EVIDENCE)
+        client.post("/events/run_complete", json={
+            "run_name": "Run 1",
+            "profile": "basic_pcr.json",
+            "results_path": str(results),
+            "run_timestamp": "2026-07-02T14:03:11Z",
+        })
+        run_complete = _events_of_type(local_db, "run_complete")[0]["payload"]
+        call_evidence = _events_of_type(local_db, "call_evidence")[0]["payload"]
+        assert call_evidence["run_timestamp"] == run_complete["run_timestamp"]
+        assert call_evidence["run_timestamp"] == "2026-07-02T14:03:11Z"
+
+    def test_call_evidence_carries_algo_version(self, db_client, tmp_path):
+        client, local_db = db_client
+        results = _write_results(tmp_path, _RESULTS_WITH_EVIDENCE)
+        client.post("/events/run_complete", json={
+            "run_name": "Run 1",
+            "profile": "basic_pcr.json",
+            "results_path": str(results),
+        })
+        payload = _events_of_type(local_db, "call_evidence")[0]["payload"]
+        assert payload.get("algo_version")
+
+    def test_rox_unavailable_run_emits_fam_only_evidence(self, db_client, tmp_path):
+        client, local_db = db_client
+        results = _write_results(tmp_path, _RESULTS_ROX_UNAVAILABLE)
+        client.post("/events/run_complete", json={
+            "run_name": "Run 1",
+            "profile": "basic_pcr.json",
+            "results_path": str(results),
+        })
+        payload = _events_of_type(local_db, "call_evidence")[0]["payload"]
+        assert {r["channel"] for r in payload["evidence"]} == {"fam"}
+        assert all(r["call"] != "ROX Unavailable" for r in payload["evidence"])
+
+    def test_results_without_evidence_enqueues_no_call_evidence(self, db_client, tmp_path):
+        # A legacy results file with no evidence block must not enqueue an empty
+        # call_evidence event (mirrors optics_readings skipping an empty capture).
+        client, local_db = db_client
+        legacy = {"1": {"1": "Detected"}, "2": {"1": "Not Detected"}}
+        results = _write_results(tmp_path, legacy)
+        client.post("/events/run_complete", json={
+            "run_name": "Run 1",
+            "profile": "basic_pcr.json",
+            "results_path": str(results),
+        })
+        assert _events_of_type(local_db, "run_complete")  # run_complete still emitted
+        assert _events_of_type(local_db, "call_evidence") == []


### PR DESCRIPTION
Closes #297. The device track of Call Evidence (see acorn-analytics ADR-0008 + the frozen contract acorn-analytics#61).

## What it does
At Run completion the Sentri enqueues a **separate `call_evidence` event** alongside `run_complete` (mirroring `optics_readings`), one **summary** record per evaluated Call (Well × Channel):
- `raw_status` — the engine verdict, canonicalized (`undetected → Not Detected`, ADR-017; the engine word never escapes).
- `call` — the final Call after ROX suppression.
- A `ROX Unavailable` Channel ran no curve → **no record** (coverage rule).
- Shares the `run_complete` `run_timestamp` so it derives the same `run_id`.

## How
- **`aq_curve/curve.py`**: extracted `canonical_call()` (idempotent; an unknown engine status maps to `Inconclusive`, preserving the original `resolve_status` catch-all); snapshot rox status *before* the FAM-undetected/late-ROX suppression loop so the `raw_status` vs `call` divergence is captured; `summarize_call_evidence()` builds the records; `results_to_json` writes an `evidence` block.
- **`aquila_web/main.py`**: emit the event alongside `run_complete` (both the `/events/run_complete` endpoint and the simulate path); skip when evidence is empty.
- `algo_version` is a placeholder constant — its derivation (subtree sha vs semantic tag) is deferred to **#298**.

Summary-only by design: `decision_reason` / `flags` / `metrics` arrive in #298/#299 (the frozen contract makes them optional).

## Testing
`test_call_evidence.py` (pure: canonical mapping, one record per call, fam raw==call, **rox-suppression divergence**, ROX-Unavailable → fam-only) and `test_call_evidence_event.py` (enqueue at run completion, `run_timestamp` match, divergence preserved end-to-end, empty→no event). Relevant suites green (curve analysis, results_to_json, run_complete, sync). Built test-first; one catch-all regression found and fixed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)