### PR TITLE
Suppress fabricated PCR positives: clamp negative baseline slope + flag rapid rise after cycle 35

### DIFF
--- a/aq_curve/curve.py
+++ b/aq_curve/curve.py
@@ -237,6 +237,17 @@ class Curve:
             # Fallback to original fit if too few points remain
             filtered_coeffs = coeffs
 
+        # Guardrail: never allow a downward-tilting baseline. A negative-slope
+        # baseline is the ONLY way linear correction can manufacture a rising
+        # curve from a flat/decaying raw signal — extrapolated past the fit
+        # window it sinks below a stationary signal and fabricates fake
+        # amplification (e.g. a bright photobleaching well read as Detected).
+        # Clamping to a flat baseline anchored at the window mean lets
+        # correction remove offset but never invent a rise; it can only ever
+        # lower an apparent signal, so it cannot create a false positive.
+        if filtered_coeffs[0] < 0:
+            filtered_coeffs = numpy.array([0.0, float(numpy.mean(ydata[start:end]))])
+
         return filtered_coeffs
 
     @staticmethod

--- a/aq_curve/evaluator.py
+++ b/aq_curve/evaluator.py
@@ -294,7 +294,7 @@ def check_no_rapid_terminal_rise(curve_data, curve):
     left AND covers more than PCR_RAPID_RISE_FRACTION of the total signal range
     in the first three post-rise cycles is an unphysiologically fast artifact.
     """
-    _, y_corrected, _ = curve_data
+    xdata, y_corrected, _ = curve_data
     threshold, _ = get_threshold(y_corrected, curve.baseline_slice)
     min_consecutive = config.get_int("PCR_SUSTAINED_CYCLES")
     rise_idx = sustained_rise_index(y_corrected, threshold, min_consecutive)
@@ -304,7 +304,14 @@ def check_no_rapid_terminal_rise(curve_data, curve):
     n = len(y_corrected)
     cycles_remaining = n - rise_idx
     max_remaining = config.get_int("PCR_RAPID_RISE_MAX_REMAINING")
-    if cycles_remaining >= max_remaining:
+    onset_cycle = float(xdata[rise_idx]) if rise_idx < len(xdata) else float(n)
+    late_cycle = config.get_float("PCR_RAPID_RISE_LATE_CYCLE")
+    # A rise is "terminal" if it starts in the last few cycles OR its onset is
+    # after the late-cycle cutoff (35). The cycles-remaining test alone lets a
+    # steep rise that starts exactly at cycle 36 (5 cycles left) slip through as
+    # non-terminal; anchoring to the absolute cycle catches any rapid rise that
+    # first emerges after cycle 35.
+    if cycles_remaining >= max_remaining and onset_cycle <= late_cycle:
         return True
 
     signal_range = float(np.max(y_corrected)) - float(np.min(y_corrected))

--- a/aq_curve/pcr_curve_config.py
+++ b/aq_curve/pcr_curve_config.py
@@ -29,6 +29,10 @@ DEFAULTS = {
     "PCR_MIN_ABS_SIGNAL": 0.25,
     "PCR_RAPID_RISE_MAX_REMAINING": 5,
     "PCR_RAPID_RISE_FRACTION": 0.65,
+    # A sustained rise that first emerges AFTER this cycle is treated as a
+    # terminal rise regardless of how many cycles remain: genuine amplification
+    # does not first appear this late, so a rapid rise past it is an artifact.
+    "PCR_RAPID_RISE_LATE_CYCLE": 35,
     "PCR_MIN_FOLD": 0.015,
     "PCR_MIN_PEAK_FRACTION": 0.35,
     "PCR_MIN_RISE_CYCLES": 3,

--- a/aquila_web/static/help.html
+++ b/aquila_web/static/help.html
@@ -278,7 +278,7 @@
 
         <!-- Footer -->
         <div class="help-footer" style="padding-bottom:16px;">
-          <span class="help-footer__meta" id="help-version-info">V 2.0.0.2</span>
+          <span class="help-footer__meta" id="help-version-info">V 2.1.0.3</span>
           <button class="help-exit-btn" onclick="notifyExitForce()">Exit GUI</button>
         </div>
 

--- a/aquila_web/static/settings.html
+++ b/aquila_web/static/settings.html
@@ -227,7 +227,7 @@
         </div><!-- /.help-scroll -->
 
         <div class="help-footer" style="padding-bottom:16px;">
-          <span class="help-footer__meta" id="settings-version-info">V 2.0.0.2</span>
+          <span class="help-footer__meta" id="settings-version-info">V 2.1.0.3</span>
           <button class="help-exit-btn" onclick="notifyExitForce()">Exit GUI</button>
         </div>
 

--- a/tests/unit/analysis/test_curve_analysis.py
+++ b/tests/unit/analysis/test_curve_analysis.py
@@ -258,3 +258,50 @@ def test_unknown_evaluate_status_gives_inconclusive(tmp_path, monkeypatch):
     for row_key in ("1", "2"):
         for col_key in ("1", "2", "3", "4"):
             assert data[row_key][col_key] == "Inconclusive"
+
+
+# ---------------------------------------------------------------------------
+# baseline() slope clamp — a downward baseline may never be produced, because
+# a negative-slope baseline is what fabricates fake amplification out of a flat
+# photobleaching signal (see run7 tube 4).
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_baseline_negative_slope_is_clamped_to_flat():
+    """A raw signal that decays over the baseline window must yield a flat
+    (zero-slope) baseline anchored at the window mean, not a downward line."""
+    curve = Curve(src_basedir=str(OPTICS_LOG.parent))
+    x = np.arange(1, 41, dtype=float)
+    y = 10.0 - 0.1 * x  # strictly decreasing -> negative fitted slope
+    start, end = curve.baseline_slice
+    slope, intercept = curve.baseline(x, y)
+    assert slope == 0.0
+    assert intercept == pytest.approx(float(np.mean(y[start:end])))
+
+
+@pytest.mark.unit
+def test_baseline_positive_slope_is_untouched():
+    """A genuinely rising baseline window keeps its fitted slope — the clamp
+    only removes downward tilt, so real positives are unaffected."""
+    curve = Curve(src_basedir=str(OPTICS_LOG.parent))
+    x = np.arange(1, 41, dtype=float)
+    y = 5.0 + 0.02 * x  # positive slope
+    slope, _ = curve.baseline(x, y)
+    assert slope > 0.0
+
+
+@pytest.mark.unit
+def test_baseline_clamp_kills_photobleach_artifact():
+    """Decay-then-flat trace (bleaching well, no real amplification): after the
+    clamp the baseline-corrected endpoint must not be a positive rise."""
+    curve = Curve(src_basedir=str(OPTICS_LOG.parent))
+    x = np.arange(1, 41, dtype=float)
+    # steep early decay that flattens by ~cycle 17, then dead flat (the run7
+    # tube-4 shape). Without the clamp the extrapolated line manufactures a
+    # large positive endpoint (~+1.7); with it the endpoint stays <= threshold.
+    y = np.concatenate([7.4 - 0.1 * np.arange(16), np.full(24, 5.9)])
+    slope, intercept = curve.baseline(x, y)
+    corrected_end = y[-1] - slope * x[-1] - intercept
+    assert slope == 0.0
+    assert corrected_end <= 0.2  # no fabricated amplification above threshold

--- a/tests/unit/analysis/test_rapid_terminal_rise.py
+++ b/tests/unit/analysis/test_rapid_terminal_rise.py
@@ -108,6 +108,32 @@ def test_rapid_terminal_rise_fails_when_covers_full_range():
 # Edge cases
 # ---------------------------------------------------------------------------
 
+# ---------------------------------------------------------------------------
+# Fails: rapid rise whose onset is after cycle 35 (absolute late-cycle cutoff),
+# even with exactly PCR_RAPID_RISE_MAX_REMAINING cycles left.
+# ---------------------------------------------------------------------------
+
+def test_rapid_rise_onset_after_cycle_35_fails():
+    """A steep rise starting at cycle 36 (index 35, 5 cycles remaining) is a
+    terminal artifact: the cycles-remaining test alone would pass it, but the
+    absolute cycle-35 cutoff flags it as rapid."""
+    baseline = [0.0] * 35
+    tail = [0.2, 0.6, 1.0, 1.0, 1.0]  # onset at cycle 36, jumps most of range in 3
+    y = baseline + tail  # 40 cycles
+    # remaining = 5 (== max_remaining, would early-pass), but onset cycle 36 > 35
+    # so steepness is evaluated: fraction = (1.0-0.2)/1.0 = 0.8 > 0.65 → fails
+    assert check_no_rapid_terminal_rise(_cd(y), _make_curve()) is False
+
+
+def test_gradual_rise_after_cycle_35_still_passes():
+    """A slow rise emerging after cycle 35 is a late-Cq signal, not rapid —
+    the cutoff only fails it when the rise is also steep."""
+    baseline = [0.0] * 35
+    gradual = [0.1, 0.2, 0.35, 0.55, 0.80]  # onset cycle 36 but shallow
+    y = baseline + gradual
+    assert check_no_rapid_terminal_rise(_cd(y), _make_curve()) is True
+
+
 def test_no_rise_passes():
     """Flat noise with no sustained rise passes the check."""
     y = [0.0 + 0.01 * np.sin(i) for i in range(40)]


### PR DESCRIPTION
Two independent guardrails against false-positive PCR calls seen on `logs/optics/run7_2026-07-20_15-03-13.log` (tube 4).

## 1. Clamp baseline slope to zero

Tube 4 (brightest optical channel → most photobleaching) has a raw signal that decays for ~17 cycles then goes dead flat (~0.05 RFU wander). The fixed baseline window (cycles 5–15) lands mid-decay, so the linear fit gets a steep **negative slope**; extrapolated to cycle 40 it sinks below the now-flat signal, and `corrected = raw − baseline` grows every cycle into a ~1.7 RFU fake sigmoid → false Detected.

**Fix** (`Curve.baseline()`): if the fitted slope is negative, clamp to a flat baseline anchored at the window mean.

```python
if filtered_coeffs[0] < 0:
    filtered_coeffs = numpy.array([0.0, float(numpy.mean(ydata[start:end]))])
```

A downward baseline is the only way linear correction can invent a rise from a flat signal, so this **cannot create a false positive**. The `(5, 15)` window is unchanged.

### run7 results

| tube | FAM | ROX |
|---|---|---|
| 1 | Detected (Cq 17.2) | Detected (Cq 17.6) |
| 2 | Not Detected | Not Detected |
| 3 | Detected (Cq 22.1) | Not Detected |
| **4** | **Not Detected** ✅ | **Not Detected** ✅ |

Both artifacts flip to Not Detected; all real positives keep their calls and Cq.

## 2. Flag rapid rise after cycle 35

`check_no_rapid_terminal_rise` anchored "terminal" only on cycles-remaining (`< PCR_RAPID_RISE_MAX_REMAINING = 5`), so a steep rise starting exactly at cycle 36 (5 cycles left) passed as non-terminal and could be Detected. Genuine amplification does not first emerge that late.

**Fix**: add `PCR_RAPID_RISE_LATE_CYCLE = 35`. A sustained rise whose onset is after cycle 35 is evaluated for rapidness regardless of cycles remaining — a steep post-35 rise is flagged (→ undetected); a shallow late-Cq rise still passes, so real late positives are unaffected.

## Tests

- `test_curve_analysis.py`: 3 new baseline-clamp tests.
- `test_rapid_terminal_rise.py`: 2 new after-35 tests (steep post-35 fails, gradual post-35 passes).
- Full regression `pytest tests/pcr_curve tests/unit/analysis unit_tests`: **172 passed, 112 skipped, 0 failed.**

## Caveat / follow-up

Both changes trade a little sensitivity to weak/late true positives for immunity to these artifacts. All run7 positives are strong, so unaffected — validate against known weak-positive runs before relying on it. Principled follow-up for #1 is an adaptive settled-window baseline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)