### PR TITLE
Device: 30-day synced-only retention on the Sync loop (#304)

### DIFF
--- a/aquila_web/local_db.py
+++ b/aquila_web/local_db.py
@@ -168,7 +168,7 @@ def mark_event_synced(event_ids: list[int]) -> None:
         connection.execute(query, values)
 
 
-def cleanup_synced_events(retain_days: int = 7) -> int:
+def cleanup_synced_events(retain_days: int = 30) -> int:
     with _connect() as connection:
         cursor = connection.execute(
             """

--- a/aquila_web/main.py
+++ b/aquila_web/main.py
@@ -2275,21 +2275,31 @@ async def _background_update_poller() -> None:
 _SYNC_INTERVAL_SECONDS = int(os.getenv("AQ_SYNC_INTERVAL_SECONDS", "900"))
 
 
+def _run_sync_cycle() -> int:
+    """One outbox reconciliation: push pending Events, then prune long-since-synced
+    ones (ADR-020). Cleanup runs only after a flush -- never on an independent
+    clock -- and only touches synced Events past the retention window; pending and
+    quarantined Events are always retained. Returns the number of Events synced."""
+    from aquila_web.sync import sync_pending_events
+    from aquila_web.local_db import cleanup_synced_events
+    synced = sync_pending_events()
+    cleanup_synced_events()
+    return synced
+
+
 async def _background_sync_poller() -> None:
     """Flush SQLite event queue to AWS ingest endpoint every AQ_SYNC_INTERVAL_SECONDS."""
     while True:
         await asyncio.sleep(_SYNC_INTERVAL_SECONDS)
         try:
-            from aquila_web.sync import sync_pending_events
-            sync_pending_events()
+            _run_sync_cycle()
         except Exception as exc:
             logger.warning("Background sync error: %s", exc)
 
 
 @app.post("/sync/flush")
 async def sync_flush():
-    from aquila_web.sync import sync_pending_events
-    synced = sync_pending_events()
+    synced = _run_sync_cycle()
     return {"synced": synced}
 
 

--- a/docs/adr/ADR-020-device-retention-trusts-ingest-pipeline.md
+++ b/docs/adr/ADR-020-device-retention-trusts-ingest-pipeline.md
@@ -1,0 +1,137 @@
+# ADR-020: Device retention trusts the ingest pipeline (S3 as source of truth), not warehouse acknowledgement
+
+**Status:** Accepted
+**Date:** 2026-07-09
+**Author:** Nicole Cornell
+**Deciders:** Nicole Cornell
+
+---
+
+## Context
+
+Each Sentri keeps a local SQLite database (`data/db/app.db`) that is a **thin
+outbox**: a single `events` table into which the app enqueues typed JSON Events
+(`run_complete`, `optics_readings`, `call_evidence`) as a Run completes. The
+background Sync task flushes pending Events to the Ingest Endpoint every 15
+minutes (and on WiFi reconnect) and stamps `synced_at` on each row.
+
+Two facts forced a retention decision:
+
+- **`synced_at` is set on the ingest HTTP `2xx`, not on warehouse landing.**
+  The Ingest Endpoint is only the front door of an asynchronous pipeline
+  (ingest Lambda → SQS → archiver Lambda → **S3** → loader/ETL Lambda →
+  analytics warehouse; ADR-015). A `2xx` means "accepted into the pipeline,"
+  which is returned long before the loader writes the fact to Postgres. The
+  device has **no signal** that a row reached the warehouse.
+- **The cleanup was never wired up.** `cleanup_synced_events` existed but had no
+  caller, so synced rows accumulated on the SD card indefinitely. Adding a real
+  retention policy meant first deciding what "safe to delete" means.
+
+Live options ranged from "delete as soon as ingest accepts" to "only delete once
+the warehouse confirms the row landed." The relevant durability fact is that the
+pipeline **archives every raw Event to S3** before loading, with DLQ retry on the
+loader — so S3, not the device, is the replayable record of what was sent.
+
+Doing nothing was not viable: the device DB grows without bound, and the
+retention semantics stay ambiguous.
+
+---
+
+## Decision
+
+**We will treat the ingest `2xx` as a durable hand-off and let device retention
+trust the pipeline — the S3 archive is the source of truth for replay, not the
+device SQLite.**
+
+Concretely:
+
+- `synced_at` continues to mean **"accepted by the Ingest Endpoint (`2xx`),"**
+  i.e. durably handed to SQS + archived to S3. It does **not** mean "present in
+  the Postgres warehouse."
+- `cleanup_synced_events` runs **after** the flush inside the existing 15-minute
+  Sync loop, deleting only rows that are **both** synced **and** older than
+  **30 days** (`WHERE synced_at IS NOT NULL AND synced_at < now − 30d`).
+- Pending (un-synced) and quarantined rows are **never** auto-deleted — an
+  offline Sentri retains everything until it flushes; quarantined rows persist
+  for diagnosis.
+- We will **not** build a device↔warehouse acknowledgement channel. The device
+  never asks acorn-analytics "did my rows load?"
+
+The 30-day window is a **safety buffer**, not the correctness mechanism.
+Correctness — the guarantee that a sent Event can always be recovered — lives in
+the S3 archive and the pipeline's DLQ retry.
+
+This is reversible in code (retention window and caller are trivial to change),
+but the *data* it deletes is not recoverable from the device once gone.
+
+---
+
+## Consequences
+
+### Positive
+- **No new API surface or coupling.** No confirmation endpoint, no per-device
+  polling of the warehouse across the fleet.
+- **Bounded local storage.** The SD card no longer accumulates synced Events
+  forever; the outbox stays a buffer.
+- **Undelivered data is never lost.** Only synced rows are eligible; pending and
+  quarantined rows are retained until delivered or explicitly resolved.
+- **Generous recovery window.** 30 days is ample time for any transient loader
+  failure to be noticed and resolved (via S3 replay) before the device copy ages
+  out.
+
+### Negative
+- **A deleted device row is not a warehouse guarantee.** In a pathological
+  failure where an Event is accepted (`2xx`) but never loads to Postgres and the
+  issue is unresolved for 30 days, the device copy is gone — recovery then
+  depends entirely on the S3 archive, not the device.
+- **`synced_at` is a mild misnomer:** it records ingest acceptance, not warehouse
+  arrival. Documented in the Device Event Contract and CONTEXT.md to prevent
+  misreading.
+
+### Neutral / Tradeoffs
+- Retention is a housekeeping buffer, decoupled from correctness. Anyone
+  reasoning about "is this data safe?" must look at S3, not the device DB.
+
+---
+
+## Alternatives Considered
+
+### Option A: True warehouse acknowledgement (device confirms landing before delete)
+The device would ask acorn-analytics which `run_timestamp`s have loaded and mark
+only those confirmed, deleting later.
+**Why rejected:** duplicates a durability guarantee the S3 archive + DLQ already
+provide, while adding a new confirmation endpoint, device↔warehouse coupling, and
+per-device polling that is costly to operate across a growing fleet.
+
+### Option B: Delete immediately on `2xx`
+Drop each row as soon as it syncs.
+**Why rejected:** leaves no buffer for a transient pipeline issue and no local
+window for diagnosis; a same-day loader outage would have no device-side fallback.
+
+### Option C: Never delete (keep forever)
+**Why rejected:** unbounded SD-card growth on a field device; the outbox is meant
+to be a buffer, not an archive.
+
+---
+
+## Revisit Conditions
+
+- If the S3 raw-Event archive is removed or stops being the replay source of
+  truth, the trust assumption collapses and this must be reopened.
+- If the pipeline loses its DLQ/retry durability between ingest and warehouse.
+- If a real incident shows 30 days is too short (or needlessly long) for the
+  fleet's recovery patterns.
+- If on-device querying of historical Events becomes a product requirement (the
+  thin-outbox premise itself would change — see the retired
+  `local-db-schema.md` relational design).
+
+---
+
+## References
+
+- Related ADRs: ADR-015 (ingest moves to acorn-analytics Lambda pipeline),
+  ADR-013 (ingest moves to Sentri Analytics Platform, mTLS)
+- Glossary: CONTEXT.md — **Event**, **Sync**, **Ingest Endpoint**
+- Code: `aquila_web/local_db.py` (`cleanup_synced_events`, `mark_event_synced`),
+  `aquila_web/sync.py`, `aquila_web/main.py` (Sync loop)
+- Doc: `docs/local-db-schema.md` (Device Event Contract)

--- a/tests/unit/test_retention.py
+++ b/tests/unit/test_retention.py
@@ -1,0 +1,107 @@
+"""
+Retention of the local Event outbox (#304, ADR-020).
+
+The device SQLite is a thin outbox: Events are pruned only once they are safely
+synced AND old enough. `synced_at` means "accepted by the Ingest Endpoint (2xx)",
+not "in the warehouse" — S3 is the source of truth, so the 30-day window is a
+safety buffer. Pending and quarantined Events are never pruned.
+"""
+import sqlite3
+from datetime import datetime, timedelta
+
+import pytest
+
+pytestmark = pytest.mark.unit
+
+
+@pytest.fixture
+def db(tmp_path, monkeypatch):
+    monkeypatch.setenv("AQ_LOCAL_DB_PATH", str(tmp_path / "retention.db"))
+    from aquila_web import local_db
+    local_db.init_local_db()
+    return local_db
+
+
+@pytest.fixture
+def client_db(tmp_path, monkeypatch):
+    """App TestClient sharing an isolated DB; no sync endpoint (flush pushes nothing)."""
+    monkeypatch.setenv("AQ_LOCAL_DB_PATH", str(tmp_path / "retention.db"))
+    monkeypatch.delenv("AQ_SYNC_ENDPOINT", raising=False)
+    from fastapi.testclient import TestClient
+    from aquila_web import local_db, main as web_main
+    local_db.init_local_db()
+    with TestClient(web_main.app) as client:
+        yield client, local_db
+
+
+def _backdate_sync(db, event_id: int, days_ago: int) -> None:
+    """Arrange a row that was synced `days_ago` days ago (no public backdate API)."""
+    ts = (datetime.utcnow() - timedelta(days=days_ago)).isoformat(timespec="seconds") + "Z"
+    with sqlite3.connect(db.get_db_path()) as conn:
+        conn.execute("UPDATE events SET synced_at = ? WHERE id = ?", (ts, event_id))
+
+
+def _backdate_created(db, event_id: int, days_ago: int) -> None:
+    ts = (datetime.utcnow() - timedelta(days=days_ago)).isoformat(timespec="seconds") + "Z"
+    with sqlite3.connect(db.get_db_path()) as conn:
+        conn.execute("UPDATE events SET created_at = ? WHERE id = ?", (ts, event_id))
+
+
+def _ids(db) -> set[int]:
+    with sqlite3.connect(db.get_db_path()) as conn:
+        return {row[0] for row in conn.execute("SELECT id FROM events")}
+
+
+def test_synced_row_within_window_is_retained(db):
+    eid = db.enqueue_event("run_complete", {"run": 1})
+    db.mark_event_synced([eid])
+    _backdate_sync(db, eid, days_ago=29)
+
+    db.cleanup_synced_events()  # default window
+
+    assert eid in _ids(db)
+
+
+def test_synced_row_past_window_is_pruned(db):
+    eid = db.enqueue_event("run_complete", {"run": 1})
+    db.mark_event_synced([eid])
+    _backdate_sync(db, eid, days_ago=31)
+
+    db.cleanup_synced_events()  # default window
+
+    assert eid not in _ids(db)
+
+
+def test_pending_row_is_never_pruned(db):
+    # An undelivered Event is retained regardless of age -- never drop data the
+    # cloud has not acknowledged.
+    eid = db.enqueue_event("run_complete", {"run": 1})
+    _backdate_created(db, eid, days_ago=100)  # ancient, but never synced
+
+    db.cleanup_synced_events()
+
+    assert eid in _ids(db)
+
+
+def test_flush_prunes_old_synced_rows(client_db):
+    # One sync cycle both pushes pending Events and prunes long-since-synced ones.
+    client, db = client_db
+    eid = db.enqueue_event("run_complete", {"run": 1})
+    db.mark_event_synced([eid])
+    _backdate_sync(db, eid, days_ago=31)
+
+    resp = client.post("/sync/flush")
+
+    assert resp.status_code == 200
+    assert eid not in _ids(db)
+
+
+def test_quarantined_row_is_never_pruned(db):
+    # Quarantined Events are retained for diagnosis, never auto-deleted.
+    eid = db.enqueue_event("call_evidence", {"run": 1})
+    db.mark_event_quarantined(eid, "too big to split")
+    _backdate_created(db, eid, days_ago=100)
+
+    db.cleanup_synced_events()
+
+    assert eid in _ids(db)


### PR DESCRIPTION
Closes #304.

## What & why

The local Event outbox never pruned synced rows — `cleanup_synced_events` existed but had **no caller**, so the SD card grew without bound. This wires it up per **ADR-020**.

A single `_run_sync_cycle()` pushes pending Events, then prunes synced Events past a **30-day** window (was 7). Both the background poller **and** the manual `POST /sync/flush` route through it, so cleanup runs **only after a flush** — never on an independent clock.

Per ADR-020, `synced_at` means "accepted by the Ingest Endpoint (2xx)", **not** "in the warehouse" — the S3 archive is the source of truth, so the 30-day window is a safety buffer. **Pending and quarantined Events are always retained.**

## Behavior (TDD, 5 slices)

- [x] Synced row **within** 30d → retained (drove default 7→30)
- [x] Synced row **past** 30d → pruned
- [x] **Pending** row → never pruned, even ancient
- [x] **Quarantined** row → never pruned
- [x] A **flush prunes** after pushing (via `/sync/flush`)

Tests assert through the public interface (`cleanup_synced_events` / `/sync/flush`); `synced_at` is backdated only for arrangement.

## Safety

Retention + sync + local_db suites green; Calls/sync behavior unchanged. Includes ADR-020 as the decision record.

🤖 Generated with [Claude Code](https://claude.com/claude-code)