### PR TITLE
Add sn06-specific 'sn06 brewery' profile group

### DIFF
--- a/config_files/device_profiles.json
+++ b/config_files/device_profiles.json
@@ -17,7 +17,7 @@
         "profile_group": "duke"
     },
     "sn06": {
-        "profile_group": "breweries",
+        "profile_group": "sn06 brewery",
         "profile_editing_disabled": true
     },
     "sn07": {

--- a/config_files/profile_groups.json
+++ b/config_files/profile_groups.json
@@ -15,5 +15,8 @@
     ],
     "breweries": [
         "Beer_Spoilers_Bacteria.json"
+    ],
+    "sn06 brewery": [
+        "ABBA_ramp1.75_EA30_sn006.json"
     ]
 }

--- a/profiles/bundled/ABBA_ramp1.75_EA30_sn006.json
+++ b/profiles/bundled/ABBA_ramp1.75_EA30_sn006.json
@@ -1,0 +1,89 @@
+{
+"output_dir": "pcr_data",
+"post_in_gui": "True",
+"title": "Beer Spoilers - Bacteria",
+"steps": [
+    {
+        "disable": 0,
+        "duration": 1,
+        "description": "Record equilabrion without power."
+    },
+    {
+        "ramp_rate": 1.6
+    },
+    {  
+        "pcr_fanon" : 1
+    },
+    {
+        "enable": 0, 
+        "duration": 1,
+        "description": "Turn on and record temperature for a little bit"
+    },
+    {
+	"optics":""
+    },
+    {
+        "setpoint": 25,
+        "duration": 1,
+        "description": "Presetting temperature"
+    },
+    {
+        "setpoint": 50,
+        "duration": 120,
+        "description": "50C for 120 seconds"
+    },
+    {
+        "setpoint": 95,
+        "duration": 240,
+        "description": "Denaturation temperature for 4 minute"
+    },
+    {
+        "ramp_rate": 1.75
+    },
+    {
+        "repeat": [
+            {
+                "setpoint": 96.2,
+                "duration": 11,
+                "description": "Melt"
+            },
+	    {
+                "setpoint": 60.5,
+                "duration": 20,
+                "description": "Annealing"
+            },
+	    {
+		"optics":""
+	    },
+	    {
+                "setpoint": 60.5,
+                "duration": 18,
+                "description": "Annealing"
+            }
+        ],
+        "cycles": 40
+    },
+    {
+        "ramp_rate": 1
+    },
+    {
+        "setpoint": 40,
+        "duration": 20,
+        "description": "Initial cooling"
+    },
+    {
+        "setpoint": 25,
+        "duration": 10,
+        "description": "Restoring setpoint to RT"
+    },
+    {
+        "disable": 0,
+        "duration": 5,
+        "description": "Turn off and record temperature for a little bit"
+    },
+
+    { 
+        "pcr_fanoff" : 0
+    }
+]
+}


### PR DESCRIPTION
## Summary
Follow-up to #320 (which merged with only the profile-lock + version bump). This adds the sn06-specific profile that didn't make it into that merge.

- **New profile**: `profiles/bundled/ABBA_ramp1.75_EA30_sn006.json` (display title "Beer Spoilers - Bacteria").
- **New group** in `config_files/profile_groups.json`: `sn06 brewery` → `["ABBA_ramp1.75_EA30_sn006.json"]`.
- **Repoint sn06** in `config_files/device_profiles.json` from `breweries` → `sn06 brewery`.

## Verification
Resolution chain checked: sn06 → group `sn06 brewery` → `ABBA_ramp1.75_EA30_sn006.json` (present in `profiles/bundled/`). Group name matches between `device_profiles.json` and `profile_groups.json` (case-sensitive lookup).

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)