### PR TITLE
fix(analysis): hard Cq cutoff 36→35 and suppress ROX whenever FAM is undetected

### DIFF
--- a/aq_curve/curve.py
+++ b/aq_curve/curve.py
@@ -356,13 +356,11 @@ class Curve:
             # even where suppression later flips the final call (#297).
             rox_raw_status = dict(rox_status)
 
-            # FAM undetected + late ROX Cq → suppress ROX.
-            # A late-rising ROX with no FAM signal is non-specific; treat as undetected.
-            late_cq_threshold = config.get_int("PCR_LATE_CQ_THRESHOLD")
+            # FAM undetected → suppress ROX unconditionally.
+            # With no FAM signal any ROX call (detected, inconclusive, or late)
+            # is non-specific, so the well is treated as undetected.
             for w in _WELLS:
-                if (fam_status[w] == "Not Detected"
-                        and rox_cq[w] is not None
-                        and rox_cq[w] >= late_cq_threshold):
+                if fam_status[w] == "Not Detected":
                     rox_status[w] = "Not Detected"
                     rox_cq[w] = None
 

--- a/aq_curve/pcr_curve_config.py
+++ b/aq_curve/pcr_curve_config.py
@@ -6,7 +6,7 @@ DEFAULTS = {
     "PCR_CQ_MAX": 40,
     # Hard negative cutoff: any Cq strictly greater than this is called Not
     # Detected regardless of curve shape/fold evidence (overrides late-Cq rescue).
-    "PCR_CQ_HARD_MAX": 36,
+    "PCR_CQ_HARD_MAX": 35,
     "PCR_CQ_MIN": 7,
     "PCR_END_MIDPOINT_FRACTION": 0.50,
     "PCR_LATE_CQ_THRESHOLD": 35,

--- a/config_files/version.json
+++ b/config_files/version.json
@@ -1,3 +1,3 @@
 {
-    "app_version": "2.1.0.4"
+    "app_version": "2.1.0.5"
 }

--- a/tests/unit/analysis/test_hard_cq_cutoff.py
+++ b/tests/unit/analysis/test_hard_cq_cutoff.py
@@ -8,8 +8,8 @@ the late-Cq-confident rescue path. A Cq at or below the cutoff is unaffected.
 Fixtures are real baseline-corrected curves captured from optics logs:
   * PAST_CUTOFF  — run5_2026-07-16 FAM well 4 (Cq ~38.6): a terminal-spike artifact
     that the late-Cq path used to promote to Detected.
-  * WITHIN_CUTOFF — aba_form_3_set_3 FAM well 1 (Cq ~35.4): a genuine late riser
-    below the cutoff that must stay Detected.
+  * PAST_CUTOFF_NEAR — aba_form_3_set_3 FAM well 1 (Cq ~35.4): a late riser just
+    past the cutoff that must be Not Detected under PCR_CQ_HARD_MAX=35.
 """
 import numpy as np
 import pytest
@@ -28,8 +28,8 @@ PAST_CUTOFF = [
     0.0193, 0.07623,
 ]
 
-# aba_form_3_set_3_2026-05-08_20-05-19.log, FAM well 1 — crosses at Cq ~35.4 (<= 36).
-WITHIN_CUTOFF = [
+# aba_form_3_set_3_2026-05-08_20-05-19.log, FAM well 1 — crosses at Cq ~35.4 (> 35).
+PAST_CUTOFF_NEAR = [
     -0.07761, -0.06425, -0.02999, -0.0319, -0.00847, -0.0041, 0.00333, 0.00239,
     0.00058, -0.00386, -0.00243, -0.00082, 0.00605, 0.00951, -0.01063, -0.01575,
     -0.00411, -0.00054, -0.0057, -0.00617, -0.00944, -0.00325, -0.0057, -0.0045,
@@ -65,12 +65,13 @@ def test_cq_past_hard_max_is_undetected(monkeypatch):
     assert ev["decision_reason"] == "cq_after_hard_max"
 
 
-def test_cq_within_hard_max_still_detected(monkeypatch):
-    """A late crossing at or below the cutoff is unaffected and stays Detected."""
-    ev = _evaluate(WITHIN_CUTOFF, monkeypatch)
-    assert ev["flags"]["cq_after_hard_max"] is False
-    assert ev["status"] == "detected"
+def test_cq_just_past_hard_max_is_undetected(monkeypatch):
+    """A crossing at Cq ~35.4 is now past the cutoff and Not Detected."""
+    ev = _evaluate(PAST_CUTOFF_NEAR, monkeypatch)
+    assert ev["flags"]["cq_after_hard_max"] is True
+    assert ev["status"] == "undetected"
+    assert ev["decision_reason"] == "cq_after_hard_max"
 
 
-def test_hard_max_default_is_36():
-    assert config.get_float("PCR_CQ_HARD_MAX") == 36
+def test_hard_max_default_is_35():
+    assert config.get_float("PCR_CQ_HARD_MAX") == 35

--- a/tests/unit/analysis/test_results_to_json.py
+++ b/tests/unit/analysis/test_results_to_json.py
@@ -273,13 +273,13 @@ def test_late_rox_suppressed_when_fam_undetected(tmp_path, monkeypatch):
 
 
 @pytest.mark.unit
-def test_early_rox_not_suppressed_when_fam_undetected(tmp_path, monkeypatch):
-    """ROX with an early Cq must remain Detected even when FAM is undetected."""
+def test_early_rox_suppressed_when_fam_undetected(tmp_path, monkeypatch):
+    """ROX must become Not Detected when FAM is undetected, even with an early Cq."""
     monkeypatch.setattr(curve_module, "evaluate_curve",
                         _stub_evaluate_by_dye("undetected", "detected"))
     monkeypatch.setattr(curve_module, "get_curve_data", _stub_get_curve_data)
     monkeypatch.setattr(curve_module, "get_threshold", _stub_get_threshold)
-    # FAM wells 1-4: None; ROX wells 1-4: 22.0 (< threshold, rule does not fire)
+    # FAM wells 1-4: None; ROX wells 1-4: 22.0 (early) — suppressed regardless of Cq
     monkeypatch.setattr(curve_module, "compute_cq",
                         _make_cq_sequence(None, None, None, None, 22.0, 22.0, 22.0, 22.0))
 
@@ -288,8 +288,27 @@ def test_early_rox_not_suppressed_when_fam_undetected(tmp_path, monkeypatch):
     data = json.loads((tmp_path / "results.json").read_text())
 
     for col in ("1", "2", "3", "4"):
-        assert data["2"][col] == "Detected", f"ROX well {col} should remain Detected"
-        assert data["cq"]["2"][col] == 22.0, f"ROX Cq well {col} should be preserved"
+        assert data["2"][col] == "Not Detected", f"ROX well {col} should be suppressed"
+        assert data["cq"]["2"][col] is None, f"ROX Cq well {col} should be None"
+
+
+@pytest.mark.unit
+def test_inconclusive_rox_suppressed_when_fam_undetected(tmp_path, monkeypatch):
+    """ROX must become Not Detected when FAM is undetected, even if ROX is inconclusive."""
+    monkeypatch.setattr(curve_module, "evaluate_curve",
+                        _stub_evaluate_by_dye("undetected", "inconclusive"))
+    monkeypatch.setattr(curve_module, "get_curve_data", _stub_get_curve_data)
+    monkeypatch.setattr(curve_module, "get_threshold", _stub_get_threshold)
+    monkeypatch.setattr(curve_module, "compute_cq",
+                        _make_cq_sequence(None, None, None, None, 22.0, 22.0, 22.0, 22.0))
+
+    curve = Curve(src_basedir=str(tmp_path))
+    curve.results_to_json("raw.dat", "results.json")
+    data = json.loads((tmp_path / "results.json").read_text())
+
+    for col in ("1", "2", "3", "4"):
+        assert data["2"][col] == "Not Detected", f"ROX well {col} should be suppressed"
+        assert data["cq"]["2"][col] is None, f"ROX Cq well {col} should be None"
 
 
 @pytest.mark.unit


### PR DESCRIPTION
## What & why

Two related PCR call-logic changes requested for the analysis engine:

### 1. Hard Cq cutoff lowered 36 → 35
`PCR_CQ_HARD_MAX` drops from 36 to 35 (`aq_curve/pcr_curve_config.py`). Any threshold crossing with **Cq > 35** is now called **Not Detected**, overriding the late-Cq rescue path — same mechanism as before, just a tighter line.

### 2. FAM undetected now suppresses ROX unconditionally
In `aq_curve/curve.py`, when a well's FAM call is **Not Detected**, the corresponding ROX call is forced to **Not Detected** (Cq cleared) **regardless of ROX's own status** — detected, inconclusive, early, or late. Previously ROX was only suppressed when its Cq was late (`>= PCR_LATE_CQ_THRESHOLD`). Rationale: with no FAM signal, any ROX call in that well is non-specific.

## Tests
- `test_hard_max_default_is_36` → `test_hard_max_default_is_35`
- Reclassified the real ~35.4 Cq fixture from "within cutoff / Detected" to "past cutoff / Not Detected" (it now genuinely is one under the 35 cutoff)
- `test_early_rox_not_suppressed_when_fam_undetected` → `test_early_rox_suppressed_when_fam_undetected` (behavior inverted by the new rule)
- Added `test_inconclusive_rox_suppressed_when_fam_undetected` to cover the "regardless if inconclusive" case

All directly-affected suites pass (60/60 across the touched files; full non-e2e suite green apart from **pre-existing, unrelated** `tests/unit/hardware/` lid-heater thread-leak failures that also fail on `main`, and e2e collection errors from a missing `playwright` dependency).

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)