### PR TITLE
fix(sync): wire homing-log parser into the sync cycle (Homing Misses metric empty) + unlock sn03 profile editing

### DIFF
--- a/aquila_web/main.py
+++ b/aquila_web/main.py
@@ -2279,13 +2279,33 @@ async def _background_update_poller() -> None:
 _SYNC_INTERVAL_SECONDS = int(os.getenv("AQ_SYNC_INTERVAL_SECONDS", "900"))
 
 
+def _import_homing_samples_safely() -> None:
+    """Load Homing Samples from the on-device homing log into the outbox before a
+    flush (ADR-021, issue #326). motor_class writes Samples to a dedicated homing
+    log but never enqueues them; the backend owns the outbox, so the import runs
+    here on the sync cadence. A parse failure must never block the flush of other
+    Events, so it is logged and swallowed -- the Samples retry next cycle."""
+    from aquila_web.homing_parser import import_homing_samples
+    from aq_lib.homing_log import DEFAULT_LOG_DIR
+    log_dir = os.getenv("AQ_HOMING_LOG_DIR", DEFAULT_LOG_DIR)
+    try:
+        imported = import_homing_samples(log_dir)
+        if imported:
+            logger.info("Imported %d Homing Sample(s) into the outbox", imported)
+    except Exception as exc:  # noqa: BLE001 - never block the flush on homing import
+        logger.warning("Homing import failed (will retry next cycle): %s", exc)
+
+
 def _run_sync_cycle() -> int:
-    """One outbox reconciliation: push pending Events, then prune long-since-synced
-    ones (ADR-020). Cleanup runs only after a flush -- never on an independent
-    clock -- and only touches synced Events past the retention window; pending and
-    quarantined Events are always retained. Returns the number of Events synced."""
+    """One outbox reconciliation: import new Homing Samples from the on-device
+    homing log into the outbox (ADR-021), push pending Events, then prune
+    long-since-synced ones (ADR-020). Cleanup runs only after a flush -- never on
+    an independent clock -- and only touches synced Events past the retention
+    window; pending and quarantined Events are always retained. Returns the number
+    of Events synced."""
     from aquila_web.sync import sync_pending_events
     from aquila_web.local_db import cleanup_synced_events
+    _import_homing_samples_safely()
     synced = sync_pending_events()
     cleanup_synced_events()
     return synced

