### PR TITLE
fix(run): stop a start-time double-tap from auto-launching a phantom next run (#333)

### DIFF
--- a/aq_lib/state_requests.py
+++ b/aq_lib/state_requests.py
@@ -171,6 +171,19 @@ def reset_stop_request() -> None:
     except requests.exceptions.RequestException as e:
         logger.exception("Error resetting stop request: %s", e)
 
+def reset_run_request() -> None:
+    # Consume a latched run-request edge WITHOUT clearing the selected profile.
+    # /button/run sets run_requested=True even while a run is in progress and
+    # nothing acks it until end() next polls, so a Run press (e.g. a double-tap
+    # at run start) survives the whole run and would arm a phantom next run
+    # (#333 regression). Uses /run_requested/ack — NOT /run_status/reset — so
+    # the profile stays set and a genuine results-screen press can still reuse
+    # it (#275).
+    try:
+        requests.post(f"{BACKEND_URL}/run_requested/ack", timeout=5)
+    except requests.exceptions.RequestException as e:
+        logger.exception("Error resetting run request: %s", e)
+
 _stop_poll_failures = 0
 _STOP_POLL_FAILURE_LIMIT = 10
 

--- a/state_run_assay.py
+++ b/state_run_assay.py
@@ -370,6 +370,13 @@ class AssayInterface():
         time.sleep(2)
         sr.timer_control( "reset" )
         sr.change_screen("3")
+        # Drop any Run press that was latched during the run before we inspect
+        # the button (#333 regression): /button/run keeps setting run_requested
+        # mid-run, so a double-tap at run start would still be pending here and
+        # arm a phantom next run. Clearing it now means only a fresh press on
+        # the results screen arms the next run; the profile is preserved so that
+        # single press still reuses it.
+        sr.reset_run_request()
         profile, run_name = self.button_logic( state = "end" )
         if profile is not None:
             # Run pressed on the results screen: arm the next run here,

--- a/unit_tests/test_run_request_latch_drop.py
+++ b/unit_tests/test_run_request_latch_drop.py
@@ -1,0 +1,95 @@
+"""
+Regression test for the #333 follow-up fix.
+
+Issue #333 made end() arm the next run whenever it saw a Run press on the
+results screen. But /button/run keeps setting run_requested=True even while a
+run is in progress, and nothing acks that flag until end() next polls — so a
+Run press made during a run (e.g. a double-tap at run start, as seen on sn06)
+survives the whole run and arms a *phantom* next run: results flash, then a new
+run starts on its own.
+
+The fix drains that latch in end() via state_requests.reset_run_request()
+right after the results screen appears, so only a *fresh* press on the results
+screen arms the next run.
+
+end() itself can't be unit-imported on a dev machine (state_run_assay does
+GPIO/I2C at import time — see test_run_button_double_press.py). This module
+guards the piece the fix depends on: reset_run_request() must consume the
+run-request edge via /run_requested/ack — which clears run_requested but
+PRESERVES the selected profile (#275) — and must NOT hit /run_status/reset,
+which would wipe the profile and break the single-press reuse from #333.
+"""
+import importlib
+import sys
+import types
+from pathlib import Path
+
+import pytest
+
+pytestmark = pytest.mark.unit
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(REPO_ROOT))
+
+
+@pytest.fixture
+def state_requests():
+    """Import the REAL aq_lib.state_requests with hardware stubbed out, and
+    fully restore module state afterward.
+
+    aq_lib.config_module pulls in serial.tools and probes hardware in Config();
+    state_requests only needs Config to *construct* at import, so we stub it.
+    A sibling test (test_run_button_double_press.py) swaps the whole aq_lib
+    package for a stub at collection time, so we snapshot and restore both
+    sys.modules and the aq_lib package's attributes to stay order-independent.
+    """
+    saved_modules = dict(sys.modules)
+    aq = sys.modules.get("aq_lib")
+    saved_aq_attrs = dict(aq.__dict__) if aq is not None else None
+
+    cfg = types.ModuleType("aq_lib.config_module")
+    cfg.Config = lambda *a, **k: types.SimpleNamespace()
+    sys.modules["aq_lib.config_module"] = cfg
+    sys.modules.pop("aq_lib.state_requests", None)
+    # Drop any stubbed aq_lib package (empty __path__) so the real one loads.
+    if aq is not None and not getattr(aq, "__path__", None):
+        sys.modules.pop("aq_lib", None)
+
+    try:
+        yield importlib.import_module("aq_lib.state_requests")
+    finally:
+        sys.modules.clear()
+        sys.modules.update(saved_modules)
+        if aq is not None and saved_aq_attrs is not None:
+            aq.__dict__.clear()
+            aq.__dict__.update(saved_aq_attrs)
+
+
+def test_reset_run_request_acks_edge_without_wiping_profile(state_requests, monkeypatch):
+    """reset_run_request() acks the run edge and preserves the profile."""
+    calls = []
+    monkeypatch.setattr(
+        state_requests.requests,
+        "post",
+        lambda url, *a, **k: calls.append(url) or types.SimpleNamespace(),
+    )
+
+    state_requests.reset_run_request()
+
+    assert len(calls) == 1, "expected exactly one POST"
+    assert calls[0].endswith("/run_requested/ack")
+    # Load-bearing: /run_status/reset would clear selected_profile too, breaking
+    # the single-press profile reuse the #333 fix relies on.
+    assert "/run_status/reset" not in calls[0]
+
+
+def test_reset_run_request_swallows_backend_errors(state_requests, monkeypatch):
+    """A backend that's down must not crash the end-of-run path."""
+    def _boom(*a, **k):
+        raise state_requests.requests.exceptions.RequestException("backend down")
+
+    monkeypatch.setattr(state_requests.requests, "post", _boom)
+
+    # Must not raise — end() runs this on the results screen; an exception here
+    # would take down application.main()'s loop.
+    state_requests.reset_run_request()


