### PR TITLE
fix(run): start next run on a single Run press after completion (#333)

### DIFF
--- a/application.py
+++ b/application.py
@@ -12,10 +12,14 @@ logger = logging.getLogger( "aquila_app" )
 def main():
     try:
         ai = AssayInterface()
+        run_armed = False
         while True:
-            ai.ready()
+            # When end() already armed a run from the results screen (#333),
+            # skip ready() so the operator's single Run press starts it.
+            if not run_armed:
+                ai.ready()
             ai.run()
-            ai.end()
+            run_armed = ai.end()
     except Exception as e:
         print("Exception caught in execution of application")
         print ( e )

--- a/state_run_assay.py
+++ b/state_run_assay.py
@@ -357,17 +357,28 @@ class AssayInterface():
 
     def end( self ):
         #End of run
+        # Returns True if the operator armed another run from the results
+        # screen (issue #333), so the caller can start it directly instead of
+        # falling back to ready() — which would silently eat the first press.
         if self.run_aborted:
             self.run_aborted = False
             sr.timer_control( "stop" )
             sr.timer_control( "reset" )
             sr.change_screen("1")
-            return
+            return False
         sr.timer_control( "stop" )
         time.sleep(2)
         sr.timer_control( "reset" )
         sr.change_screen("3")
-        self.button_logic( state = "end" ) 
+        profile, run_name = self.button_logic( state = "end" )
+        if profile is not None:
+            # Run pressed on the results screen: arm the next run here,
+            # mirroring ready() (self.run_name / self.thermal_profile), so the
+            # single press that got us out of button_logic actually runs.
+            self.run_name = run_name
+            self.thermal_profile = ("profiles/" + profile)
+            return True
+        return False
 
     def _monitor_stop_request(self, stop_event: Event, stop_monitor_event: Event) -> None:
         while not stop_monitor_event.is_set() and not stop_event.is_set():

--- a/unit_tests/test_run_button_double_press.py
+++ b/unit_tests/test_run_button_double_press.py
@@ -1,0 +1,142 @@
+"""
+Regression test for issue #333: the Run button had to be pressed twice to start
+a new run after a completed run.
+
+The bug lived in ``application.main()``'s ``ready -> run -> end`` loop. When the
+operator pressed Run on the results screen, ``end()`` captured the selected
+profile but the caller discarded it and unconditionally looped back to
+``ready()`` -- which then waited for a *second* press. The fix makes ``end()``
+return ``True`` when it arms a run from the results screen, and the loop skips
+``ready()`` in that case so the single press actually starts the run.
+
+These tests drive the REAL ``application.main()`` loop with a fake
+``AssayInterface``, so no Pi hardware is required. The full on-device behaviour
+(results screen "3" -> running screen "2" on a single tap, reusing the last
+profile) is a hardware-path check -- see the ``@pytest.mark.hardware`` note at
+the bottom of this module.
+
+``end()``'s own arm-decision (``profile is not None`` -> set run_name /
+thermal_profile -> return True) cannot be unit-imported on a dev machine because
+``state_run_assay`` runs GPIO/I2C calls at import time; it is exercised on
+hardware and asserted here at the loop contract level (True -> skip ready).
+"""
+import sys
+import types
+from pathlib import Path
+
+import pytest
+
+pytestmark = pytest.mark.unit
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(REPO_ROOT))
+
+# application.py imports AssayInterface (state_run_assay) and sr
+# (aq_lib.state_requests) at module load, both of which pull in the Pi hardware
+# stack, and it calls logging.config.dictConfig(APP_LOGGING_CONFIG) at import.
+# Replace those collaborators with lightweight stubs BEFORE importing
+# application so the pure loop logic can run on a dev machine / CI. This mirrors
+# the RPi/serial stubbing used by the other unit-test modules.
+_aq_pkg = types.ModuleType("aq_lib")
+_aq_pkg.__path__ = []
+sys.modules.setdefault("aq_lib", _aq_pkg)
+
+_sra = types.ModuleType("state_run_assay")
+_sra.AssayInterface = object  # replaced per-test via monkeypatch
+sys.modules["state_run_assay"] = _sra
+
+_cfg = types.ModuleType("aq_lib.config_module")
+_cfg.Config = object
+sys.modules["aq_lib.config_module"] = _cfg
+
+_utils = types.ModuleType("aq_lib.utils")
+_utils.APP_LOGGING_CONFIG = {"version": 1}
+sys.modules["aq_lib.utils"] = _utils
+
+_srq = types.ModuleType("aq_lib.state_requests")
+_srq.change_screen = lambda *a, **k: None
+sys.modules["aq_lib.state_requests"] = _srq
+
+import application  # noqa: E402  (import after stubs are installed)
+
+
+class _StopLoop(Exception):
+    """Sentinel to break application.main()'s ``while True`` loop.
+
+    main() wraps the loop in ``except Exception``, so raising this from a fake
+    call unwinds the loop and returns cleanly -- the test then asserts on the
+    recorded call order.
+    """
+
+
+class FakeAssayInterface:
+    """Records ready/run/end call order and replays scripted end() returns.
+
+    ``end_script`` is the sequence of values ``end()`` returns (mimicking "Run
+    pressed on results screen with a profile" -> True, anything else -> False).
+    The loop is stopped the ``stop_on_ready_call``-th time ``ready()`` is
+    invoked, giving each test a deterministic, finite call trace.
+    """
+
+    def __init__(self, end_script, stop_on_ready_call):
+        self.calls = []
+        self._end_script = list(end_script)
+        self._ready_calls = 0
+        self._stop_on_ready_call = stop_on_ready_call
+
+    def ready(self):
+        self._ready_calls += 1
+        self.calls.append("ready")
+        if self._ready_calls >= self._stop_on_ready_call:
+            raise _StopLoop
+
+    def run(self):
+        self.calls.append("run")
+
+    def end(self):
+        self.calls.append("end")
+        return self._end_script.pop(0) if self._end_script else False
+
+
+def _drive_main(monkeypatch, fake):
+    monkeypatch.setattr(application, "AssayInterface", lambda: fake)
+    application.main()  # loop unwinds when the fake raises _StopLoop
+    return fake.calls
+
+
+def test_run_armed_from_results_screen_skips_ready(monkeypatch):
+    """A run armed by end() (Run pressed on results screen) starts on ONE press.
+
+    end() returns True after the first completed run, so the loop must go
+    straight to run() without a ready() in between. This is the regression the
+    fix targets: before the fix the loop always re-entered ready() here, which
+    is what forced the second press.
+    """
+    fake = FakeAssayInterface(end_script=[True, False], stop_on_ready_call=2)
+    calls = _drive_main(monkeypatch, fake)
+
+    # ready, run, end(->True), [NO ready], run, end(->False), ready(stop)
+    assert calls == ["ready", "run", "end", "run", "end", "ready"]
+    # The load-bearing assertion: no ready() was inserted after the armed end().
+    assert calls[2:4] == ["end", "run"]
+
+
+def test_end_not_arming_falls_back_to_ready(monkeypatch):
+    """When end() returns False (abort / no profile), the loop re-enters ready().
+
+    This is the correct behaviour for a completed run the operator did NOT
+    immediately re-launch, and for the aborted-run path where end() returns
+    False early.
+    """
+    fake = FakeAssayInterface(end_script=[False], stop_on_ready_call=2)
+    calls = _drive_main(monkeypatch, fake)
+
+    # ready, run, end(->False), ready(stop) -- a fresh press is awaited in ready.
+    assert calls == ["ready", "run", "end", "ready"]
+
+
+# NOTE (@pytest.mark.hardware): the end-to-end single-press behaviour on the
+# device -- pressing Run on results screen "3" transitions directly to running
+# screen "2" and reuses the last-selected profile -- exercises state_run_assay's
+# real GPIO/motor/state-request stack and cannot run in CI. Validate on the Pi:
+# complete a run, press Run once, confirm it starts without a second press.