--- a/config_files/device_profiles.json
+++ b/config_files/device_profiles.json
@@ -6,8 +6,7 @@
         "profile_group": "duke"
     },
     "sn03": {
-        "profile_group": "classic",
-        "profile_editing_disabled": true
+        "profile_group": "classic"
     },
     "sn04": {
         "profile_group": "sn04 brewery",

--- a/tests/unit/test_background_sync.py
+++ b/tests/unit/test_background_sync.py
@@ -184,6 +184,83 @@ class TestSyncFlushEndpoint:
         assert len(local_db.get_pending_events()) == 1
 
 
+class TestHomingSampleImport:
+    """The sync cycle imports Homing Samples from the on-device homing log into
+    the outbox and flushes them upstream (ADR-021 wiring, issue #326). Without
+    this, samples sit in homing.log forever, never become Events, and never reach
+    the warehouse -- so the Homing Misses metric stays empty fleet-wide."""
+
+    def _write_homing_log(self, tmp_path, *lines):
+        log_dir = tmp_path / "logs" / "homing"
+        log_dir.mkdir(parents=True, exist_ok=True)
+        (log_dir / "homing.log").write_text("".join(line + "\n" for line in lines))
+        return log_dir
+
+    def _sample(self, sid, motor="axis", reached=True):
+        import json
+        return json.dumps({
+            "id": sid, "ts": "2026-07-21T20:00:00Z", "motor": motor,
+            "steps_to_flag": 100, "residual": 0, "reached_home": reached,
+        })
+
+    def test_flush_imports_the_homing_log_and_syncs_the_samples(self, db_client, tmp_path, monkeypatch):
+        client, local_db = db_client
+        log_dir = self._write_homing_log(
+            tmp_path, self._sample("aaa", "axis", True), self._sample("bbb", "drawer", False)
+        )
+        monkeypatch.setenv("AQ_HOMING_LOG_DIR", str(log_dir))
+        monkeypatch.setenv("AQ_SYNC_ENDPOINT", "http://fake-aws/ingest")
+
+        posted = []
+
+        class _OK:
+            status_code = 200
+            def raise_for_status(self): pass
+
+        def _capture(*a, **kw):
+            posted.append(kw["json"])
+            return _OK()
+
+        monkeypatch.setattr("aquila_web.sync.requests.post", _capture)
+        resp = client.post("/sync/flush")
+
+        # Both Homing Samples became homing_sample Events and flushed upstream.
+        assert resp.json()["synced"] == 2
+        types = [e["event_type"] for body in posted for e in body["events"]]
+        assert types.count("homing_sample") == 2
+        assert local_db.get_pending_events() == []
+
+    def test_reflush_does_not_double_enqueue_the_same_samples(self, db_client, tmp_path, monkeypatch):
+        client, local_db = db_client
+        log_dir = self._write_homing_log(tmp_path, self._sample("aaa"), self._sample("bbb"))
+        monkeypatch.setenv("AQ_HOMING_LOG_DIR", str(log_dir))
+        monkeypatch.setenv("AQ_SYNC_ENDPOINT", "http://fake-aws/ingest")
+
+        class _OK:
+            status_code = 200
+            def raise_for_status(self): pass
+
+        monkeypatch.setattr("aquila_web.sync.requests.post", lambda *a, **kw: _OK())
+
+        assert client.post("/sync/flush").json()["synced"] == 2
+        # Same log, second cycle: dedup by sample id means nothing new to enqueue.
+        assert client.post("/sync/flush").json()["synced"] == 0
+
+    def test_missing_homing_log_does_not_break_the_sync_cycle(self, db_client, tmp_path, monkeypatch):
+        client, local_db = db_client
+        _seed_event(local_db, tmp_path)  # a normal run_complete event, no homing log
+        monkeypatch.setenv("AQ_HOMING_LOG_DIR", str(tmp_path / "no" / "such" / "dir"))
+        monkeypatch.setenv("AQ_SYNC_ENDPOINT", "http://fake-aws/ingest")
+
+        class _OK:
+            status_code = 200
+            def raise_for_status(self): pass
+
+        monkeypatch.setattr("aquila_web.sync.requests.post", lambda *a, **kw: _OK())
+        # A missing homing log is a no-op; the run_complete still syncs normally.
+        assert client.post("/sync/flush").json()["synced"] == 1
+
+
 class TestNonFiniteFloats:
     """A NaN/Infinity metric must not wedge the outbox. JSON has no NaN token, so
     a single non-finite value (e.g. a fold-change over a zero baseline) otherwise


### PR DESCRIPTION
Two independent changes (separate commits).

## 1. fix(sync): homing samples never reached the warehouse

**Problem** — the fleet-wide **Homing Misses** metric is empty because Homing Samples never leave the device. The pipeline has three stages and the middle one was dead in production:

1. Motor → `homing.log` ✓ (`emit_homing_sample`, #325) — sn03 has 49 samples.
2. `homing.log` → outbox events — `import_homing_samples()` (#326) exists and is tested, **but nothing ever called it** (only `test_homing_parser.py` referenced it). ← the gap
3. Sync → ingest → warehouse → dashboard ✓, but received zero homing events.

So Samples piled up in the on-device log, never became `homing_sample` Events, never synced, and the warehouse had 0 homing rows → blank metric fleet-wide.

**Fix** — invoke the parser from `_run_sync_cycle()`, the single choke point both the background sync poller and `POST /sync/flush` share. Each cycle imports new Samples (dedup by sample `id`) then flushes them upstream via the existing Sync — the aquila-backend parser cadence ADR-021 specified. Homing events ride the same mTLS POST (and benefit from the #338 non-finite guard). A homing-import failure is logged and swallowed so it can never block the flush of other Events. Log dir overridable via `AQ_HOMING_LOG_DIR` (tests).

**Recovers the backlog:** the parser reads the whole log, so deploying this drains each device's existing `homing.log` on the first cycle — sn03's 49 samples included.

**Tests (TDD):** `TestHomingSampleImport` — flush imports the log and syncs the samples as `homing_sample` events; re-flush doesn't double-enqueue (dedup); a missing log is a no-op that doesn't break normal sync. RED→GREEN. Full sync+homing suite: 39 passed.

## 2. config(sn03): unlock profile editing

Remove `profile_editing_disabled` from sn03 in `device_profiles.json` so operators can build/edit Protocols on that unit (matches the enabled devices, which omit the flag). sn04 and sn06 remain locked. Persists an on-device change across redeploys. *(Unrelated to the homing fix — kept as its own commit.)*

## Deploy note
Same as #338: not live until merged, image built, and the devices pull it (Watchtower is HTTP-API-only, no cron). Once sn03/sn05/sn08 run this build, homing starts flowing and the Homing Misses metric populates (note its own "band withheld below 20 homings" rule).

🤖 Generated with [Claude Code](https://claude.com/claude-code)