### PR DESCRIPTION
## Problem (reported on sn06)

Double-tapping **Run** to start a run causes the results to flash at the end and a **new run to start on its own** — as if the second tap were queued and replayed after the run.

## Root cause

Introduced by #333 (`63aecea`). That change made `end()` arm the next run whenever it sees a Run press on the results screen. But the button is a **latched server-side flag**: `/button/run` sets `run_requested=True` even *while a run is in progress*, and nothing acks it until `end()` next polls. So the second tap of a start-time double-tap survives the entire run, and `end()` reads that stale flag as "operator pressed Run on the results screen" → arms a phantom next run.

Before #333 the loop always fell back through `ready()`, which absorbed the stale tap — so this is a **new** regression, not longstanding.

The backend can't gate this on "run in progress": `run_in_progress` is only tracked on the DEV_SIMULATE path (`aquila_web/main.py`), never for a real hardware run. So the fix belongs in the state machine.

## Fix

`end()` now calls `sr.reset_run_request()` the instant the results screen appears — draining any press latched during the run **before** it inspects the button. Only a genuine, fresh press on the results screen arms the next run.

The helper acks via `/run_requested/ack` (**not** `/run_status/reset`), so the selected profile is preserved and the single-press profile-reuse from #333 still works (#275).

Result: double-tap → **exactly one run** → results → it waits for a deliberate press. The extra tap is absorbed, not queued.

## Tests

- Adds `unit_tests/test_run_request_latch_drop.py`: `reset_run_request()` acks the run edge without wiping the profile, and tolerates a down backend (can't crash the end-of-run loop). Passes in every collection order alongside the existing #333 test.
- `end()`'s full path can't run off-hardware (GPIO at import) — same constraint the #333 test documents.

### On-device verification (sn06)
Complete a run, double-tap **Run** at the start of the next one, and confirm the results screen no longer auto-launches. A single deliberate press on the results screen should still start the next run, reusing the last profile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)