### PR TITLE
fix(tests): repair pre-existing unit-suite failures

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -8,6 +8,40 @@ from pathlib import Path
 import pytest
 from fastapi.testclient import TestClient
 
+# config_module.Config() resolves this machine's device identity from
+# DEVICE_HOSTNAME (falling back to socket.gethostname()) against
+# config_files/host_config.json, which only knows real devices (sn01-sn03). On a
+# dev machine or CI the hostname is not a device, so any module that constructs
+# Config() at import time (e.g. aq_lib.state_requests) fails to import -- breaking
+# collection outright, or failing at runtime depending on sys.modules caching.
+# Pin a canonical test device so those imports resolve on any machine. setdefault
+# keeps a real device's / CI's own identity; tests that exercise hostname
+# behaviour still override this per-test via monkeypatch.setenv. Set before any
+# test module is imported for collection.
+os.environ.setdefault("DEVICE_HOSTNAME", "sn01")
+
+def pytest_collection_modifyitems(config, items):
+    """Auto-skip @pytest.mark.hardware tests when real Pi hardware is absent.
+
+    pytest.ini documents the `hardware` marker as "requires real Pi hardware --
+    skipped in CI", but nothing enforced that skip, so those tests failed on a dev
+    machine at `import RPi.GPIO`. Skip them when RPi.GPIO can't be imported (i.e.
+    off-device); on a Pi they run as before.
+    """
+    try:
+        import RPi.GPIO  # noqa: F401
+        return  # real hardware present -- run them
+    except Exception:
+        skip_hardware = pytest.mark.skip(reason="requires real Pi hardware (RPi.GPIO unavailable)")
+        for item in items:
+            # Match the explicit @pytest.mark.hardware marker only -- NOT
+            # item.keywords, which also contains parent names (e.g. the
+            # `hardware/` directory) and would skip the mocked hardware tests
+            # under it that run fine off-device.
+            if item.get_closest_marker("hardware") is not None:
+                item.add_marker(skip_hardware)
+
+
 # Path to fixtures directory
 FIXTURES_DIR = Path(__file__).parent / "fixtures"
 

--- a/tests/unit/config/test_config_loading.py
+++ b/tests/unit/config/test_config_loading.py
@@ -11,13 +11,18 @@ from pathlib import Path
 
 import pytest
 
-# serial is a C-extension that may not be present in every CI environment.
-# Mock it before importing config_module so collection never fails due to
-# a missing pyserial wheel.
+# serial (pyserial) is a C-extension that may not be present in every CI
+# environment. Prefer the REAL module; only fall back to a stub when pyserial is
+# genuinely missing. The old guard (`if "serial" not in sys.modules`) stubbed on
+# every fresh session -- even with pyserial installed -- and that incomplete stub
+# (no `Serial` class) leaked into sys.modules for the whole run, breaking any
+# later test that does `from serial import Serial` (e.g. meerstetter).
 import sys
 import types
 
-if "serial" not in sys.modules:
+try:
+    import serial  # noqa: F401  (real pyserial, when installed)
+except ImportError:
     _serial_stub = types.ModuleType("serial")
     _serial_tools = types.ModuleType("serial.tools")
     _list_ports_mod = types.ModuleType("serial.tools.list_ports")

--- a/tests/unit/test_wifi_helpers.py
+++ b/tests/unit/test_wifi_helpers.py
@@ -228,6 +228,7 @@ class TestWifiConnect:
         side_effects = self._no_profiles() + [
             _nmcli_result(0, ""),  # connection add
             _nmcli_result(0, ""),  # connection up
+            _nmcli_result(0, ""),  # connection modify (clear pinned BSSID)
         ]
         with patch.object(kc, "_nmcli", side_effect=side_effects) as mock_nmcli:
             kc._wifi_connect("HomeNet", "secret")
@@ -242,25 +243,34 @@ class TestWifiConnect:
         side_effects = self._no_profiles() + [
             _nmcli_result(0, ""),  # connection add
             _nmcli_result(0, ""),  # connection up
+            _nmcli_result(0, ""),  # connection modify (clear pinned BSSID)
         ]
         with patch.object(kc, "_nmcli", side_effect=side_effects) as mock_nmcli:
             kc._wifi_connect("HomeNet", "secret")
         calls = [c[0] for c in mock_nmcli.call_args_list]
         assert not any(c[:3] == ("device", "wifi", "connect") for c in calls)
 
