### PR TITLE
feat(deploy): add sandbox ring below dev

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -6,7 +6,7 @@ on:
   workflow_dispatch:
     inputs:
       ring_tag:
-        description: Optional ring tag to publish (dev/pilot/prod)
+        description: Optional ring tag to publish (sandbox/dev/pilot/prod)
         required: false
         type: string
 

--- a/.github/workflows/promote-images.yml
+++ b/.github/workflows/promote-images.yml
@@ -8,7 +8,7 @@ on:
         required: true
         type: string
       target_tag:
-        description: Target ring tag (dev/pilot/prod)
+        description: Target ring tag (sandbox/dev/pilot/prod)
         required: true
         type: string
 

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -12,6 +12,14 @@ A single physical Aquilla PCR instrument — a Raspberry Pi running the Aquilla 
 **Fleet**
 The collection of all deployed Sentri units. Analytics queries span the fleet; device-level queries scope to a single Sentri. There is one prod fleet; there is no separate physical "dev fleet."
 
+**Ring**
+A deployment tier a Sentri belongs to, selected by the `IMAGE_TAG` in its `device.env` and rolled out via Watchtower pulling the matching GHCR image tag. Every ring uses the identical mechanism (image tag + Watchtower); rings differ only in audience and update cadence. Ordered lowest-to-highest, promotion flows **sandbox → dev → pilot → prod**:
+- **sandbox** — throwaway / breakable units (bench, local compose); experiment freely, nothing here is relied on.
+- **dev** — in-house Sentri products in real daily use by the team; must work, but eat updates first.
+- **pilot** — the soak/hold gate: promote here, then let it bake before customers ("stop pushing" ring).
+- **prod** — customer devices; full rollout.
+See `docs/deployment/ring_rollout.md`; promotion is manual via the `promote-images` workflow (ADR-002).
+
 **Sentri Analytics Platform** _(being split — see ADR-015)_
 Historically "the separate system (repo `Acorn/sentri-analytics`) that owns cloud ingest and the analytics/query surface over Aurora." Under the six-repository split (`sentri-analytics/specs/six-repo-architecture.md`, ADR-015) this single "platform" is **decomposed**, so prefer the specific repo:
 - **`acorn-analytics`** — owns cloud **ingest** (the serverless Lambda pipeline) and the **analytics warehouse**. This is what the device POSTs to.

--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ Hardware-only behavior that cannot be tested in CI should be documented with `@p
 ## Deployment Scripts
 - Base setup: `deployment1.sh`
 - Fleet setup: `scripts/setup_fleet_device.sh`
-- Ring helpers: `scripts/setup/device_dev.sh`, `scripts/setup/device_pilot.sh`, `scripts/setup/device_prod.sh`
+- Ring helpers: `scripts/setup/device_sandbox.sh`, `scripts/setup/device_dev.sh`, `scripts/setup/device_pilot.sh`, `scripts/setup/device_prod.sh`
 
 ## Device Enrollment (Device Certificate)
 

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,5 +1,5 @@
 # NOTE: This file is NOT used in any deployment.
-# All devices (dev, pilot, prod) download and run fleet-config/docker-compose.yml
+# All devices (sandbox, dev, pilot, prod) download and run fleet-config/docker-compose.yml
 # via deployment2.sh. This file is a legacy leftover and can be ignored.
 
 services:

--- a/docs/deployment/ab-deployment.md
+++ b/docs/deployment/ab-deployment.md
@@ -291,7 +291,7 @@ KIOSK_CONTROL_URL=http://host.docker.internal:9191
 - [ ] Create `docker/docker-compose.proxy.yml` (aquila-proxy)
 - [ ] Create `docker/nginx.proxy-a.conf` and `docker/nginx.proxy-b.conf`
 - [ ] Initialize state files: `active_slot=A`, `current_good_api_tag`, `current_good_ui_tag`
-- [ ] Update `scripts/setup/device_prod.sh` (and dev/pilot) to write initial `active_slot=A`
+- [ ] Update `scripts/setup/device_prod.sh` (and sandbox/dev/pilot) to write initial `active_slot=A`
 
 ### Phase 2 — Scripts
 

--- a/docs/deployment/full_setup.md
+++ b/docs/deployment/full_setup.md
@@ -23,7 +23,7 @@ scripts/setup_fleet_device.sh
 Edit `/opt/aquila/config/device.env`:
 
 - `DEVICE_ID=...`
-- `IMAGE_TAG=dev|pilot|prod`
+- `IMAGE_TAG=sandbox|dev|pilot|prod`
 - `WATCHTOWER_HTTP_API_TOKEN=...` (or keep the generated one)
 - `GHCR_USERNAME=...`
 - `GHCR_TOKEN=...`

--- a/docs/deployment/ring_rollout.md
+++ b/docs/deployment/ring_rollout.md
@@ -1,17 +1,21 @@
-# Ring Rollout Guide (dev / pilot / prod)
+# Ring Rollout Guide (sandbox / dev / pilot / prod)
 
 This guide explains how ring tags work and how to promote images safely.
 
 ## Rings
 
-- `dev`: internal devices (fastest updates)
-- `pilot`: near‑prod devices (small rollout)
+Promotion flows lowest-to-highest: `sandbox` → `dev` → `pilot` → `prod`.
+
+- `sandbox`: throwaway / breakable units (bench, local compose) — experiment freely
+- `dev`: in-house devices in real daily use (must work, but eat updates first)
+- `pilot`: soak/hold gate — promote here, then let it bake before customers
 - `prod`: customer devices (full rollout)
 
 Devices pick a ring with `IMAGE_TAG` in their env file:
 
 ```bash
