### PR TITLE
Device: evaluate_curve — emit all Metrics, Checks, flags + Decision Reason (#298, #299)

### DIFF
--- a/aq_curve/curve.py
+++ b/aq_curve/curve.py
@@ -51,7 +51,8 @@ def canonical_call(status):
 
 
 def summarize_call_evidence(
-    fam_status, rox_status, rox_raw_status, rox_unavailable, metrics_by_curve=None
+    fam_status, rox_status, rox_raw_status, rox_unavailable,
+    metrics_by_curve=None, decision_by_curve=None,
 ):
     """Build the summary call_evidence records for one Run (#297).
 
@@ -74,6 +75,10 @@ def summarize_call_evidence(
         rec = {"well": well, "channel": channel, "raw_status": raw_status, "call": call}
         if metrics_by_curve is not None:
             rec["metrics"] = metrics_by_curve.get((channel, well), [])
+        if decision_by_curve is not None:
+            detail = decision_by_curve.get((channel, well), {})
+            rec["decision_reason"] = detail.get("decision_reason")
+            rec["flags"] = detail.get("flags", {})
         return rec
 
     evidence = []
@@ -298,10 +303,17 @@ class Curve:
         # come straight from evaluate_curve — each Check emits the value it computed —
         # so the emitted numbers are exactly what the engine saw (no recomputation).
         evidence_metrics = {}
+        # Derived decision layer per curve (#299): the flags + the cascade branch
+        # (Decision Reason) evaluate_curve produced. Explains *why* each Call came out.
+        evidence_decision = {}
 
         def resolve_status(_, dye_name, well):
             evaluation = evaluate_curve(self, src, dye_name, well)
             evidence_metrics[(dye_name, well)] = evaluation.get("metrics", [])
+            evidence_decision[(dye_name, well)] = {
+                "decision_reason": evaluation.get("decision_reason"),
+                "flags": evaluation.get("flags", {}),
+            }
             # ADR-017: canonicalize once here so the engine's "undetected" never
             # escapes to either the results file or the call_evidence summary.
             return canonical_call(evaluation["status"])
@@ -357,6 +369,7 @@ class Curve:
             "evidence": summarize_call_evidence(
                 fam_status, rox_status, rox_raw_status, rox_unavailable,
                 metrics_by_curve=evidence_metrics,
+                decision_by_curve=evidence_decision,
             ),
         }
 

--- a/aq_curve/curve.py
+++ b/aq_curve/curve.py
@@ -50,7 +50,9 @@ def canonical_call(status):
     return "Inconclusive"
 
 
-def summarize_call_evidence(fam_status, rox_status, rox_raw_status, rox_unavailable):
+def summarize_call_evidence(
+    fam_status, rox_status, rox_raw_status, rox_unavailable, metrics_by_curve=None
+):
     """Build the summary call_evidence records for one Run (#297).
 
     One record per EVALUATED Call (Well x Channel), each carrying both the
@@ -63,26 +65,27 @@ def summarize_call_evidence(fam_status, rox_status, rox_raw_status, rox_unavaila
       "Detected" -> call "Not Detected").
     - A ROX-Unavailable channel ran no curve, so it produces NO record and no
       record is ever emitted whose call is "ROX Unavailable".
+
+    When ``metrics_by_curve`` (a ``{(channel, well): [metric rows]}`` map) is
+    given, each record gains a ``metrics`` list — the Checks and Metric values for
+    that Call (#298). Omitting it leaves records metric-free (the #297 shape).
     """
+    def _record(well, channel, raw_status, call):
+        rec = {"well": well, "channel": channel, "raw_status": raw_status, "call": call}
+        if metrics_by_curve is not None:
+            rec["metrics"] = metrics_by_curve.get((channel, well), [])
+        return rec
+
     evidence = []
     for well in sorted(fam_status):
         call = fam_status[well]
-        evidence.append(
-            {"well": well, "channel": "fam", "raw_status": call, "call": call}
-        )
+        evidence.append(_record(well, "fam", call, call))
     if not rox_unavailable:
         for well in sorted(rox_status):
             call = rox_status[well]
             if call == _ROX_UNAVAILABLE:
                 continue
-            evidence.append(
-                {
-                    "well": well,
-                    "channel": "rox",
-                    "raw_status": rox_raw_status[well],
-                    "call": call,
-                }
-            )
+            evidence.append(_record(well, "rox", rox_raw_status[well], call))
     return evidence
 
 
@@ -291,8 +294,14 @@ class Curve:
         #         return "Not Detected"
         #     return "Inconclusive"
 
+        # Per-curve Metric/Check rows for the call_evidence records (#298). The rows
+        # come straight from evaluate_curve — each Check emits the value it computed —
+        # so the emitted numbers are exactly what the engine saw (no recomputation).
+        evidence_metrics = {}
+
         def resolve_status(_, dye_name, well):
             evaluation = evaluate_curve(self, src, dye_name, well)
+            evidence_metrics[(dye_name, well)] = evaluation.get("metrics", [])
             # ADR-017: canonicalize once here so the engine's "undetected" never
             # escapes to either the results file or the call_evidence summary.
             return canonical_call(evaluation["status"])
@@ -346,7 +355,8 @@ class Curve:
             # device-side emit reads this back off the results file, mirroring
             # how run_complete derives its "calls".
             "evidence": summarize_call_evidence(
-                fam_status, rox_status, rox_raw_status, rox_unavailable
+                fam_status, rox_status, rox_raw_status, rox_unavailable,
+                metrics_by_curve=evidence_metrics,
             ),
         }
 

--- a/aq_curve/evaluator.py
+++ b/aq_curve/evaluator.py
@@ -60,15 +60,22 @@ def check_baseline_length(curve_data, curve):
 
 
 def check_baseline_stability(curve_data, curve):
+    # Composite Check: passes only if BOTH baseline std and slope are in range. Both
+    # values are emitted as their own Metric rows; the check's own verdict is the AND.
     xdata, y_corrected, _ = curve_data
     start, end = curve.baseline_slice
     baseline_values = y_corrected[start:end]
     max_std = config.get_float("PCR_BASELINE_STD_MAX")
-    if float(np.std(baseline_values)) > max_std:
-        return False
-    slope = np.polyfit(xdata[start:end], baseline_values, 1)[0]
     max_slope = config.get_float("PCR_BASELINE_SLOPE_MAX")
-    return abs(float(slope)) <= max_slope
+    std = float(np.std(baseline_values))
+    slope = abs(float(np.polyfit(xdata[start:end], baseline_values, 1)[0]))
+    std_ok = std <= max_std
+    slope_ok = slope <= max_slope
+    rows = [
+        {"name": "baseline_std", "value": std, "threshold": max_std, "passed": std_ok},
+        {"name": "baseline_slope", "value": slope, "threshold": max_slope, "passed": slope_ok},
+    ]
+    return std_ok and slope_ok, rows
 
 
 def check_cycle_location(curve_data, curve):
@@ -93,7 +100,7 @@ def check_log_phase_linearity(curve_data, curve):
     floor = trough_index(y_corrected)
     start = sustained_rise_index(y_corrected, threshold, min_consecutive, floor=floor)
     if start is None:
-        return False
+        return False, []
     end = _find_log_phase_end(y_corrected, start)
     x_segment = xdata[start:end + 1]
     y_segment = y_corrected[start:end + 1]
@@ -101,7 +108,7 @@ def check_log_phase_linearity(curve_data, curve):
     x_segment = x_segment[mask]
     log_segment = np.log(y_segment[mask])
     if len(log_segment) < 2:
-        return True
+        return True, []
     r2 = compute_r2(x_segment, log_segment)
     late_threshold = config.get_float("PCR_LATE_CQ_THRESHOLD")
     if cq is not None and cq >= late_threshold:
@@ -110,7 +117,8 @@ def check_log_phase_linearity(curve_data, curve):
         min_r2 = config.get_float("PCR_LOG_PHASE_R2_MID")
     else:
         min_r2 = config.get_float("PCR_LOG_PHASE_R2_MIN")
-    return r2 >= min_r2
+    passed = r2 >= min_r2
+    return passed, [{"name": "log_phase_r2", "value": float(r2), "threshold": float(min_r2), "passed": bool(passed)}]
 
 
 def check_monotonic_rise(curve_data, curve):
@@ -136,7 +144,9 @@ def check_no_late_drift(curve_data, curve):
         1,
     )[0]
     neg_drift_min = config.get_float("PCR_LATE_NEGATIVE_DRIFT_MIN")
-    return float(slope) >= -neg_drift_min
+    terminal_slope = float(slope)
+    passed = terminal_slope >= -neg_drift_min
+    return passed, [{"name": "terminal_slope", "value": terminal_slope, "threshold": -neg_drift_min, "passed": bool(passed)}]
 
 
 def check_negative_drop(curve_data, curve):
@@ -154,13 +164,13 @@ def check_no_mountain_shape(curve_data, curve):
     min_consecutive = config.get_int("PCR_SUSTAINED_CYCLES")
     rise_index = sustained_rise_index(y_corrected, threshold, min_consecutive)
     if rise_index is None:
-        return True
+        return True, []
     rise_segment = y_corrected[rise_index:]
     peak_offset = int(np.argmax(rise_segment))
     peak_signal = float(rise_segment[peak_offset])
     end_signal = float(np.mean(y_corrected[-3:]))
     if peak_signal <= 0:
-        return True
+        return True, []
     drop_ratio = (peak_signal - end_signal) / peak_signal
     peak_cycle = rise_index + peak_offset
     total_cycles = len(y_corrected)
@@ -170,7 +180,8 @@ def check_no_mountain_shape(curve_data, curve):
         threshold_ratio = config.get_float("PCR_MOUNTAIN_DROP_RATIO_LATE")
     else:
         threshold_ratio = config.get_float("PCR_MOUNTAIN_DROP_RATIO")
-    return not (drop_ratio > threshold_ratio and peak_cycle < total_cycles - 8)
+    passed = not (drop_ratio > threshold_ratio and peak_cycle < total_cycles - 8)
+    return passed, [{"name": "drop_ratio", "value": float(drop_ratio), "threshold": float(threshold_ratio), "passed": bool(passed)}]
 
 
 def check_end_above_midpoint(curve_data, curve):
@@ -221,18 +232,24 @@ def check_signal_range(curve_data, curve):
     baseline_values = y_raw[start:end]
     baseline_mean = float(np.mean(baseline_values))
     if baseline_mean <= 0:
-        return False
+        return False, []
     peak = float(np.max(y_raw))
     min_peak_fraction = config.get_float("PCR_SIGNAL_RANGE_PEAK_FRACTION")
     min_fold = config.get_float("PCR_MIN_FOLD")
     if peak <= 0:
-        return False
+        return False, []
     amplitude_fraction = (peak - baseline_mean) / peak
     fold_change = peak / baseline_mean
     relative_ok = amplitude_fraction >= min_peak_fraction or fold_change >= min_fold
     min_abs_signal = config.get_float("PCR_MIN_ABS_SIGNAL")
-    abs_ok = float(np.max(y_corrected)) >= min_abs_signal
-    return relative_ok and abs_ok
+    abs_signal = float(np.max(y_corrected))
+    abs_ok = abs_signal >= min_abs_signal
+    rows = [
+        {"name": "amplitude_fraction", "value": float(amplitude_fraction), "threshold": float(min_peak_fraction), "passed": bool(amplitude_fraction >= min_peak_fraction)},
+        {"name": "fold_change", "value": float(fold_change), "threshold": float(min_fold), "passed": bool(fold_change >= min_fold)},
+        {"name": "abs_signal", "value": abs_signal, "threshold": float(min_abs_signal), "passed": bool(abs_ok)},
+    ]
+    return relative_ok and abs_ok, rows
 
 
 def check_single_transition(curve_data, curve):
@@ -241,14 +258,14 @@ def check_single_transition(curve_data, curve):
     min_consecutive = config.get_int("PCR_SUSTAINED_CYCLES")
     start = sustained_rise_index(y_corrected, threshold, min_consecutive)
     if start is None:
-        return False
+        return False, []
     deriv = np.diff(y_corrected)
     rise_deriv = deriv[start:]
     if len(rise_deriv) < 2:
-        return True
+        return True, []
     max_deriv = float(np.max(rise_deriv))
     if max_deriv <= 0:
-        return True
+        return True, []
     peak_fraction = config.get_float("PCR_PEAK_FRACTION")
     peak_threshold = max_deriv * peak_fraction
     dip_tolerance = config.get_float("PCR_TRANSITION_DIP_TOLERANCE")
@@ -264,7 +281,8 @@ def check_single_transition(curve_data, curve):
             in_peak = False
         # values in [dip_threshold, peak_threshold): maintain current state
     max_transitions = config.get_int("PCR_MAX_TRANSITIONS")
-    return transitions <= max_transitions
+    passed = transitions <= max_transitions
+    return passed, [{"name": "transition_count", "value": float(transitions), "threshold": float(max_transitions), "passed": bool(passed)}]
 
 
 def check_no_rapid_terminal_rise(curve_data, curve):
@@ -314,10 +332,14 @@ def check_smooth_features(curve_data, curve):
 
 def check_stable_slope(curve_data, curve):
     slope_cv = _compute_stable_slope_cv(curve_data, curve)
-    if slope_cv is None:
-        return True
     max_cv = config.get_float("PCR_LOG_PHASE_SLOPE_CV_MAX")
-    return slope_cv <= max_cv
+    passed = True if slope_cv is None else slope_cv <= max_cv
+    rows = (
+        []
+        if slope_cv is None
+        else [{"name": "slope_cv", "value": float(slope_cv), "threshold": max_cv, "passed": bool(passed)}]
+    )
+    return passed, rows
 
 
 def check_biphasic_stable_slope(curve_data, curve):
@@ -512,26 +534,57 @@ def check_late_cq_tier(curve_data, curve, cq):
     cq_idx = max(0, int(round(cq)) - 1)
     window_before = y_corrected[max(0, cq_idx - 2):cq_idx + 1]
     if len(window_before) == 0:
-        return False
+        return False, []
     base_signal = float(np.max(window_before))
     if base_signal <= 0:
-        return False
+        return False, []
     # Per-cycle fold from Cq to Cq+2: genuine amplification doubles each cycle
     # (~4× over 2 cycles), while background noise shows ~1.1×/cycle (~2.2× over 2)
     after_idx = min(cq_idx + 2, len(y_corrected) - 1)
     if after_idx <= cq_idx:
-        return False
+        return False, []
     fold_2 = float(y_corrected[after_idx]) / base_signal
     cycles_elapsed = after_idx - cq_idx
     per_cycle_fold = fold_2 ** (1.0 / cycles_elapsed)
-    return per_cycle_fold >= config.get_float("PCR_LATE_PER_CYCLE_FOLD_MIN")
+    min_fold = config.get_float("PCR_LATE_PER_CYCLE_FOLD_MIN")
+    passed = per_cycle_fold >= min_fold
+    return passed, [{"name": "per_cycle_fold", "value": float(per_cycle_fold), "threshold": float(min_fold), "passed": bool(passed)}]
 
 
 def _run_check(check, curve_data, curve):
+    """Run a check, normalizing its return to ``(passed, value_rows)``.
+
+    A check returns either a bare bool (legacy) or ``(passed, [metric rows])`` — the
+    Metric value row(s) it computed. The value is computed *before* the pass/fail
+    inside the check, so a curve that fails still logs its numbers. On exception the
+    check fails closed with no rows.
+    """
     try:
-        return bool(check(curve_data, curve))
+        out = check(curve_data, curve)
     except Exception:
-        return False
+        return False, []
+    if isinstance(out, tuple):
+        passed, rows = out
+        return bool(passed), list(rows)
+    return bool(out), []
+
+
+def _collect_checks(checks, curve_data, curve, prefix=""):
+    """Run a list of checks -> (``{name: passed}`` dict, all Metric rows).
+
+    The dict is exactly what ``evaluate_curve``'s cascade consumes (so the decision
+    logic is unchanged); the rows carry each check's value(s) plus a passed-only row
+    for the check verdict itself.
+    """
+    passes = {}
+    rows = []
+    for check in checks:
+        name = prefix + check.__name__
+        passed, value_rows = _run_check(check, curve_data, curve)
+        passes[name] = passed
+        rows.extend(value_rows)
+        rows.append({"name": name, "value": None, "threshold": None, "passed": passed})
+    return passes, rows
 
 
 def check_signal_basics(curve_data, curve):
@@ -554,7 +607,7 @@ def check_signal_basics(curve_data, curve):
         check_sustained_increase,
         check_threshold_oscillation,
     ]
-    return {check.__name__: _run_check(check, curve_data, curve) for check in checks}
+    return _collect_checks(checks, curve_data, curve)
 
 
 def check_biphasic_basics(curve_data, curve):
@@ -568,26 +621,23 @@ def check_biphasic_basics(curve_data, curve):
         check_negative_drop,
         check_biphasic_stable_slope,
     ]
-    return {
-        f"biphasic_{check.__name__}": _run_check(check, curve_data, curve)
-        for check in checks
-    }
+    return _collect_checks(checks, curve_data, curve, prefix="biphasic_")
 
 
 def evaluate_curve(curve, log_name, dye, well):
     curve_data = get_curve_data(curve, log_name, dye, well)
     xdata, y_corrected, _ = curve_data
-    results = {
-        "check_threshold_crossing": _run_check(
-            check_threshold_crossing,
-            curve_data,
-            curve,
-        )
-    }
-    typical_results = check_signal_basics(curve_data, curve)
+    tc_passed, metric_rows = _run_check(check_threshold_crossing, curve_data, curve)
+    metric_rows.append(
+        {"name": "check_threshold_crossing", "value": None, "threshold": None, "passed": tc_passed}
+    )
+    results = {"check_threshold_crossing": tc_passed}
+    typical_results, typical_rows = check_signal_basics(curve_data, curve)
     results.update(typical_results)
-    biphasic_results = check_biphasic_basics(curve_data, curve)
+    metric_rows.extend(typical_rows)
+    biphasic_results, biphasic_rows = check_biphasic_basics(curve_data, curve)
     results.update(biphasic_results)
+    metric_rows.extend(biphasic_rows)
 
     threshold_pass = results["check_threshold_crossing"]
     mountain_shape_detected = not (
@@ -619,11 +669,12 @@ def evaluate_curve(curve, log_name, dye, well):
     # Evaluate late-Cq confidence up-front so it can override strict shape checks
     # that are inherently harder to pass for a signal that barely emerged near run-end.
     if cq is not None and cq >= late_threshold:
-        late_ok = _run_check(
+        late_ok, late_rows = _run_check(
             lambda cd, c: check_late_cq_tier(cd, c, cq),
             curve_data,
             curve,
         )
+        metric_rows.extend(late_rows)
         late_confident = (
             late_ok
             and threshold_pass
@@ -654,8 +705,25 @@ def evaluate_curve(curve, log_name, dye, well):
     else:
         status = "inconclusive"
 
+    # Shared pure measures, emitted once (checks emit their own specific values).
+    metric_rows.extend([
+        {"name": "cq", "value": None if cq is None else float(cq), "threshold": None, "passed": None},
+        {"name": "threshold", "value": float(threshold_val), "threshold": None, "passed": None},
+        {"name": "n_cycles", "value": float(len(y_corrected)), "threshold": None, "passed": None},
+        {"name": "signal_range", "value": float(np.max(y_corrected)) - float(np.min(y_corrected)), "threshold": None, "passed": None},
+    ])
+    # Dedup by name (first wins): a check reused across typical/biphasic emits its
+    # value once; a shared measure is not overwritten by a later duplicate.
+    seen, metrics = set(), []
+    for row in metric_rows:
+        if row["name"] in seen:
+            continue
+        seen.add(row["name"])
+        metrics.append(row)
+
     return {
         "status": status,
         "threshold_pass": threshold_pass,
         "results": results,
+        "metrics": metrics,
     }

--- a/aq_curve/evaluator.py
+++ b/aq_curve/evaluator.py
@@ -663,7 +663,8 @@ def evaluate_curve(curve, log_name, dye, well):
     late_threshold = config.get_float("PCR_LATE_CQ_THRESHOLD")
 
     signal_range_pass = typical_results.get("check_signal_range", True)
-    if threshold_pass and _spike_only_crossings(y_corrected, threshold_val):
+    spike_only_crossings = threshold_pass and _spike_only_crossings(y_corrected, threshold_val)
+    if spike_only_crossings:
         threshold_pass = False
 
     # Evaluate late-Cq confidence up-front so it can override strict shape checks
@@ -688,22 +689,30 @@ def evaluate_curve(curve, log_name, dye, well):
 
     if late_confident:
         status = "detected"
+        decision_reason = "late_cq_confident"
     elif not threshold_pass or not signal_range_pass:
         status = "undetected"
+        decision_reason = "threshold_fail" if not threshold_pass else "signal_range_fail"
     elif mountain_shape_detected or rapid_rise_detected:
         status = "undetected"
+        decision_reason = "mountain_shape" if mountain_shape_detected else "rapid_rise"
     elif cq is None and not typical_results.get("check_sustained_increase", True):
         # No Cq and no sustained increase: threshold was crossed by noise or a spike
         status = "undetected"
+        decision_reason = "no_cq_no_increase"
     elif cq is not None and cq >= late_threshold:
         if late_ok and (typical_pass or biphasic_pass):
             status = "detected"
+            decision_reason = "typical_or_biphasic_pass"
         else:
             status = "inconclusive"
+            decision_reason = "late_cq_not_confident"
     elif typical_pass or biphasic_pass:
         status = "detected"
+        decision_reason = "typical_or_biphasic_pass"
     else:
         status = "inconclusive"
+        decision_reason = "test_run" if curve.test_run else "both_paths_failed"
 
     # Shared pure measures, emitted once (checks emit their own specific values).
     metric_rows.extend([
@@ -726,4 +735,21 @@ def evaluate_curve(curve, log_name, dye, well):
         "threshold_pass": threshold_pass,
         "results": results,
         "metrics": metrics,
+        # Derived decision layer (#299): the flags evaluate_curve already computed and
+        # the cascade branch that produced the status. Records *why* the Call came out
+        # as it did; the cascade logic itself is unchanged.
+        "decision_reason": decision_reason,
+        "flags": {
+            "threshold_pass": bool(threshold_pass),
+            "spike_only_crossings": bool(spike_only_crossings),
+            "test_run": bool(curve.test_run),
+            "typical_pass": bool(typical_pass),
+            "biphasic_pass": bool(biphasic_pass),
+            "baseline_fail": bool(baseline_fail),
+            "mountain_shape_detected": bool(mountain_shape_detected),
+            "rapid_rise_detected": bool(rapid_rise_detected),
+            "late_ok": bool(late_ok),
+            "late_confident": bool(late_confident),
+            "signal_range_pass": bool(signal_range_pass),
+        },
     }

--- a/tests/unit/test_call_evidence_flags.py
+++ b/tests/unit/test_call_evidence_flags.py
@@ -1,0 +1,103 @@
+"""
+Unit tests for call_evidence derived flags + Decision Reason (#299).
+
+evaluate_curve additively exposes the derived decision flags and the Decision Reason
+(the cascade branch that produced the status) it already computes. The cascade logic
+is unchanged; the regression suite (which asserts the Calls) proves that separately.
+"""
+import numpy as np
+import pytest
+
+from aq_curve import evaluator
+from aq_curve.evaluator import evaluate_curve
+from aq_curve.curve import Curve, summarize_call_evidence
+
+pytestmark = pytest.mark.unit
+
+FLAG_KEYS = {
+    "threshold_pass", "spike_only_crossings", "test_run", "typical_pass",
+    "biphasic_pass", "baseline_fail", "mountain_shape_detected",
+    "rapid_rise_detected", "late_ok", "late_confident", "signal_range_pass",
+}
+
+
+def _sigmoid():
+    xdata = np.arange(1, 41)
+    y = 100.0 / (1.0 + np.exp(-(xdata - 20) / 2.0))
+    y_corrected = y - y[:10].mean()
+    return (xdata, y_corrected, y_corrected + 60.0)
+
+
+def test_evaluate_curve_returns_decision_reason_and_flags(monkeypatch):
+    monkeypatch.setattr(evaluator, "get_curve_data", lambda *a: _sigmoid())
+
+    ev = evaluate_curve(Curve(), "log", "fam", 1)
+
+    assert isinstance(ev["decision_reason"], str) and ev["decision_reason"]
+    assert set(ev["flags"]) == FLAG_KEYS
+    assert all(isinstance(v, bool) for v in ev["flags"].values())
+
+
+def test_decision_reason_names_the_branch_taken(monkeypatch):
+    # This sigmoid rises through the baseline window, so it fails baseline checks and
+    # lands on the else branch -> Inconclusive / both_paths_failed. The Decision Reason
+    # names exactly that branch (and the derived flag agrees) — emitted, not inferred.
+    monkeypatch.setattr(evaluator, "get_curve_data", lambda *a: _sigmoid())
+
+    ev = evaluate_curve(Curve(), "log", "fam", 1)
+
+    assert ev["status"] == "inconclusive"
+    assert ev["decision_reason"] == "both_paths_failed"
+    assert ev["flags"]["baseline_fail"] is True
+    assert ev["flags"]["typical_pass"] is False
+
+
+def test_no_signal_curve_is_not_detected_with_a_closed_set_reason(monkeypatch):
+    # Flat noise: never Detected, and the reason is a member of the closed set.
+    xdata = np.arange(1, 41)
+    y_corrected = np.random.RandomState(1).normal(0.0, 5.0, 40)
+    monkeypatch.setattr(evaluator, "get_curve_data", lambda *a: (xdata, y_corrected, y_corrected + 60.0))
+
+    ev = evaluate_curve(Curve(), "log", "fam", 1)
+
+    assert ev["status"] in ("undetected", "inconclusive")
+    assert ev["decision_reason"] in {
+        "threshold_fail", "signal_range_fail", "mountain_shape", "rapid_rise",
+        "no_cq_no_increase", "late_cq_not_confident", "both_paths_failed", "test_run",
+    }
+
+
+def test_summary_record_carries_flags_and_decision_reason():
+    fam = {1: "Detected"}
+    rox = {1: "Detected"}
+    decision_by_curve = {
+        ("fam", 1): {"decision_reason": "typical_or_biphasic_pass", "flags": {"typical_pass": True}},
+    }
+
+    evidence = summarize_call_evidence(
+        fam, rox, dict(rox), rox_unavailable=False, decision_by_curve=decision_by_curve
+    )
+
+    fam_rec = next(r for r in evidence if r["channel"] == "fam")
+    assert fam_rec["decision_reason"] == "typical_or_biphasic_pass"
+    assert fam_rec["flags"] == {"typical_pass": True}
+
+
+def test_results_to_json_evidence_carries_decision_reason_and_flags(tmp_path, monkeypatch):
+    import json
+    from aq_curve import curve as curve_module
+
+    ev_ret = {
+        "status": "detected", "metrics": [],
+        "decision_reason": "typical_or_biphasic_pass", "flags": {"typical_pass": True},
+    }
+    monkeypatch.setattr(curve_module, "evaluate_curve", lambda self, src, dye, well: ev_ret)
+    monkeypatch.setattr(curve_module, "get_curve_data", lambda self, src, dye, well: _sigmoid())
+
+    curve = Curve(src_basedir=str(tmp_path))
+    curve.results_to_json("raw.dat", "results.json")
+    data = json.loads((tmp_path / "results.json").read_text())
+
+    fam1 = next(r for r in data["evidence"] if r["well"] == 1 and r["channel"] == "fam")
+    assert fam1["decision_reason"] == "typical_or_biphasic_pass"
+    assert fam1["flags"]["typical_pass"] is True

--- a/tests/unit/test_call_evidence_metrics.py
+++ b/tests/unit/test_call_evidence_metrics.py
@@ -1,0 +1,106 @@
+"""
+Unit tests for call_evidence Metric/Check emission (#298).
+
+Refactored engine: each Check returns ``(passed, rows)`` — the value it computed —
+so ``evaluate_curve`` emits the full Metric/Check detail with NO recomputation. The
+decision logic (the cascade) is unchanged; the regression suite (which asserts the
+Calls) proves that separately.
+
+Behaviors:
+  1. summarize_call_evidence attaches each curve's metrics to its record.
+  2. evaluate_curve emits Check verdicts + Metric values + shared pure measures.
+  3. a curve that FAILS a Check still logs that Check's number (the key fix vs. the
+     old _run_check-swallows-to-False loss).
+  4. results_to_json threads the metrics into the evidence records.
+"""
+import numpy as np
+import pytest
+
+from aq_curve import evaluator
+from aq_curve.evaluator import evaluate_curve
+from aq_curve.curve import Curve, summarize_call_evidence
+
+pytestmark = pytest.mark.unit
+
+
+def _sigmoid():
+    xdata = np.arange(1, 41)
+    y = 100.0 / (1.0 + np.exp(-(xdata - 20) / 2.0))
+    y_corrected = y - y[:10].mean()
+    return (xdata, y_corrected, y_corrected + 60.0)
+
+
+def test_summarize_attaches_metrics_per_record():
+    fam = {1: "Detected"}
+    rox = {1: "Detected"}
+    metrics_by_curve = {
+        ("fam", 1): [{"name": "cq", "value": 22.5, "threshold": None, "passed": None}],
+        ("rox", 1): [{"name": "cq", "value": 24.0, "threshold": None, "passed": None}],
+    }
+
+    evidence = summarize_call_evidence(
+        fam, rox, dict(rox), rox_unavailable=False, metrics_by_curve=metrics_by_curve
+    )
+
+    fam_rec = next(r for r in evidence if r["channel"] == "fam")
+    assert fam_rec["metrics"] == metrics_by_curve[("fam", 1)]
+
+
+def test_evaluate_curve_emits_checks_values_and_pure_measures(monkeypatch):
+    monkeypatch.setattr(evaluator, "get_curve_data", lambda *a: _sigmoid())
+
+    ev = evaluate_curve(Curve(), "log", "fam", 1)
+    by_name = {m["name"]: m for m in ev["metrics"]}
+
+    # shared pure measures (emitted once, value-only)
+    for name in ("cq", "threshold", "n_cycles", "signal_range"):
+        assert name in by_name
+        assert by_name[name]["passed"] is None
+
+    # a Check verdict is a passed-only row
+    assert by_name["check_baseline_stability"]["value"] is None
+    assert by_name["check_baseline_stability"]["passed"] in (True, False)
+
+    # a composite Check's underlying Metrics are their own value+threshold+passed rows
+    for name in ("baseline_std", "baseline_slope"):
+        assert by_name[name]["value"] is not None
+        assert by_name[name]["threshold"] is not None
+        assert by_name[name]["passed"] in (True, False)
+
+
+def test_failing_curve_still_logs_its_check_values(monkeypatch):
+    # Pure noise, no amplification -> Checks fail, but the numbers are still computed
+    # (baseline std/slope are computed before the pass/fail).
+    xdata = np.arange(1, 41)
+    y_corrected = np.random.RandomState(0).normal(0.0, 40.0, 40)
+    monkeypatch.setattr(evaluator, "get_curve_data", lambda *a: (xdata, y_corrected, y_corrected + 60.0))
+
+    ev = evaluate_curve(Curve(), "log", "fam", 1)
+    by_name = {m["name"]: m for m in ev["metrics"]}
+
+    assert by_name["baseline_std"]["value"] is not None
+    assert by_name["baseline_slope"]["value"] is not None
+
+
+def test_results_to_json_evidence_records_carry_the_metrics(tmp_path, monkeypatch):
+    import json
+    from aq_curve import curve as curve_module
+
+    metrics = [
+        {"name": "check_baseline_stability", "value": None, "threshold": None, "passed": True},
+        {"name": "cq", "value": 22.5, "threshold": None, "passed": None},
+        {"name": "baseline_std", "value": 3.1, "threshold": 5.0, "passed": True},
+    ]
+    monkeypatch.setattr(
+        curve_module, "evaluate_curve",
+        lambda self, src, dye, well: {"status": "detected", "metrics": metrics},
+    )
+    monkeypatch.setattr(curve_module, "get_curve_data", lambda self, src, dye, well: _sigmoid())
+
+    curve = Curve(src_basedir=str(tmp_path))
+    curve.results_to_json("raw.dat", "results.json")
+    data = json.loads((tmp_path / "results.json").read_text())
+
+    fam1 = next(r for r in data["evidence"] if r["well"] == 1 and r["channel"] == "fam")
+    names = {m["name"] for m in fam1["metrics"]}
+    assert {"check_baseline_stability", "cq", "baseline_std"} <= names


### PR DESCRIPTION
Closes #298 and #299 — the remaining device Call Evidence work, as **one PR to `main`** (built on top of #297, already merged). Built TDD; the analysis regression suite proves the Calls never move.

## #298 — emit all Metrics + Checks (values come from the checks)
Standard validation-framework pattern: **each Check returns its computed value**, so the emitted number is exactly what the engine used (no recompute, no divergence).
- Each `check_*` returns `(passed, rows)`; the value is computed **before** the pass/fail, so a curve that **fails** still logs its number.
- **Cascade byte-for-byte unchanged** — `_run_check` normalizes `bool | (bool, rows)`; `_collect_checks` rebuilds the exact `{name: passed}` dict the cascade already consumes.
- Composite Checks emit their boolean + underlying Metric rows; shared measures (`cq`, `threshold`, `n_cycles`, `signal_range`) emitted once. (Replaced an earlier `collect_metrics` recompute approach mid-review.)

## #299 — derived flags + Decision Reason
`evaluate_curve` additively returns the 11 derived decision `flags` and a `decision_reason` tagging the **exact cascade branch** that produced the status. Status assignments unchanged → Calls can't move. `results_to_json` threads both into the `call_evidence` records, so each record explains *why* its Call came out as it did.

## Regression
The analysis suite (asserts `Detected`/`Not Detected`/`Inconclusive` across many curves) stays green. Merged current `main` (#296, #301) in cleanly — **104 passed** on the merged state.

Supersedes the mis-merged #302.

🤖 Generated with [Claude Code](https://claude.com/claude-code)