### PR TITLE
fix(aq_curve): emit None, not 0.0, for an empty curve's baseline_rfu

### DIFF
--- a/aq_curve/evaluator.py
+++ b/aq_curve/evaluator.py
@@ -727,8 +727,11 @@ def evaluate_curve(curve, log_name, dye, well):
         # The RAW baseline floor (mean fluorescence over the baseline cycles of the
         # uncorrected curve) -- the level that drifts up as optics age. Feeds the
         # upstream Baseline Increase metric. Read from y_raw, NOT the baseline-
-        # corrected curve (whose baseline is ~0 by construction). Empty curve -> 0.0.
-        {"name": "baseline_rfu", "value": float(np.mean(get_baseline_values(y_raw, curve.baseline_slice))) if len(y_raw) else 0.0, "threshold": None, "passed": None},
+        # corrected curve (whose baseline is ~0 by construction). An empty curve's
+        # baseline is UNKNOWN, not 0: emit None (like cq), never 0.0. A 0 gets pooled
+        # into the upstream all-time-median reference and drags it to 0, which NULLs
+        # out the increase for every real run on the device (#319 follow-up).
+        {"name": "baseline_rfu", "value": float(np.mean(get_baseline_values(y_raw, curve.baseline_slice))) if len(y_raw) else None, "threshold": None, "passed": None},
     ])
     # Dedup by name (first wins): a check reused across typical/biphasic emits its
     # value once; a shared measure is not overwritten by a later duplicate.

--- a/tests/unit/test_call_evidence_metrics.py
+++ b/tests/unit/test_call_evidence_metrics.py
@@ -130,8 +130,11 @@ def test_empty_curve_emits_zero_signal_range_without_crashing(monkeypatch):
 
     assert by_name["signal_range"]["value"] == 0.0
     assert by_name["n_cycles"]["value"] == 0.0
-    # baseline_rfu over an empty raw curve has no floor -> 0.0 (np.mean([]) is nan).
-    assert by_name["baseline_rfu"]["value"] == 0.0
+    # baseline_rfu over an empty raw curve is UNKNOWN, not 0: emit None (like cq).
+    # A 0 would pool into the upstream all-time-median reference and drag it to 0,
+    # NULLing out the increase for every real run on the device (#319 follow-up).
+    assert by_name["baseline_rfu"]["value"] is None
+    assert by_name["cq"]["value"] is None
 
 
 def test_results_to_json_evidence_records_carry_the_metrics(tmp_path, monkeypatch):


### PR DESCRIPTION
## Problem

`evaluate_curve` emits `baseline_rfu = 0.0` for an empty raw curve (an empty/aborted or truncated read), mirroring how `signal_range` handles the empty case. For `signal_range` a 0 is harmless. For `baseline_rfu` it is not: the measure feeds the upstream **Baseline Increase** metric as a **median reference** over a device×channel's prior runs. A few `0` values drag that median to 0, and the view's divide-by-zero guard (`reference = 0 ⇒ NULL`) then NULLs out the increase for **every real run on the device**.

Observed on sn03 (`100000002be4e16a`): three empty runs emitted `baseline_rfu = 0`, which zeroed the reference and hid its two genuine runs — the Baseline Aggregate Increase page showed nothing despite real data.

## Fix

An empty curve's baseline is **unknown, not zero** — emit `None`, exactly like `cq` already does for an undetectable curve. The upstream view filters `value IS NOT NULL`, so a NULL self-excludes from the reference and never pollutes it.

```python
{"name": "baseline_rfu", "value": ...get_baseline_values(y_raw...)... if len(y_raw) else None, ...}
```

## Test

The existing empty-curve test now asserts `baseline_rfu is None` (alongside `cq is None`). `tests/unit/test_call_evidence_metrics.py` — **7 passed**.

## Related

Warehouse-side counterpart (belt-and-suspenders; needs no device deploy): acorn-analytics PR #80 excludes `baseline_rfu <= 0` in `v_baseline_increase_run`. Either fix alone makes the metric correct. This device fix prevents future empty runs from re-introducing the `0` sentinel at the source.

🤖 Generated with [Claude Code](https://claude.com/claude-code)