-IMAGE_TAG=dev
+IMAGE_TAG=sandbox
+# or IMAGE_TAG=dev
 # or IMAGE_TAG=pilot
 # or IMAGE_TAG=prod
 ```
@@ -19,7 +23,7 @@ IMAGE_TAG=dev
 ## How Updates Flow
 
 1. Push to `main` → CI builds `:latest` + `:<sha>`
-2. Manually tag a ring (`dev`, `pilot`, or `prod`)
+2. Manually tag a ring (`sandbox`, `dev`, `pilot`, or `prod`)
 3. Devices on that ring pull the new tag (Watchtower or manual `pull`)
 
 ## Build and Tag Images
@@ -28,6 +32,7 @@ IMAGE_TAG=dev
 
 Run the GitHub Action **build-and-push-images** and set `ring_tag`:
 
+- `ring_tag=sandbox` → publishes `:sandbox`
 - `ring_tag=dev` → publishes `:dev`
 - `ring_tag=pilot` → publishes `:pilot`
 - `ring_tag=prod` → publishes `:prod`
@@ -37,7 +42,7 @@ Run the GitHub Action **build-and-push-images** and set `ring_tag`:
 Run **promote-images** with:
 
 - `source_tag=<sha>`
-- `target_tag=dev|pilot|prod`
+- `target_tag=sandbox|dev|pilot|prod`
 
 This retags the existing image without rebuilding.
 
@@ -59,6 +64,7 @@ DEVICE_ID=pi-001
 You can use the helper scripts under `scripts/setup/` to stamp the ring and
 device metadata after running the fleet setup:
 
+- `scripts/setup/device_sandbox.sh`
 - `scripts/setup/device_dev.sh`
 - `scripts/setup/device_pilot.sh`
 - `scripts/setup/device_prod.sh`

--- a/docs/deployment2_plan.md
+++ b/docs/deployment2_plan.md
@@ -146,7 +146,7 @@ Each phase asks for what it needs, when it needs it. Example flow:
 
 ```
 [Phase 8] Enter device hostname (e.g. sn04): _
-[Phase 8] Enter IMAGE_TAG (dev/pilot/prod): _
+[Phase 8] Enter IMAGE_TAG (sandbox/dev/pilot/prod): _
 [Phase 8] Enter lid heater upper bound voltage (e.g. 0.34): _
 [Phase 8] Enter lid heater lower bound voltage (e.g. 0.20): _
 [Phase 8] Enter drawer read_steps for this device (e.g. 160): _
@@ -426,7 +426,7 @@ mkdir -p /opt/fleet
 
 Prompts for device-specific values at this point:
 - `DEVICE_HOSTNAME` — device serial (e.g. `sn04`)
-- `IMAGE_TAG` — release ring (`dev`/`pilot`/`prod`)
+- `IMAGE_TAG` — release ring (`sandbox`/`dev`/`pilot`/`prod`)
 - `LID_HEATER_UPPER_BOUND` — voltage upper bound (e.g. `0.34`)
 - `LID_HEATER_LOWER_BOUND` — voltage lower bound (e.g. `0.20`)
 - `DRAWER_READ_STEPS` — drawer close distance in steps, varies per physical device (e.g. `160`)
