### PR TITLE
fix(run): countdown survives Reset + re-run; resolve estimate by name recursively (#312)

### DIFF
--- a/aquila_web/main.py
+++ b/aquila_web/main.py
@@ -1829,7 +1829,11 @@ async def profile_details(id: str | None = Query(default=None), name: str | None
         if not profile_path.exists():
             raise HTTPException(status_code=404, detail="Profile not found")
     else:
-        for path in profile_dir.glob("*.json"):
+        # Recurse into subdirs (bundled/, local/) — profiles do not live at the
+        # root. Mirrors _resolve_profile_display_name, which produces the very
+        # name searched here; a non-recursive glob would 404 every bundled/local
+        # profile looked up by name (#312).
+        for path in profile_dir.rglob("*.json"):
             try:
                 with path.open() as f:
                     data = json.load(f)

--- a/aquila_web/static/run.html
+++ b/aquila_web/static/run.html
@@ -164,7 +164,7 @@
     </main>
   </div>
   <script src="static/nav.js?v=1"></script>
-  <script src="static/script.js?v=68"></script>
+  <script src="static/script.js?v=69"></script>
   <script src="static/keyboard.js?v=14"></script>
 </body>
 </html>

--- a/aquila_web/static/script.js
+++ b/aquila_web/static/script.js
@@ -220,18 +220,56 @@ function setTimerLabel(text) {
   }
 }
 
-// Decide countdown vs. stopwatch for the active run and update the timer label.
-// Called when the running screen is entered; locks in the selected profile's estimate.
-function beginTimerMode() {
+// Monotonic token identifying the current run's timer session. Bumped on every
+// run-start and every reset so an estimate fetch that resolves late (after Reset
+// or a subsequent run) can detect it is stale and abstain (#312 race guard).
+let timerModeToken = 0;
+
+// Apply countdown-vs-stopwatch from an estimate value (null / non-positive =>
+// stopwatch) and update the timer label.
+function applyTimerMode(estimateSeconds) {
   countdownSeconds =
-    typeof cachedEstimateSeconds === "number" && cachedEstimateSeconds > 0
-      ? cachedEstimateSeconds
-      : null;
+    typeof estimateSeconds === "number" && estimateSeconds > 0 ? estimateSeconds : null;
   setTimerLabel(countdownSeconds != null ? TIMER_LABEL_REMAINING : TIMER_LABEL_ELAPSED);
 }
 
-// Reset timer to default stopwatch mode (run ended / stopped).
+// Decide countdown vs. stopwatch for the active run and update the timer label.
+// Called when the running screen is entered.
+//
+// The selection-warmed cache (`cachedEstimateSeconds`) is only a fast path: it is
+// populated solely by loadProfileLabels() on a UI selection, so after a run
+// completes and Reset clears the selected profile server-side (#275), a re-run of
+// the same profile re-enters `running` with a cold/stale cache and would wrongly
+// fall back to the stopwatch (#312). So we re-derive the mode from the
+// authoritative active profile (activeRunProfileName, set from the server panel)
+// via /profiles/details. This also covers runs started by the device's physical
+// button, which bypass notifyRun().
+function beginTimerMode() {
+  const token = ++timerModeToken;
+  applyTimerMode(cachedEstimateSeconds); // fast path: no flash when the cache is warm
+  const profileRef = activeRunProfileName;
+  if (!profileRef) {
+    return;
+  }
+  fetch(`/profiles/details?name=${encodeURIComponent(profileRef)}`)
+    .then((resp) => (resp.ok ? resp.json() : null))
+    .then((data) => {
+      // Ignore a late fetch: a Reset or a newer run has moved on (#312 race guard).
+      if (data == null || token !== timerModeToken || lastScreen !== "running") {
+        return;
+      }
+      setCachedEstimate(data.estimated_completion_seconds);
+      applyTimerMode(cachedEstimateSeconds);
+    })
+    .catch(() => {
+      /* keep the fast-path decision on network error (fall back to stopwatch) */
+    });
+}
+
+// Reset timer to default stopwatch mode (run ended / stopped). Also invalidates the
+// run token so any in-flight beginTimerMode() estimate fetch is ignored (#312).
 function resetTimerMode() {
+  timerModeToken++;
   countdownSeconds = null;
   setTimerLabel(TIMER_LABEL_ELAPSED);
 }

--- a/specs/frontend/spec_countdown_reset_rerun.md
+++ b/specs/frontend/spec_countdown_reset_rerun.md
@@ -1,0 +1,177 @@
+# Frontend / UI Spec: Countdown timer survives Reset + re-run
+
+**Status:** Draft
+**Author:** Jack Hu
+**Last updated:** 2026-07-10
+**GitHub issue:** #312
+**Affected screens:** Run (running state)
+**Source file(s):** `aquila_web/static/script.js`
+**Related:** feature spec `specs/frontend/countdown-timer.md` (#110/#121); interacting change #275 (Reset clears `selected_profile` server-side)
+
+---
+
+## 1. Overview
+
+Bug fix. The countdown timer added in #110/#121 regresses to the stopwatch after a
+run completes, the operator hits **Reset**, and then re-runs the **same** profile.
+The first run correctly shows the **countdown** ("Time Remaining"); the second run
+shows the **stopwatch** ("Elapsed Time") even though the profile still has an estimate.
+
+The fix makes the countdown-vs-stopwatch decision at run start derive from the
+**authoritative active profile**, not from a client-side cache that is only warmed
+by the selection UI event.
+
+No visible design changes. The countdown / stopwatch presentation, the "Finishing
+Run" overlay, and all wording remain exactly as specified in
+`specs/frontend/countdown-timer.md`. This spec only changes *when and how the mode is
+decided*.
+
+---
+
+## 2. Root cause
+
+The mode decision depends entirely on `cachedEstimateSeconds`, which is written
+**only** by `loadProfileLabels()` (`script.js:146`, `:166`). `loadProfileLabels()`
+is called only from selection paths:
+
+- the dropdown `change` handler (`script.js:1394`), and
+- the initial page-load restore (`script.js:1350`).
+
+`beginTimerMode()` blindly trusts that cache on the transition into `running`
+(`script.js:225-231`, called at `script.js:626`). `notifyRun()` re-syncs
+`/profile/select` to the server before running (`script.js:798`) but never refreshes
+the estimate cache.
+
+**Reset clears the profile server-side** (added for #275): Reset →
+`resetRunScreen()` → `POST /run/complete/ack` → `_set_selected_profile(None)`
+(`main.py:895`), persisted to disk. When the profile is subsequently restored from
+server/persisted state (page reload or ready-screen reconciliation) **without going
+back through `loadProfileLabels()`**, `cachedEstimateSeconds` is stale/`null` while
+the profile still looks selected. The next run's `beginTimerMode()` reads `null` and
+falls back to the stopwatch.
+
+The first run works because the operator's manual selection warmed the cache; the
+second run reuses the profile without re-selecting, so the cache is never re-warmed.
+
+---
+
+## 3. Fix
+
+Derive countdown mode at run start from the **authoritative selected profile**, not
+the UI-populated cache.
+
+`beginTimerMode()` becomes authoritative: on the transition into `running` it
+fetches the estimate for the **active run profile** and sets the mode from that.
+
+- The active profile is `activeRunProfileName` — set from the server-authoritative
+  WebSocket panel (`panel.profile_name`, `script.js:617-619`) **before**
+  `beginTimerMode()` is called (`script.js:626`). It is a human-readable display
+  name (`_resolve_profile_display_name`, `main.py:121`), which `/profiles/details`
+  resolves via its `?name=` lookup (`main.py:1831-1844`). That lookup **must be
+  recursive** (`rglob`) — profiles live in `bundled/` and `local/` subdirs, so a
+  non-recursive `glob` 404s every profile looked up by name and the fix silently
+  stays on the stopwatch. See §7.
+- This also covers runs started by the device's **physical button**, which bypass
+  `notifyRun()` entirely.
+
+### 3.1 Behavior
+
+1. **Fast path (no flash).** On entering `running`, apply the mode from
+   `cachedEstimateSeconds` immediately so a warm cache renders the correct label on
+   the first tick with no network round-trip.
+2. **Authoritative path.** Then fetch `/profiles/details?name=<activeRunProfileName>`
+   and re-apply the mode from the returned `estimated_completion_seconds`. This
+   corrects a cold/stale cache (the #312 case) and warms `cachedEstimateSeconds` for
+   the duration of the run.
+3. **Fallback.** If `activeRunProfileName` is empty, or the fetch fails / is not
+   `ok`, keep the fast-path decision (silently fall back to whatever the cache said,
+   i.e. stopwatch when the cache is null) — matching the existing error-state
+   behavior in `specs/frontend/countdown-timer.md` §4.
+4. **Race guard.** The fetch is async and may resolve after the run has already
+   ended or a *different* run has started. Capture a monotonically increasing run
+   token when `beginTimerMode()` is entered; only apply the fetched result if the
+   token still matches the current run **and** the screen is still `running`. This
+   prevents an in-flight fetch from re-enabling countdown mode after Reset or on a
+   subsequent stopwatch-only run.
+
+`resetTimerMode()` (leaving `running`) is unchanged in intent — it still sets
+`countdownSeconds = null` and the label back to "Elapsed Time" — but it also
+invalidates the run token so any in-flight `beginTimerMode()` fetch is ignored.
+
+---
+
+## 4. Data binding (delta from countdown-timer.md §5)
+
+| UI Element | Data Source (was → now) | Update Trigger |
+|------------|--------------------------|----------------|
+| `#run-timer-label` | Presence of `cachedEstimateSeconds` **→** estimate for the **active run profile**, fetched at run start from `/profiles/details?name=<activeRunProfileName>` (cache used only as a fast-path prime) | On entering `running` |
+
+All other rows in `countdown-timer.md` §5 are unchanged.
+
+---
+
+## 5. Acceptance criteria
+
+(From issue #312.)
+
+- [ ] Run a profile with an estimate → countdown ("Time Remaining") shows.
+- [ ] After the run completes, hit **Reset**, run the **same** profile again →
+      countdown **still** shows (not the stopwatch). *(the regression)*
+- [ ] A profile with **no** estimate shows the stopwatch ("Elapsed Time") on both
+      the first and every subsequent run.
+- [ ] An in-flight estimate fetch that resolves after Reset (or after a later
+      stopwatch-only run starts) does **not** flip the timer back to countdown.
+- [ ] Regression coverage exists for the reset → re-run path (not just DOM presence).
+
+---
+
+## 6. Test plan
+
+### 6.1 E2E live-run regression — `tests/e2e/test_countdown_timer.py` (`e2e`)
+
+New Playwright test(s) driving an actual simulated run (backend started with
+`AQ_DEV_SIMULATE=1`, short `AQ_DEV_RUN_DURATION`). The existing tests in this file
+only assert DOM presence (`countdown-timer.md` §9.3); these exercise the live
+reset → re-run flow that #312 regressed.
+
+- **`test_countdown_survives_reset_and_rerun`** — select a profile **with** an
+  estimate; start a run; assert `#run-timer-label` reads **"Time Remaining"**; let
+  it complete; press **Reset**; run the **same** profile again **without** re-opening
+  the dropdown; assert the label **still** reads **"Time Remaining"**. Fails on
+  today's code (shows "Elapsed Time"); passes after the fix.
+- **`test_stopwatch_stays_stopwatch_across_rerun`** — a profile with **no** estimate
+  shows **"Elapsed Time"** on the first and second runs (guards against the fix
+  wrongly forcing countdown mode).
+
+If the live simulate harness is not reachable in CI, the tests `pytest.skip` using
+the same reachability guard as the existing `_goto()` helper, and the flow is added
+to the manual dev checklist in `countdown-timer.md` §9.4.
+
+### 6.2 Manual dev checklist addition (`countdown-timer.md` §9.4)
+
+- [ ] Profile **with** estimate → run → Reset → **re-run same profile** → label
+      **still** reads "Time Remaining" and counts down.
+
+---
+
+## 7. Server-side dependency
+
+The authoritative run-start fetch calls `/profiles/details?name=<activeRunProfileName>`.
+That endpoint's `?name=` branch (`main.py`) must search **recursively** — profiles
+live in `bundled/` and `local/` subdirectories, not at the profiles root. It
+originally used a non-recursive `glob("*.json")`, so any profile looked up by name
+(e.g. **Beer Spoilers - Bacteria** in `bundled/`) returned **404**; the client fetch
+then fell through to its `.catch()` and left the timer on the stopwatch — masking the
+fix entirely. Changed to `rglob("*.json")`, consistent with
+`_resolve_profile_display_name` (`main.py:121`), which produces the very name searched.
+
+Covered by the contract regression `test_profile_details_by_name_resolves_profile_in_subdir`
+(`tests/contract/test_profile_endpoints.py`). Note the e2e tests stub
+`/profiles/details`, so they cannot catch this — the contract test is the guard.
+
+## 8. Out of scope
+
+- No change to the profile editor, the JSON data model, the "Finishing Run" overlay,
+  or the stopwatch/countdown rendering math — all remain as in
+  `specs/frontend/countdown-timer.md`.
+- #275's server-side clearing of `selected_profile` on Reset is intentional and stays.

--- a/tests/contract/test_profile_endpoints.py
+++ b/tests/contract/test_profile_endpoints.py
@@ -104,6 +104,28 @@ def test_profile_details_nonexistent_returns_404(client):
     assert resp.status_code == 404
 
 
+@pytest.mark.contract
+def test_profile_details_by_name_resolves_profile_in_subdir(client):
+    """GET /profiles/details?name=<name> resolves a profile that lives in a
+    subdirectory (local/ or bundled/), not just the profiles root.
+
+    Regression for #312: the countdown race guard re-fetches the active profile's
+    estimate by name at run start (it only has the display name from the WS panel,
+    not the id). Profiles live in bundled/ and local/ subdirs, so a non-recursive
+    lookup 404s and the timer silently stays on the stopwatch.
+    """
+    name = "Name Lookup Subdir"
+    pid = _create_profile(client, name=name, estimated_minutes=45)
+    # a created profile lands under local/ — i.e. a subdirectory of the profiles root
+    assert pid.replace("\\", "/").startswith("local/")
+    try:
+        resp = client.get(f"/profiles/details?name={name}")
+        assert resp.status_code == 200, resp.text
+        assert resp.json()["estimated_completion_seconds"] == 45 * 60
+    finally:
+        _delete_profile(client, pid)
+
+
 # ---------------------------------------------------------------------------
 # POST /profiles/delete
 # ---------------------------------------------------------------------------

--- a/tests/e2e/test_countdown_timer.py
+++ b/tests/e2e/test_countdown_timer.py
@@ -9,7 +9,10 @@ checklist in spec §9.4.
 Requires a running backend at base_url (default http://localhost:8090).
 Run with: pytest -m e2e tests/e2e/test_countdown_timer.py
 """
+import json
+
 import pytest
+from playwright.sync_api import expect
 
 pytestmark = pytest.mark.e2e
 
@@ -20,6 +23,44 @@ def _goto(page, base_url, path):
         page.goto(f"{base_url}{path}", timeout=10_000)
     except Exception as exc:
         pytest.skip(f"Backend not reachable at {base_url}: {exc}")
+
+
+def _route_details(page, *, estimate_seconds, title="Beer Spoilage"):
+    """Stub GET /profiles/details so the active profile reports *estimate_seconds*
+    (or None for no estimate), independent of the selection-warmed client cache."""
+    body = json.dumps(
+        {
+            "id": "beer.json",
+            "title": title,
+            "labels": {},
+            "rox_unavailable": False,
+            "time_unavailable": estimate_seconds is None,
+            "estimated_completion_seconds": estimate_seconds,
+            "steps": [],
+        }
+    )
+    page.route(
+        "**/profiles/details*",
+        lambda route: route.fulfill(
+            status=200, content_type="application/json", body=body
+        ),
+    )
+
+
+def _drive_running(page, *, profile_name="Beer Spoilage", cached_estimate="null"):
+    """Drive the real WebSocket 'running' transition with a cold-or-warm estimate
+    cache, mirroring a reset -> re-run where the selection cache was never re-warmed.
+    Goes through wsHandleMessage() — the same path the live socket uses."""
+    page.evaluate(
+        """([name, cached]) => {
+            cachedEstimateSeconds = cached;   // simulate post-reset cache state
+            lastScreen = 'ready';
+            wsHandleMessage({ data: JSON.stringify({
+                screen: 'running', profile_name: name, elapsed: 1
+            }) });
+        }""",
+        [profile_name, None if cached_estimate == "null" else cached_estimate],
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -41,6 +82,58 @@ def test_timer_label_element_present(page, base_url):
     """The timer label (#run-timer-label) the JS toggles must exist."""
     _goto(page, base_url, "/run")
     assert page.locator("#run-timer-label").count() == 1, "#run-timer-label not found"
+
+
+# ---------------------------------------------------------------------------
+# #312 regression: countdown must survive Reset + re-run (cold estimate cache)
+# ---------------------------------------------------------------------------
+
+def test_countdown_shown_when_cache_cold_but_profile_has_estimate(page, base_url):
+    """#312: after a run completes and Reset clears the selection, re-running the
+    same estimate-bearing profile must STILL show the countdown. The mode is
+    re-derived from the authoritative active profile at run start, not from the
+    selection-only cache (which is cold here)."""
+    _route_details(page, estimate_seconds=3900)
+    _goto(page, base_url, "/run")
+    _drive_running(page, cached_estimate="null")  # cold cache, as after Reset
+    expect(page.locator("#run-timer-label")).to_have_text("Time Remaining")
+
+
+def test_stopwatch_stays_stopwatch_when_profile_has_no_estimate(page, base_url):
+    """A profile with no estimate must keep the stopwatch on every run — the
+    authoritative fetch must not wrongly force countdown mode."""
+    _route_details(page, estimate_seconds=None)
+    _goto(page, base_url, "/run")
+    _drive_running(page, cached_estimate="null")
+    expect(page.locator("#run-timer-label")).to_have_text("Elapsed Time")
+
+
+def test_late_estimate_fetch_after_reset_is_ignored(page, base_url):
+    """#312 race guard: a /profiles/details response that resolves AFTER Reset must
+    not flip the timer back to countdown. The run-start fetch is held pending, Reset
+    happens, then the estimate arrives late — the label must stay on the stopwatch."""
+    pending = []
+    page.route("**/profiles/details*", lambda route: pending.append(route))
+    _goto(page, base_url, "/run")
+    _drive_running(page, cached_estimate="null")  # issues the estimate fetch
+    for _ in range(50):  # wait until the fetch is actually intercepted
+        if pending:
+            break
+        page.wait_for_timeout(50)
+    assert pending, "expected /profiles/details to be requested at run start"
+
+    page.evaluate("() => resetTimerMode()")  # Reset before the estimate resolves
+    expect(page.locator("#run-timer-label")).to_have_text("Elapsed Time")
+
+    pending[0].fulfill(  # the late estimate now arrives — must be ignored
+        status=200,
+        content_type="application/json",
+        body=json.dumps(
+            {"time_unavailable": False, "estimated_completion_seconds": 3900}
+        ),
+    )
+    page.wait_for_timeout(200)
+    expect(page.locator("#run-timer-label")).to_have_text("Elapsed Time")
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## What Changed

Fixes the countdown timer regressing to the stopwatch. The countdown-vs-stopwatch mode is now decided **at run start** from the authoritative active profile, instead of a client-side cache that only the profile-selection UI ever fills.

Closes #312.

## Why

A run with an estimate showed the **countdown** on the first run but flipped to the **stopwatch** on a subsequent run (reported as run → Reset → re-run). Diagnosed live: the deterministic trigger is the Run screen loading **while a run is active** (page reload / kiosk navigation / WS reconnect). `beginTimerMode()` fired on the first `running` tick and read a cold `cachedEstimateSeconds` (only warmed by a UI selection), locking the stopwatch for the whole run.

## Root cause (two layers)

1. **Client** — mode was read from `cachedEstimateSeconds`, never re-derived at run start.
2. **Server** — the intended fix re-fetches the estimate via `/profiles/details?name=<display name>`, but that endpoint's `?name=` lookup used a non-recursive `glob("*.json")` and **404'd every profile in `bundled/` or `local/`** (e.g. *Beer Spoilers - Bacteria*). So the client fetch fell through to its `.catch()` and the timer stayed on the stopwatch — the fix looked implemented but did nothing.

## The fix

- **`script.js`** — `beginTimerMode()` re-derives the mode at run start from `activeRunProfileName` (from the WS panel) via `/profiles/details?name=…`, with a monotonic token so a late fetch after Reset / a newer run is ignored. Selection cache kept only as a no-flash fast path. Also covers physical-button runs that bypass `notifyRun()`.
- **`main.py`** — `/profiles/details` `?name=` lookup: `glob` → **`rglob`**, so bundled/local profiles resolve (consistent with `_resolve_profile_display_name`, which produces the searched name).
- **`run.html`** — bump `script.js?v=68 → v=69` so devices load the new JS.

## Verification

Live, on a server carrying the fix vs. the old one — the exact call the timer makes:

| Server | `/profiles/details?name=Beer Spoilers - Bacteria` |
|---|---|
| **Fixed** | `estimated_completion_seconds=4080, time_unavailable=false` ✅ |
| Old | `404 / null` ❌ |

## Tests

- **Contract (new):** `test_profile_details_by_name_resolves_profile_in_subdir` — resolves a profile in a subdir by name. RED (`404`) before the `rglob` change, GREEN after. This is the real guard; the e2e tests **stub** `/profiles/details`, so they could not catch the 404.
- **E2E (new):** countdown shown on a cold cache, stopwatch stays stopwatch with no estimate, and the late-fetch-after-Reset race guard.
- Full contract + unit run: new test passes; 5 unrelated failures (bundled-profile-presence and device-cert tests) pre-exist on the pristine tree — verified by stash-and-rerun.

## Changes Made

- [x] Source code modified
- [x] Spec added (`specs/frontend/spec_countdown_reset_rerun.md`)
- [x] New tests written
- [x] Existing tests still pass (pre-existing failures unrelated)
- [x] No secrets or `.env` files in this diff

## Hardware Testing

- [x] Tested in simulation mode only — timer/estimate behavior is frontend + HTTP; no hardware path involved.

## Reviewer Notes

The subtle bit: the e2e tests stub `/profiles/details`, which is why the earlier client-only fix passed CI but failed on the device. The contract test closes that gap. The race guard (`timerModeToken`) is what makes a mid-run reload safe — a late estimate response after Reset is dropped rather than flipping the timer back.

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)