### PR DESCRIPTION
Fixes #333

## Problem

After a run finished, pressing **Run** on the results screen only cleared the result circles; the run started only on a **second** press.

The state machine consumed the first press as a `complete → ready` transition and discarded the profile `end()` had captured, so `application.main()` fell back to `ready()` and waited for another press.

## Root cause

A run executes off `self.thermal_profile` / `self.run_name`, which are only ever set in `ready()`. On the results screen, `end()` called `button_logic("end")` — which detected the press and returned `(profile, run_name)` — but discarded the return, so the next run was never armed. The loop then went `end → ready` (never `end → run`), and `wait_for_button` had already cleared `run_requested`, so `ready()` sat waiting for a fresh press.

## Fix

- `end()` now catches `button_logic("end")`'s return; when a run is armed from the results screen it sets `self.run_name` / `self.thermal_profile` (mirroring `ready()`) and returns `True`. Aborted-run and no-profile paths return `False`.
- `application.main()` skips `ready()` when `end()` armed a run, so the single press starts it (reusing the last-selected profile).

Both halves are required: arming without skipping `ready()` still lands on a re-waiting ready screen; skipping `ready()` without arming would run a stale/empty profile.

## Tests

- `unit_tests/test_run_button_double_press.py` drives the real `application.main()` loop with a fake `AssayInterface` (no hardware). Verified to **fail** against the pre-fix loop, so it's a genuine regression guard.
- Full collectable unit suite passes locally.

## On-device validation

Verified on real hardware (Pi, `sn07`) by overlaying the version-matched files into the `aquila-app` container: after a completed run, a **single** Run press on the results screen starts the next run. Also confirmed the results screen (State 3) still holds until acknowledged — no skip, no regression to the completion flow. Device restored to stock afterward.

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)