@@ -600,7 +600,7 @@ print("Meerstetter tuning applied")
 PY
 ```
 
-Watchtower will watch the running containers and automatically pull new images for the same tag (dev/pilot/prod) whenever they are pushed to GHCR.
+Watchtower will watch the running containers and automatically pull new images for the same tag (sandbox/dev/pilot/prod) whenever they are pushed to GHCR.
 
 #### Verification (runs automatically at end of phase)
 > Full test definitions: [deployment2_tests.md — Phase 11](deployment2_tests.md#phase-11--fleet-device-configuration)

--- a/docs/deployment2_tests.md
+++ b/docs/deployment2_tests.md
@@ -187,7 +187,7 @@ Pass = `✓`, Fail = `✗` with reason. A failed test stops the script.
 | Test | Command | Pass Condition |
 |---|---|---|
 | DEVICE_ID set in device.env | `grep -q "DEVICE_ID=" /opt/aquila/config/device.env` | exits 0 |
-| IMAGE_TAG is valid ring | `grep -E "IMAGE_TAG=(dev\|pilot\|prod)" /opt/aquila/config/device.env` | exits 0 |
+| IMAGE_TAG is valid ring | `grep -E "IMAGE_TAG=(sandbox\|dev\|pilot\|prod)" /opt/aquila/config/device.env` | exits 0 |
 | aquila-backend running | `docker ps --filter name=aquila-backend --format '{{.Status}}' \| grep -q Up` | exits 0 |
 | aquila-app running | `docker ps --filter name=aquila-app --format '{{.Status}}' \| grep -q Up` | exits 0 |
 | aquila-ui running | `docker ps --filter name=aquila-ui --format '{{.Status}}' \| grep -q Up` | exits 0 |

--- a/fleet-config/README.md
+++ b/fleet-config/README.md
@@ -11,7 +11,7 @@ templates intended to live on each device (or in a fleet-config repo).
 4. On each device, edit `/opt/aquila/config/device.env` with:
    - `DEVICE_ID`
    - `RUN_MODE`
-   - `IMAGE_TAG` (`dev`, `pilot`, or `prod`)
+   - `IMAGE_TAG` (`sandbox`, `dev`, `pilot`, or `prod`)
    - `WATCHTOWER_HTTP_API_TOKEN`
    - `GHCR_USERNAME`
    - `GHCR_TOKEN`
@@ -38,6 +38,7 @@ envsubst < /opt/fleet/vector.yaml.template > /opt/fleet/vector.yaml
 
 Optional: use the helper scripts to stamp the ring on a device after setup:
 
+- `scripts/setup/device_sandbox.sh`
 - `scripts/setup/device_dev.sh`
 - `scripts/setup/device_pilot.sh`
 - `scripts/setup/device_prod.sh`
@@ -54,7 +55,7 @@ docker compose --env-file /opt/aquila/config/device.env -f /opt/fleet/docker-com
 
 Use the GitHub Actions workflows:
 
-- `build-and-push-images`: optional `ring_tag` input to publish `dev/pilot/prod`
+- `build-and-push-images`: optional `ring_tag` input to publish `sandbox/dev/pilot/prod`
 - `promote-images`: retag `source_tag` to `target_tag`
 
 ## Watchtower API Example

--- a/scripts/deploy/deployment2.sh
+++ b/scripts/deploy/deployment2.sh
@@ -329,7 +329,7 @@ phase_pass "all persistent directories created"
 phase_start 8 "Device Identity and Config Files"
 
 prompt_if_unset DEVICE_HOSTNAME "Enter device hostname (e.g. sn04)"
-prompt_if_unset IMAGE_TAG       "Enter IMAGE_TAG (dev/pilot/prod)"
+prompt_if_unset IMAGE_TAG       "Enter IMAGE_TAG (sandbox/dev/pilot/prod)"
 prompt_if_unset GHCR_USER       "Enter GHCR username"
 prompt_if_unset GHCR_TOKEN      "Enter GHCR personal access token"
 # Optional: second token for zero-downtime rotation (leave blank to skip)
@@ -886,7 +886,7 @@ fi
 WATCHTOWER_TOKEN=$(grep WATCHTOWER_HTTP_API_TOKEN /opt/aquila/config/device.env | cut -d= -f2)
 
 run_test "DEVICE_ID set"            "grep -q 'DEVICE_ID=' /opt/aquila/config/device.env"
-run_test "IMAGE_TAG is valid ring"   "grep -E 'IMAGE_TAG=(dev|pilot|prod)' /opt/aquila/config/device.env"
+run_test "IMAGE_TAG is valid ring"   "grep -E 'IMAGE_TAG=(sandbox|dev|pilot|prod)' /opt/aquila/config/device.env"
 run_test "aquila-backend running"    \
     "docker ps --filter name=aquila-backend --format '{{.Status}}' | grep -q Up"
 run_test "aquila-app running"        \

--- a/scripts/deploy/deployment2_verify.sh
+++ b/scripts/deploy/deployment2_verify.sh
@@ -132,7 +132,7 @@ test_phase_11() {
     local token
     token=$(grep WATCHTOWER_HTTP_API_TOKEN /opt/aquila/config/device.env | cut -d= -f2)
     check 11 "DEVICE_ID set"             "grep -q 'DEVICE_ID=' /opt/aquila/config/device.env"
-    check 11 "IMAGE_TAG is valid ring"   "grep -E 'IMAGE_TAG=(dev|pilot|prod)' /opt/aquila/config/device.env"
+    check 11 "IMAGE_TAG is valid ring"   "grep -E 'IMAGE_TAG=(sandbox|dev|pilot|prod)' /opt/aquila/config/device.env"
     check 11 "aquila-backend running"    \
         "docker ps --filter name=aquila-backend --format '{{.Status}}' | grep -q Up"
     check 11 "aquila-app running"        \

--- a/scripts/setup/device_sandbox.sh
+++ b/scripts/setup/device_sandbox.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+DEVICE_ID="${DEVICE_ID:-sandbox-000}"
+WATCHTOWER_HTTP_API_TOKEN="${WATCHTOWER_HTTP_API_TOKEN:-REPLACE_WATCHTOWER_TOKEN}"
+GHCR_USERNAME="${GHCR_USERNAME:-REPLACE_GHCR_USERNAME}"
+GHCR_TOKEN="${GHCR_TOKEN:-REPLACE_GHCR_TOKEN}"
+IMAGE_TAG="sandbox"
+
+bash "$(dirname "$0")/../setup_fleet_device.sh"
+
+sudo tee /opt/aquila/config/device.env >/dev/null <<EOF
+DEVICE_ID=${DEVICE_ID}
+RUN_MODE=prod
+IMAGE_TAG=${IMAGE_TAG}
+WATCHTOWER_HTTP_API_TOKEN=${WATCHTOWER_HTTP_API_TOKEN}
+GHCR_USERNAME=${GHCR_USERNAME}
+GHCR_TOKEN=${GHCR_TOKEN}
+EOF
+sudo chown root:root /opt/aquila/config/device.env
+sudo chmod 600 /opt/aquila/config/device.env
+
+sudo docker compose --env-file /opt/aquila/config/device.env -f /opt/fleet/docker-compose.yml up -d
+
+echo "Configured device.env with IMAGE_TAG=${IMAGE_TAG}."


### PR DESCRIPTION
## What

Adds a new **lowest** deployment ring, `sandbox`, ahead of `dev` in the hierarchy:

```
sandbox → dev → pilot → prod
```

`sandbox` is a **mechanical copy** of the existing ring pattern (a GHCR image tag pulled by Watchtower) — no new behavior, no auto-publish. Real disposable hardware joins it via `IMAGE_TAG=sandbox`, exactly like every other ring.

## Why

So in-house devices in real daily use can live on `dev` (must work, but eat updates first) while throwaway/bench units sit on `sandbox`. `pilot` remains the soak/hold gate before customer `prod`.

## Changes

- **`scripts/setup/device_sandbox.sh`** — literal copy of `device_dev.sh`; only `IMAGE_TAG=sandbox` and default `DEVICE_ID=sandbox-000` differ.
- **CI** — `build-and-push-images` (`ring_tag`) and `promote-images` (`target_tag`) input descriptions now list `sandbox`.
- **Validators** — `deployment2.sh` and `deployment2_verify.sh` "IMAGE_TAG is valid ring" regex now accepts `sandbox` (would otherwise **reject** a sandbox device at verify time).
- **Docs** — `ring_rollout.md`, `fleet-config/README.md`, `README.md`, `full_setup.md`, `deployment2_plan.md`, `deployment2_tests.md`, and the legacy compose header.
- **`CONTEXT.md`** — adds a **Ring** glossary term (the concept had no canonical definition before): the four-ring hierarchy, the shared tag+Watchtower mechanism, and each ring's audience.

## Notes

- The fleet compose files are ring-agnostic (`${IMAGE_TAG}`), so no change needed there.
- No ADR: mechanically cloning a ring isn't hard-to-reverse or a real trade-off; rings are documented in `ring_rollout.md` + ADR-002.

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)