### PR TITLE
fix(sync): a NaN metric can't wedge the outbox (coerce non-finite floats to null before POST)

### DIFF
--- a/aquila_web/sync.py
+++ b/aquila_web/sync.py
@@ -1,5 +1,6 @@
 import base64
 import binascii
+import math
 import os
 import logging
 from typing import Any
@@ -136,10 +137,30 @@ def _chunk_events(event: dict, cap: int, device_id: str | None) -> list[dict] | 
     return chunks
 
 
+def _json_safe(value: Any) -> Any:
+    """Recursively replace non-finite floats (NaN, +/-Infinity) with None.
+
+    JSON has no NaN/Infinity token, so a single non-finite value -- e.g. a
+    per-Well metric like a fold-change over a zero baseline, or a Ct that never
+    crossed -- makes the batch fail to serialize (InvalidJSONError). Left
+    unguarded that poisons the oldest batch and wedges the entire outbox
+    indefinitely, since the same event is retried at the front every flush. A
+    non-finite number carries no value a consumer can use, so null is its
+    faithful representation and the run still reaches the warehouse.
+    """
+    if isinstance(value, float):
+        return value if math.isfinite(value) else None
+    if isinstance(value, dict):
+        return {key: _json_safe(item) for key, item in value.items()}
+    if isinstance(value, list):
+        return [_json_safe(item) for item in value]
+    return value
+
+
 def _post_batch(endpoint: str, body: dict[str, Any], cert, timeout: int) -> bool:
     """POST one batch; True on success, False on network error (caller retries)."""
     try:
-        response = requests.post(endpoint, json=body, cert=cert, timeout=timeout)
+        response = requests.post(endpoint, json=_json_safe(body), cert=cert, timeout=timeout)
         response.raise_for_status()
         return True
     except requests.exceptions.RequestException as exc:

--- a/tests/unit/test_background_sync.py
+++ b/tests/unit/test_background_sync.py
@@ -184,6 +184,81 @@ class TestSyncFlushEndpoint:
         assert len(local_db.get_pending_events()) == 1
 
 
+class TestNonFiniteFloats:
+    """A NaN/Infinity metric must not wedge the outbox. JSON has no NaN token, so
+    a single non-finite value (e.g. a fold-change over a zero baseline) otherwise
+    raises InvalidJSONError on serialize, fails the whole batch, and blocks every
+    event behind it indefinitely. Such values POST as null and the run still flows."""
+
+    def _seed_nan_event(self, local_db):
+        # A call_evidence event whose per-Well metrics came out non-finite.
+        local_db.enqueue_event(
+            "call_evidence",
+            {"evidence": [{"metrics": [
+                {"name": "fold_change", "value": float("nan")},
+                {"name": "ct", "value": float("inf")},
+                {"name": "baseline_sd", "value": float("-inf")},
+                {"name": "delta", "value": 0.8},
+            ]}]},
+        )
+
+    def test_non_finite_metrics_post_as_null_and_the_batch_syncs(self, db_client, tmp_path, monkeypatch):
+        client, local_db = db_client
+        self._seed_nan_event(local_db)
+        monkeypatch.setenv("AQ_SYNC_ENDPOINT", "http://fake-aws/ingest")
+
+        captured = {}
+
+        class _OK:
+            status_code = 200
+            def raise_for_status(self): pass
+
+        def _capture(*a, **kw):
+            captured.update(kw)
+            return _OK()
+
+        monkeypatch.setattr("aquila_web.sync.requests.post", _capture)
+        response = client.post("/sync/flush")
+
+        # The poisoned event no longer blocks the flush.
+        assert response.json()["synced"] == 1
+        metrics = captured["json"]["events"][0]["payload"]["evidence"][0]["metrics"]
+        by_name = {m["name"]: m["value"] for m in metrics}
+        assert by_name["fold_change"] is None   # NaN -> null
+        assert by_name["ct"] is None            # Infinity -> null
+        assert by_name["baseline_sd"] is None   # -Infinity -> null
+        assert by_name["delta"] == 0.8          # finite values pass through untouched
+
+    def test_poison_event_does_not_block_healthy_events_behind_it(self, db_client, tmp_path, monkeypatch):
+        import json as _json
+        import requests as _requests
+
+        client, local_db = db_client
+        self._seed_nan_event(local_db)                                  # id 1: poisoned
+        local_db.enqueue_event("run_complete", {"run_name": "Run 2"})   # id 2: healthy
+        monkeypatch.setenv("AQ_SYNC_ENDPOINT", "http://fake-aws/ingest")
+
+        class _OK:
+            status_code = 200
+            def raise_for_status(self): pass
+
+        # Faithful to on-device requests: json= is strictly serialized, and a
+        # non-finite float raises InvalidJSONError (a RequestException) rather
+        # than emitting an illegal `NaN` token. This is the wedge we're fixing.
+        def _strict_post(*a, **kw):
+            try:
+                _json.dumps(kw["json"], allow_nan=False)
+            except ValueError as exc:
+                raise _requests.exceptions.InvalidJSONError(exc)
+            return _OK()
+
+        monkeypatch.setattr("aquila_web.sync.requests.post", _strict_post)
+        response = client.post("/sync/flush")
+
+        assert response.json()["synced"] == 2
+        assert local_db.get_pending_events() == []
+
+
 class TestMaxMessageBytesValidation:
     """AQ_SYNC_MAX_MESSAGE_BYTES is validated so a misconfigured value can't
     crash the flush or drive the cap negative and mass-quarantine every event."""


