### PR TITLE
Persist the sync outbox so updates don't drop unsynced runs

### DIFF
--- a/fleet-config/docker-compose.yml
+++ b/fleet-config/docker-compose.yml
@@ -28,6 +28,11 @@ services:
       - /opt/aquila/logs:/opt/aquila/logs
       - /opt/aquila/profiles:/opt/aquila/profiles
       - /opt/aquila/config:/opt/aquila/config
+      # Persist the sync outbox (/opt/aquila/data/db/app.db): it queues completed
+      # runs not yet pushed to the cloud. Without a host-backed mount it lives in
+      # the container and every recreate (update / --force-recreate) silently
+      # discards unsynced runs. The on-device schema migrates in place (#305).
+      - /opt/aquila/data:/opt/aquila/data
       # Mount the whole fleet dir (not just .env) so the OTA reboot sentinel
       # /opt/fleet/last_update.json is host-backed and survives the Watchtower
       # container swap. See specs/backend/spec_ota_sentinel_persistent_volume.md.

--- a/tests/fleet_device/test_compose_config.py
+++ b/tests/fleet_device/test_compose_config.py
@@ -148,6 +148,25 @@ class TestFleetCompose:
             f"swap. Mounting only /opt/fleet/.env is not enough. Volumes: {volumes}"
         )
 
+    def test_backend_persists_sync_outbox(self):
+        """
+        The sync outbox (/opt/aquila/data/db/app.db) holds completed runs not yet
+        pushed to the cloud. It must sit on a host-backed bind mount so it
+        survives a container recreate (update / --force-recreate); otherwise
+        every update silently discards unsynced runs.
+
+        enqueue_event + the sync poller live only in the backend (aquila_web), so
+        the backend is the sole owner of the queue and the one to persist it.
+        """
+        backend = _load(FLEET_COMPOSE)["services"]["backend"]
+        volumes = backend.get("volumes", [])
+        targets = [str(v).split(":")[1] for v in volumes if ":" in str(v)]
+        assert "/opt/aquila/data" in targets, (
+            "backend service must bind-mount /opt/aquila/data so the sync outbox "
+            "(app.db) survives container recreation; otherwise unsynced runs are "
+            f"lost on every update. Volumes: {volumes}"
+        )
+
 
 # ---------------------------------------------------------------------------
 # Container DNS resilience (#314): the containers that make outbound calls must


### PR DESCRIPTION
## Problem
The sync outbox — `/opt/aquila/data/db/app.db`, the SQLite queue of completed runs not yet pushed to the cloud — is **not persisted**. `/opt/aquila/data` isn't in the `backend` service's bind mounts, so the db lives *inside* the container and is **destroyed on every recreate**. Since updates now always `--force-recreate` (#317), each update silently discards any runs queued but not yet synced.

**Observed on sn06:** 5 pending `run_complete` events were wiped when the backend container recreated (the on-device `app.db` came back a fresh 0-byte file). Those runs never reached the warehouse.

## Fix
Bind-mount `/opt/aquila/data` into the **backend** service (one line). Ownership verified: `enqueue_event` and the sync poller live only in `aquila_web` (backend); the `app` service routes run data to the backend via `BACKEND_URL`, so there's no second outbox — no split-brain.

The on-device schema already migrates in place (`_add_missing_columns` + `PRAGMA user_version`, #305/#289) — logic that only matters once the db survives across versions, confirming persistence is the intended design.

## Test
`test_backend_persists_sync_outbox` asserts the backend bind-mounts `/opt/aquila/data`. Full suite: 51 passed.

## Note
Existing devices with an unmounted (ephemeral) `app.db` will start persisting once this compose reaches them via a normal `update.sh` (it re-downloads the compose from `main`). Runs already lost to prior recreates can't be recovered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)