-    def test_connect_without_password_uses_device_wifi_connect(self):
+    def test_connect_without_password_creates_explicit_open_profile(self):
+        # Open networks use an explicit `connection add` + `up` (same as the
+        # passworded path, minus the wpa-psk secrets), NOT `device wifi connect` --
+        # the latter can auto-create a profile pinned to a stale BSSID (see the
+        # _wifi_connect docstring), which is exactly what this path avoids.
         side_effects = self._no_profiles() + [
-            _nmcli_result(0, ""),  # device wifi connect
+            _nmcli_result(0, ""),  # connection add
+            _nmcli_result(0, ""),  # connection up
+            _nmcli_result(0, ""),  # connection modify (clear pinned BSSID)
         ]
         with patch.object(kc, "_nmcli", side_effect=side_effects) as mock_nmcli:
             kc._wifi_connect("OpenNet", "")
         calls = [c[0] for c in mock_nmcli.call_args_list]
-        assert any(c[:3] == ("device", "wifi", "connect") for c in calls)
+        assert any(c[:2] == ("connection", "add") for c in calls)
+        assert not any(c[:3] == ("device", "wifi", "connect") for c in calls)
 
     def test_returns_ok_true_on_success(self):
         side_effects = self._no_profiles() + [
             _nmcli_result(0, ""),  # connection add
             _nmcli_result(0, ""),  # connection up
+            _nmcli_result(0, ""),  # connection modify (clear pinned BSSID)
         ]
         with patch.object(kc, "_nmcli", side_effect=side_effects):
             result = kc._wifi_connect("HomeNet", "secret")
@@ -293,6 +303,7 @@ class TestWifiConnect:
             _nmcli_result(0, ""),                         # delete stale profile
             _nmcli_result(0, ""),                         # connection add
             _nmcli_result(0, ""),                         # connection up
+            _nmcli_result(0, ""),                         # connection modify (clear pinned BSSID)
         ]
         with patch.object(kc, "_nmcli", side_effect=side_effects) as mock_nmcli:
             result = kc._wifi_connect("HomeNet", "newpass")


### PR DESCRIPTION
Pre-existing breakage in the unit suite, unrelated to any feature — running the full `tests/unit` went from **10 failed + 2 collection errors** to **399 passed, 1 skipped**.

## Root causes & fixes
- **wifi (5 tests):** `_wifi_connect` was refactored — it drops `nmcli device wifi connect` (which can auto-create a profile pinned to a stale BSSID) in favour of an explicit `connection add` + `up`, then a trailing `connection modify … 802-11-wireless.bssid ""`. The mocked `_nmcli` side-effect sequences were stale (ran out on the extra call), and one test asserted the removed `device wifi connect`. Updated the sequences and rewrote the open-network test to current behaviour.
- **Config hostname (4 event tests + `test_state_request` collection):** `Config()` resolves a device identity from `DEVICE_HOSTNAME`/`gethostname()` against `host_config.json` (real devices only). On a dev machine / CI that import fails — at collection (top-level import) or at runtime (flaky via `sys.modules` caching). Pin a canonical test device: `os.environ.setdefault("DEVICE_HOSTNAME", "sn01")` in the root conftest, before collection. Per-test `monkeypatch.setenv` still overrides it (e.g. the unknown-host test).
- **`serial` stub leak (`test_meer_log_stop` collection):** `test_config_loading` installed an **incomplete** `serial` stub (no `Serial` class) into `sys.modules` on every fresh session, shadowing real pyserial for the whole run. Now it stubs only when pyserial is **genuinely absent** (its own stated intent).
- **hardware skip (`test_lid_worker_instrumentation`):** `@pytest.mark.hardware` tests need real `RPi.GPIO`; pytest.ini documents them as "skipped in CI" but nothing enforced it. Added a conftest hook that skips them when `RPi.GPIO` is unavailable — matched on the **marker** (not `item.keywords`, which also contains the `hardware/` directory name and would wrongly skip the 76 mocked hardware tests under it).

🤖 Generated with [Claude Code](https://claude.com/claude-code)