### PR TITLE
Device: stamp local outbox DB with PRAGMA user_version = 1 (#305)

### DIFF
--- a/aquila_web/local_db.py
+++ b/aquila_web/local_db.py
@@ -43,6 +43,16 @@ def init_local_db() -> None:
             """
         )
         _add_missing_columns(connection)
+        # Stamp the schema version, bumping forward only so a newer device DB
+        # (a future migration) is never regressed by an older build.
+        current_version = connection.execute("PRAGMA user_version").fetchone()[0]
+        if current_version < _SCHEMA_VERSION:
+            connection.execute(f"PRAGMA user_version = {_SCHEMA_VERSION}")
+
+
+# The current on-device schema version, stamped into the DB header via
+# PRAGMA user_version (#305) so future non-additive migrations can gate on it.
+_SCHEMA_VERSION = 1
 
 
 # Additive quarantine columns for the size guard (#289). Applied as ALTER TABLE

--- a/tests/unit/test_schema_version.py
+++ b/tests/unit/test_schema_version.py
@@ -1,0 +1,67 @@
+"""
+Schema version stamp on the local outbox DB (#305).
+
+`init_local_db` stamps `PRAGMA user_version` so every Sentri's outbox carries an
+explicit schema version to gate future non-additive migrations on, instead of
+inferring state from column introspection. The stamp only ever moves forward.
+"""
+import sqlite3
+
+import pytest
+
+pytestmark = pytest.mark.unit
+
+SCHEMA_VERSION = 1
+
+
+@pytest.fixture
+def db(tmp_path, monkeypatch):
+    monkeypatch.setenv("AQ_LOCAL_DB_PATH", str(tmp_path / "schema.db"))
+    from aquila_web import local_db
+    return local_db
+
+
+def _user_version(db) -> int:
+    with sqlite3.connect(db.get_db_path()) as conn:
+        return conn.execute("PRAGMA user_version").fetchone()[0]
+
+
+def test_fresh_db_reports_schema_version(db):
+    db.init_local_db()
+
+    assert _user_version(db) == SCHEMA_VERSION
+
+
+def test_init_does_not_regress_a_higher_version(db):
+    # A DB already stamped at a future version must not be lowered by init.
+    db.init_local_db()
+    with sqlite3.connect(db.get_db_path()) as conn:
+        conn.execute("PRAGMA user_version = 2")
+
+    db.init_local_db()
+
+    assert _user_version(db) == 2
+
+
+def test_init_is_idempotent(db):
+    db.init_local_db()
+    db.init_local_db()  # running again must not error or change the version
+
+    assert _user_version(db) == SCHEMA_VERSION
+
+
+def test_existing_pre_stamp_db_is_upgraded_in_place(db):
+    # A DB created before the stamp existed: an events table, no user_version, and
+    # missing the later quarantine columns. init must migrate it and stamp it.
+    with sqlite3.connect(db.get_db_path()) as conn:
+        conn.execute(
+            "CREATE TABLE events ("
+            "id INTEGER PRIMARY KEY AUTOINCREMENT, event_type TEXT NOT NULL, "
+            "payload TEXT NOT NULL, device_id TEXT, created_at TEXT NOT NULL, "
+            "synced_at TEXT)"
+        )
+    assert _user_version(db) == 0  # precondition: unstamped legacy DB
+
+    db.init_local_db()
+
+    assert _user_version(db) == SCHEMA_VERSION


### PR DESCRIPTION
Closes #305.

## What & why

`init_local_db` now stamps `PRAGMA user_version` on the local outbox DB. Today it is `0` (unset) and schema state is inferred by column introspection, which only works for additive changes. The stamp gives every Sentri an explicit version marker to gate future non-additive migrations on. It bumps **forward only** — a newer device DB (a future migration) is never regressed by an older build.

## Behavior (TDD, 4 slices)

- [x] Fresh DB reports `user_version = 1` (drove the stamp)
- [x] init does **not regress** a higher version — a DB at v2 stays v2 (drove the forward-only guard)
- [x] Idempotent — running init repeatedly does not error or change the version
- [x] Existing pre-stamp DB (legacy events table, missing quarantine columns, v0) is migrated + stamped in place

Tests verify via `PRAGMA user_version` — the header value is the observable outcome; there is no higher-level interface.

## Safety

`init_local_db` consumers (quarantine, retention, background sync) all still green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)