### PR TITLE
Hotfix: guard empty-curve signal_range crash (regression from #303)

### DIFF
--- a/aq_curve/evaluator.py
+++ b/aq_curve/evaluator.py
@@ -719,7 +719,10 @@ def evaluate_curve(curve, log_name, dye, well):
         {"name": "cq", "value": None if cq is None else float(cq), "threshold": None, "passed": None},
         {"name": "threshold", "value": float(threshold_val), "threshold": None, "passed": None},
         {"name": "n_cycles", "value": float(len(y_corrected)), "threshold": None, "passed": None},
-        {"name": "signal_range", "value": float(np.max(y_corrected)) - float(np.min(y_corrected)), "threshold": None, "passed": None},
+        # Guard against a well/channel with no signal (e.g. ROX Unavailable, or an
+        # aborted/truncated read): np.max on an empty array raises and would sink the
+        # entire Run's results. An empty curve has no range -> 0.0.
+        {"name": "signal_range", "value": (float(np.max(y_corrected)) - float(np.min(y_corrected))) if len(y_corrected) else 0.0, "threshold": None, "passed": None},
     ])
     # Dedup by name (first wins): a check reused across typical/biphasic emits its
     # value once; a shared measure is not overwritten by a later duplicate.

--- a/tests/pcr_curve/test_baseline_stability.py
+++ b/tests/pcr_curve/test_baseline_stability.py
@@ -2,4 +2,4 @@ from aq_curve.evaluator import check_baseline_stability
 
 
 def test_baseline_stability(curve_data, curve):
-    assert check_baseline_stability(curve_data, curve)
+    assert check_baseline_stability(curve_data, curve)[0]

--- a/tests/pcr_curve/test_late_cq_fixes.py
+++ b/tests/pcr_curve/test_late_cq_fixes.py
@@ -24,7 +24,7 @@ def test_mountain_passes_early_cq_at_0_35():
     y = [0.0] * 5 + list(np.linspace(0.0, 1.0, 15)) + list(np.linspace(1.0, 0.70, 20))
     cd = _curve_data(y)
     curve = _make_curve()
-    assert check_no_mountain_shape(cd, curve) is True
+    assert check_no_mountain_shape(cd, curve)[0] is True
 
 
 def test_mountain_rejected_late_cq_drop_ratio_above_0_25():
@@ -38,7 +38,7 @@ def test_mountain_rejected_late_cq_drop_ratio_above_0_25():
     cd = _curve_data(y)
     curve = _make_curve()
     with patch("aq_curve.evaluator.compute_cq", return_value=36.0):
-        result = check_no_mountain_shape(cd, curve)
+        result = check_no_mountain_shape(cd, curve)[0]
     assert result is False
 
 
@@ -52,7 +52,7 @@ def test_mountain_rejected_early_cq_drop_ratio_above_0_35():
     cd = _curve_data(y)
     curve = _make_curve()
     with patch("aq_curve.evaluator.compute_cq", return_value=20.0):
-        result = check_no_mountain_shape(cd, curve)
+        result = check_no_mountain_shape(cd, curve)[0]
     # drop_ratio ~0.38 > 0.35 → rejected at early Cq too
     assert result is False
 
@@ -65,7 +65,7 @@ def test_late_cq_tier_rejects_bg_fam_like_curve():
     cd = _curve_data(y)
     curve = _make_curve()
     cq = 36.0  # 0-based index 35, 1-based cycle 36 ≈ Cq
-    result = check_late_cq_tier(cd, curve, cq)
+    result = check_late_cq_tier(cd, curve, cq)[0]
     assert result is False
 
 
@@ -75,7 +75,7 @@ def test_late_cq_tier_passes_genuine_doubling():
     cd = _curve_data(y)
     curve = _make_curve()
     cq = 36.0
-    result = check_late_cq_tier(cd, curve, cq)
+    result = check_late_cq_tier(cd, curve, cq)[0]
     assert result is True
 
 
@@ -85,6 +85,6 @@ def test_late_cq_tier_uses_two_cycle_window_not_five():
     cd = _curve_data(y)
     curve = _make_curve()
     cq = 36.0
-    result = check_late_cq_tier(cd, curve, cq)
+    result = check_late_cq_tier(cd, curve, cq)[0]
     # fold at +2: 0.13/0.10 = 1.3 → fails (confirms 2-cycle window is used)
     assert result is False

--- a/tests/pcr_curve/test_log_phase_linearity.py
+++ b/tests/pcr_curve/test_log_phase_linearity.py
@@ -2,4 +2,4 @@ from aq_curve.evaluator import check_log_phase_linearity
 
 
 def test_log_phase_linearity(curve_data, curve):
-    assert check_log_phase_linearity(curve_data, curve)
+    assert check_log_phase_linearity(curve_data, curve)[0]

