### PR TITLE
Add per-device ABBA brewery profiles for sn04 and sn05

### DIFF
--- a/config_files/device_profiles.json
+++ b/config_files/device_profiles.json
@@ -10,11 +10,11 @@
         "profile_editing_disabled": true
     },
     "sn04": {
-        "profile_group": "breweries",
+        "profile_group": "sn04 brewery",
         "profile_editing_disabled": true
     },
     "sn05": {
-        "profile_group": "duke"
+        "profile_group": "sn05 brewery"
     },
     "sn06": {
         "profile_group": "sn06 brewery",

--- a/config_files/profile_groups.json
+++ b/config_files/profile_groups.json
@@ -16,7 +16,18 @@
     "breweries": [
         "Beer_Spoilers_Bacteria.json"
     ],
+    "sn04 brewery": [
+        "ABBA_sn004.json"
+        ],
+    "sn05 brewery": [
+        "ABBA_sn005.json",
+        "O157__ESBL_full.json",
+        "ryan_thermal_tests.json",
+        "STEC_and_EPEC_Hygiena1.75_no37Cstep.json",
+        "verification_profile.json"
+    ],
     "sn06 brewery": [
         "ABBA_ramp1.75_EA30_sn006.json"
     ]
+    
 }

--- a/profiles/bundled/ABBA_sn004.json
+++ b/profiles/bundled/ABBA_sn004.json
@@ -1,0 +1,91 @@
+{
+"output_dir": "pcr_data",
+"post_in_gui": "True",
+"title": "Beer Spoilers - Bacteria",
+"time_unavailable": false,
+"estimated_completion_seconds": 4080,
+"steps": [
+    {
+        "disable": 0,
+        "duration": 1,
+        "description": "Record equilabrion without power."
+    },
+    {
+        "ramp_rate": 1.6
+    },
+    {  
+        "pcr_fanon" : 1
+    },
+    {
+        "enable": 0, 
+        "duration": 1,
+        "description": "Turn on and record temperature for a little bit"
+    },
+    {
+	"optics":""
+    },
+    {
+        "setpoint": 25,
+        "duration": 1,
+        "description": "Presetting temperature"
+    },
+    {
+        "setpoint": 50,
+        "duration": 120,
+        "description": "50C for 120 seconds"
+    },
+    {
+        "setpoint": 95,
+        "duration": 240,
+        "description": "Denaturation temperature for 4 minute"
+    },
+    {
+        "ramp_rate": 1.75
+    },
+    {
+        "repeat": [
+            {
+                "setpoint": 96.5,
+                "duration": 9,
+                "description": "Melt"
+            },
+	    {
+                "setpoint": 60.5,
+                "duration": 20,
+                "description": "Annealing"
+            },
+	    {
+		"optics":""
+	    },
+	    {
+                "setpoint": 60.5,
+                "duration": 18,
+                "description": "Annealing"
+            }
+        ],
+        "cycles": 40
+    },
+    {
+        "ramp_rate": 1
+    },
+    {
+        "setpoint": 40,
+        "duration": 20,
+        "description": "Initial cooling"
+    },
+    {
+        "setpoint": 25,
+        "duration": 10,
+        "description": "Restoring setpoint to RT"
+    },
+    {
+        "disable": 0,
+        "duration": 5,
+        "description": "Turn off and record temperature for a little bit"
+    },
+
+    { 
+        "pcr_fanoff" : 0
+    }
+]
+}

--- a/profiles/bundled/ABBA_sn005.json
+++ b/profiles/bundled/ABBA_sn005.json
@@ -1,0 +1,91 @@
+{
+"output_dir": "pcr_data",
+"post_in_gui": "True",
+"title": "Beer Spoilers - Bacteria",
+"time_unavailable": false,
+"estimated_completion_seconds": 4080,
+"steps": [
+    {
+        "disable": 0,
+        "duration": 1,
+        "description": "Record equilabrion without power."
+    },
+    {
+        "ramp_rate": 1.6
+    },
+    {  
+        "pcr_fanon" : 1
+    },
+    {
+        "enable": 0, 
+        "duration": 1,
+        "description": "Turn on and record temperature for a little bit"
+    },
+    {
+	"optics":""
+    },
+    {
+        "setpoint": 25,
+        "duration": 1,
+        "description": "Presetting temperature"
+    },
+    {
+        "setpoint": 50,
+        "duration": 120,
+        "description": "50C for 120 seconds"
+    },
+    {
+        "setpoint": 94,
+        "duration": 240,
+        "description": "Denaturation temperature for 4 minute"
+    },
+    {
+        "ramp_rate": 1.75
+    },
+    {
+        "repeat": [
+            {
+                "setpoint": 95.5,
+                "duration": 9,
+                "description": "Melt"
+            },
+	    {
+                "setpoint": 60.5,
+                "duration": 20,
+                "description": "Annealing"
+            },
+	    {
+		"optics":""
+	    },
+	    {
+                "setpoint": 60.5,
+                "duration": 18,
+                "description": "Annealing"
+            }
+        ],
+        "cycles": 40
+    },
+    {
+        "ramp_rate": 1
+    },
+    {
+        "setpoint": 40,
+        "duration": 20,
+        "description": "Initial cooling"
+    },
+    {
+        "setpoint": 25,
+        "duration": 10,
+        "description": "Restoring setpoint to RT"
+    },
+    {
+        "disable": 0,
+        "duration": 5,
+        "description": "Turn off and record temperature for a little bit"
+    },
+
+    { 
+        "pcr_fanoff" : 0
+    }
+]
+}


### PR DESCRIPTION
Gives sn04 and sn05 their own ABBA profiles.

## Changes
- Add `profiles/bundled/ABBA_sn004.json` and `ABBA_sn005.json`
- Add `"sn04 brewery"` and `"sn05 brewery"` groups in `config_files/profile_groups.json`
- Repoint devices in `config_files/device_profiles.json`:
  - `sn04`: `"breweries"` → `"sn04 brewery"`
  - `sn05`: `"duke"` → `"sn05 brewery"`

## Why
The new groups had been added but no device referenced them, so they were orphaned — sn04/sn05 never actually served their own ABBA profile. This repoints both devices at their dedicated groups.

Validated: all files are valid JSON and every profile filename referenced by the groups exists in `profiles/bundled/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)