### PR TITLE
feat(aq_curve): emit baseline_rfu per-curve measure (#319)

### DIFF
--- a/aq_curve/evaluator.py
+++ b/aq_curve/evaluator.py
@@ -4,6 +4,7 @@ from aq_curve.pcr_curve_helpers import (
     compute_cq,
     compute_r2,
     count_threshold_crossings,
+    get_baseline_values,
     get_curve_data,
     get_threshold,
     sustained_rise_index,
@@ -626,7 +627,7 @@ def check_biphasic_basics(curve_data, curve):
 
 def evaluate_curve(curve, log_name, dye, well):
     curve_data = get_curve_data(curve, log_name, dye, well)
-    xdata, y_corrected, _ = curve_data
+    xdata, y_corrected, y_raw = curve_data
     tc_passed, metric_rows = _run_check(check_threshold_crossing, curve_data, curve)
     metric_rows.append(
         {"name": "check_threshold_crossing", "value": None, "threshold": None, "passed": tc_passed}
@@ -723,6 +724,11 @@ def evaluate_curve(curve, log_name, dye, well):
         # aborted/truncated read): np.max on an empty array raises and would sink the
         # entire Run's results. An empty curve has no range -> 0.0.
         {"name": "signal_range", "value": (float(np.max(y_corrected)) - float(np.min(y_corrected))) if len(y_corrected) else 0.0, "threshold": None, "passed": None},
+        # The RAW baseline floor (mean fluorescence over the baseline cycles of the
+        # uncorrected curve) -- the level that drifts up as optics age. Feeds the
+        # upstream Baseline Increase metric. Read from y_raw, NOT the baseline-
+        # corrected curve (whose baseline is ~0 by construction). Empty curve -> 0.0.
+        {"name": "baseline_rfu", "value": float(np.mean(get_baseline_values(y_raw, curve.baseline_slice))) if len(y_raw) else 0.0, "threshold": None, "passed": None},
     ])
     # Dedup by name (first wins): a check reused across typical/biphasic emits its
     # value once; a shared measure is not overwritten by a later duplicate.

--- a/tests/unit/test_call_evidence_metrics.py
+++ b/tests/unit/test_call_evidence_metrics.py
@@ -68,6 +68,40 @@ def test_evaluate_curve_emits_checks_values_and_pure_measures(monkeypatch):
         assert by_name[name]["passed"] in (True, False)
 
 
+def test_evaluate_curve_emits_baseline_rfu_as_pure_measure(monkeypatch):
+    # baseline_rfu (the raw baseline floor) feeds the upstream Baseline Increase
+    # metric. It is a pure measure -- a number, with no per-curve pass/fail (the
+    # 10%/20% banding lives in the acorn-analytics view, not on the device).
+    monkeypatch.setattr(evaluator, "get_curve_data", lambda *a: _sigmoid())
+
+    ev = evaluate_curve(Curve(), "log", "fam", 1)
+    by_name = {m["name"]: m for m in ev["metrics"]}
+
+    assert "baseline_rfu" in by_name
+    assert by_name["baseline_rfu"]["threshold"] is None
+    assert by_name["baseline_rfu"]["passed"] is None
+
+
+def test_baseline_rfu_reports_the_raw_floor_not_the_corrected_baseline(monkeypatch):
+    # The raw curve sits on a 500-count floor; baseline correction flattens that
+    # region to ~0. baseline_rfu must report the RAW floor (the drift signal),
+    # NOT the corrected ~0 -- otherwise the upstream % -increase metric never moves.
+    xdata = np.arange(1, 41)
+    sig = 100.0 / (1.0 + np.exp(-(xdata - 20) / 2.0))
+    y_corrected = sig - sig[5:15].mean()          # baseline slice (5,15) -> mean 0
+    floor = 500.0
+    y_raw = y_corrected + floor
+    monkeypatch.setattr(evaluator, "get_curve_data", lambda *a: (xdata, y_corrected, y_raw))
+
+    ev = evaluate_curve(Curve(), "log", "fam", 1)
+    by_name = {m["name"]: m for m in ev["metrics"]}
+
+    # Curve default baseline_slice = (5, 15); value is the mean raw fluorescence there.
+    assert by_name["baseline_rfu"]["value"] == pytest.approx(float(np.mean(y_raw[5:15])))
+    # And it clearly reflects the raw floor (~500), not the corrected ~0.
+    assert by_name["baseline_rfu"]["value"] == pytest.approx(floor, abs=1.0)
+
+
 def test_failing_curve_still_logs_its_check_values(monkeypatch):
     # Pure noise, no amplification -> Checks fail, but the numbers are still computed
     # (baseline std/slope are computed before the pass/fail).
@@ -96,6 +130,8 @@ def test_empty_curve_emits_zero_signal_range_without_crashing(monkeypatch):
 
     assert by_name["signal_range"]["value"] == 0.0
     assert by_name["n_cycles"]["value"] == 0.0
+    # baseline_rfu over an empty raw curve has no floor -> 0.0 (np.mean([]) is nan).
+    assert by_name["baseline_rfu"]["value"] == 0.0
 
 
 def test_results_to_json_evidence_records_carry_the_metrics(tmp_path, monkeypatch):


### PR DESCRIPTION
Closes #319.

## What
`evaluate_curve` already computes the curve's baseline mean internally but discards it. This emits it as a **pure measure** (`baseline_rfu`) so it flows through the existing `call_evidence` pipeline into `fact_call_evidence_metric` — the raw input for the upstream **Baseline 10% Aggregate Increase** fleet metric (acorn-analytics view + acorn-internal-app Metrics page).

## Correction to the issue premise
The issue said to emit "the `baseline_mean` the evaluator already computes." That value is over the baseline-**corrected** curve (~0, never drifts), so it would make a useless metric. `baseline_rfu` is instead the mean of the **raw** fluorescence (`y_raw`) over `curve.baseline_slice` — the raw floor that rises as optics age. Confirmed with the owner before implementing.

## Details
- Pure measure: `threshold`/`passed` are `null` (the 10%/20% banding lives upstream in the analytics view, not on the device).
- Empty curve → `0.0`, mirroring the existing `signal_range` guard (ROX Unavailable / truncated reads).

## Tests (TDD)
- emits a `baseline_rfu` pure-measure row
- value = raw baseline floor, **not** the corrected ~0 (guards the correction above)
- empty curve → `0.0`

`tests/unit`: 399 passed, 1 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)