### PR DESCRIPTION
## Problem

sn05 and sn08 stopped landing runs in the app on **2026-07-15**. Diagnosis: not endpoint/cert/connectivity — those are all healthy (correct `ingest.cloud.acorngenetics.com/ingest`, valid certs, manual mTLS POST returns 202). The outbox was **wedged**.

A handful of `call_evidence` events carry a **non-finite float** (`NaN`/`Infinity`) at `.evidence[].metrics[].value` — a per-Well qPCR metric that came out non-finite (e.g. a fold-change over a zero baseline, or a Ct that never crossed). JSON has no `NaN`/`Infinity` token, so when the poller serializes the batch, `requests` raises `InvalidJSONError: Out of range float values are not JSON compliant`. `_post_batch` catches it, returns `False`, and the flush aborts with **0 synced**.

Because the poisoned events sit at the **front** of the queue, every 15-min retry re-hits the same wall. On sn08, **4 poison-pill events blocked all 68 pending events** — including every `run_complete`/`optics_readings` record the app needs. The size-guard quarantine doesn't catch this: it's a *serialization* failure, not an oversize one, so it slips past `partition_oversized` before any of that logic runs.

## Fix

`_json_safe()` recursively replaces non-finite floats with `null` on the **outbound copy** in `_post_batch` — the single POST choke point, covering both normal and split-chunk batches. A non-finite number carries no value a consumer can use, so `null` is its faithful representation and the run still reaches the warehouse.

No stored payloads are mutated — sanitization happens at send time, so **deploying this flushes each device's existing backlog on the next sync** (ingest is idempotent: deterministic run_id + `ON CONFLICT DO NOTHING`). Events are well within the 30-day outbox retention.

## Tests (TDD)

`tests/unit/test_background_sync.py::TestNonFiniteFloats`:
- `test_non_finite_metrics_post_as_null_and_the_batch_syncs` — NaN/±Inf metrics POST as `null`, finite values pass through untouched, batch syncs.
- `test_poison_event_does_not_block_healthy_events_behind_it` — with a **faithful strict-serializing** mock (reproduces the real `InvalidJSONError`), a poisoned event no longer blocks a healthy `run_complete` behind it; both drain.

Both were RED before the fix (the second reproduced the exact on-device log line), GREEN after. Full sync suite: 30 passed.

## Deploy note

Recall Watchtower on these Pis is HTTP-API-only (no cron), so publishing the image won't auto-deploy — sn05/sn08 will need the image pull triggered + `aquila-backend` force-recreated. Once they run this build, the backlog flushes itself.

🤖 Generated with [Claude Code](https://claude.com/claude-code)