--- a/tests/pcr_curve/test_no_late_drift.py
+++ b/tests/pcr_curve/test_no_late_drift.py
@@ -2,4 +2,4 @@ from aq_curve.evaluator import check_no_late_drift
 
 
 def test_no_late_drift(curve_data, curve):
-    assert check_no_late_drift(curve_data, curve)
+    assert check_no_late_drift(curve_data, curve)[0]

--- a/tests/pcr_curve/test_signal_range.py
+++ b/tests/pcr_curve/test_signal_range.py
@@ -2,4 +2,4 @@ from aq_curve.evaluator import check_signal_range
 
 
 def test_signal_range(curve_data, curve):
-    assert check_signal_range(curve_data, curve)
+    assert check_signal_range(curve_data, curve)[0]

--- a/tests/pcr_curve/test_single_transition.py
+++ b/tests/pcr_curve/test_single_transition.py
@@ -4,7 +4,7 @@ from aq_curve.evaluator import check_single_transition
 
 
 def test_single_transition(curve_data, curve):
-    assert check_single_transition(curve_data, curve)
+    assert check_single_transition(curve_data, curve)[0]
 
 
 class _Curve:
@@ -53,7 +53,7 @@ def test_minor_dip_within_tolerance_passes(monkeypatch):
     # Depress index 23 (cycle 24) so the derivative from index 22→23 = 0.034.
     # The following step compensates upward, keeping the rest of the curve intact.
     y[23] = y[22] + 0.034
-    assert check_single_transition(_curve_data(y), _Curve())
+    assert check_single_transition(_curve_data(y), _Curve())[0]
 
 
 def test_large_dip_outside_tolerance_counts_as_new_transition(monkeypatch):
@@ -78,4 +78,4 @@ def test_large_dip_outside_tolerance_counts_as_new_transition(monkeypatch):
     y = _pcr_sigmoid()
     # Depress index 23 (cycle 24) so the derivative from index 22→23 = 0.030.
     y[23] = y[22] + 0.030
-    assert not check_single_transition(_curve_data(y), _Curve())
+    assert not check_single_transition(_curve_data(y), _Curve())[0]

--- a/tests/pcr_curve/test_stable_slope.py
+++ b/tests/pcr_curve/test_stable_slope.py
@@ -2,4 +2,4 @@ from aq_curve.evaluator import check_stable_slope
 
 
 def test_stable_slope(curve_data, curve):
-    assert check_stable_slope(curve_data, curve)
+    assert check_stable_slope(curve_data, curve)[0]

--- a/tests/unit/test_call_evidence_metrics.py
+++ b/tests/unit/test_call_evidence_metrics.py
@@ -82,6 +82,22 @@ def test_failing_curve_still_logs_its_check_values(monkeypatch):
     assert by_name["baseline_slope"]["value"] is not None
 
 
+def test_empty_curve_emits_zero_signal_range_without_crashing(monkeypatch):
+    # A well/channel with no signal (ROX Unavailable, or an aborted/truncated read)
+    # yields an empty corrected curve. The metric emission must not call np.max on it
+    # and sink the whole Run's results -- an empty curve has no range, so 0.0.
+    monkeypatch.setattr(
+        evaluator, "get_curve_data",
+        lambda *a: (np.array([]), np.array([]), np.array([])),
+    )
+
+    ev = evaluate_curve(Curve(), "log", "rox", 1)
+    by_name = {m["name"]: m for m in ev["metrics"]}
+
+    assert by_name["signal_range"]["value"] == 0.0
+    assert by_name["n_cycles"]["value"] == 0.0
+
+
 def test_results_to_json_evidence_records_carry_the_metrics(tmp_path, monkeypatch):
     import json
     from aq_curve import curve as curve_module


### PR DESCRIPTION
## What & why

Follow-up to #303 (already merged). A device update with the new Call Evidence logging **failed on sn03** with `Failed to generate results: zero-size array to reduction operation maximum which has no identity`, surfaced in the UI as "error in results path."

**Root cause:** the new metrics block emits `signal_range` via `np.max(y_corrected)` **unconditionally**. A well/channel with no signal — a **ROX Unavailable** channel, or an aborted/truncated read — has an empty corrected curve, so `np.max` raises and sinks the **entire Runs** results. Reproduced locally and verified the guard fixes it.

**Fix:** an empty curve has no range → `signal_range = 0.0` (matching the existing guard in `pcr_curve_helpers.py`).

Also includes the `pcr_curve` test-debt from the #298 refactor (checks now return `(passed, rows)`; direct-call tests index `[0]`). These did not land in #303, so `main`s `pcr_curve` suite is currently red — this greens it.

## Safety

- Regression suites green (analysis + rapid_rise + pcr_curve): **79 passed** — Calls unchanged.
- New test `test_empty_curve_emits_zero_signal_range_without_crashing` locks in the fix.

## Deploy

Merging rebuilds the `:dev` image; watchtower pulls it onto the fleet. Will confirm a clean run on sn03 after deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)