### PR TITLE
chore(deploy): one fallback image per device, scoped to the current ring

### DIFF
--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -13,6 +13,33 @@ if [[ -d "${bundled_profile_dir}" ]]; then
   shopt -u nullglob
 fi
 
+# Sync host-side helper scripts out to /opt/fleet (#355).
+#
+# Container images are the ONLY automatic delivery path to a device. Host
+# scripts have none: /opt/fleet/update.sh is written once by deployment2.sh at
+# provisioning and never refreshes itself, so anything fetched from GitHub at
+# provisioning time is frozen there forever.
+#
+# Shipping helpers in the image and writing them out here fixes that, and it
+# keeps them versioned with the ring the device is on — a pilot device gets the
+# pilot build's script, not whatever main says right now. That matters for a
+# script that deletes images: bugs in it should soak through
+# sandbox -> dev -> pilot -> prod like everything else.
+#
+# Only the backend service bind-mounts /opt/fleet, so this is a no-op in the
+# app container. Best-effort: an absent or read-only mount must never stop the
+# backend from starting.
+fleet_dir="${FLEET_DIR:-/opt/fleet}"
+helper_src="/opt/aquila/scripts/deploy"
+if [[ -d "${fleet_dir}" && -w "${fleet_dir}" ]]; then
+  for helper in prune-images.sh; do
+    if [[ -f "${helper_src}/${helper}" ]]; then
+      install -m 0755 "${helper_src}/${helper}" "${fleet_dir}/${helper}" \
+        || echo "warning: could not sync ${helper} to ${fleet_dir}"
+    fi
+  done
+fi
+
 # If this container is running the hardware app, wait until the backend is
 # healthy before starting. This removes the race condition without needing
 # a compose-file change on each device.

--- a/scripts/deploy/deployment2.sh
+++ b/scripts/deploy/deployment2.sh
@@ -622,6 +622,15 @@ curl -fsSL \
     -o /opt/fleet/update.sh
 chmod +x /opt/fleet/update.sh
 
+# Image retention (#355). Nothing else on the device removes old images, so they
+# accumulate without limit — sn03 was measured holding 27 images, 19 dangling,
+# 8.84 GB reclaimable. Installed here and driven by the timer in Phase 10.
+curl -fsSL \
+    -H "Authorization: token ${GHCR_TOKEN}" \
+    "https://raw.githubusercontent.com/${GHCR_REPO}/main/scripts/deploy/prune-images.sh" \
+    -o /opt/fleet/prune-images.sh
+chmod +x /opt/fleet/prune-images.sh
+
 # Generate the device keypair + CSR on-device (CN = Device ID = Pi serial). The
 # private key is written owner-only (0600) and never leaves the Pi; only the CSR
 # is later submitted to acorn-ca /enroll (#240). Runs in the app image, which
@@ -828,6 +837,51 @@ run_test "renew timer active"        "systemctl is-active aquila-cert-renew.time
 run_test "AQ_RENEW_ENDPOINT set"     "grep -q 'AQ_RENEW_ENDPOINT=' /opt/aquila/config/device.env"
 
 phase_pass "aquila-cert-renew.timer registered and enabled"
+
+# ── Image retention timer (#355) ───────────────────────────────────────────────
+# A timer rather than only the fleet-update.sh hook, because there are two update
+# paths and the script covers one: /opt/fleet/update.sh is manual, while the UI's
+# "Update Now" goes through Watchtower's POST /v1/update and never touches it.
+# The timer is path-independent, and also catches devices that have not updated
+# in a long time.
+cat > /etc/systemd/system/aquila-prune-images.service <<'EOF'
+[Unit]
+Description=Cap retained Aquila container images
+After=docker.service
+Requires=docker.service
+
+[Service]
+Type=oneshot
+ExecStart=/opt/fleet/prune-images.sh
+EOF
+
+# Daily with a randomized delay, matching aquila-cert-renew: there is no reason
+# for the fleet to prune in lockstep. Persistent=true catches up after downtime,
+# which matters here — devices are routinely offline for days.
+cat > /etc/systemd/system/aquila-prune-images.timer <<'EOF'
+[Unit]
+Description=Daily retained-image prune
+
+[Timer]
+OnCalendar=daily
+RandomizedDelaySec=6h
+Persistent=true
+
+[Install]
+WantedBy=timers.target
+EOF
+
+systemctl daemon-reload
+systemctl enable --now aquila-prune-images.timer
+
+run_test "prune script present"   "test -x /opt/fleet/prune-images.sh"
+run_test "prune service file"     "test -f /etc/systemd/system/aquila-prune-images.service"
+run_test "prune timer file"       "test -f /etc/systemd/system/aquila-prune-images.timer"
+run_test "prune timer enabled"    "systemctl is-enabled aquila-prune-images.timer | grep -q enabled"
+run_test "prune timer active"     "systemctl is-active aquila-prune-images.timer | grep -q active"
+run_test "prune script runs"      "DRY_RUN=1 /opt/fleet/prune-images.sh >/dev/null"
+
+phase_pass "aquila-prune-images.timer registered and enabled"
 
 # ═══════════════════════════════════════════════════════════════════════════════
 # Phase 11 — Fleet Device Configuration (Start Stack)

--- a/scripts/deploy/deployment2.sh
+++ b/scripts/deploy/deployment2.sh
@@ -622,14 +622,12 @@ curl -fsSL \
     -o /opt/fleet/update.sh
 chmod +x /opt/fleet/update.sh
 
-# Image retention (#355). Nothing else on the device removes old images, so they
-# accumulate without limit — sn03 was measured holding 27 images, 19 dangling,
-# 8.84 GB reclaimable. Installed here and driven by the timer in Phase 10.
-curl -fsSL \
-    -H "Authorization: token ${GHCR_TOKEN}" \
-    "https://raw.githubusercontent.com/${GHCR_REPO}/main/scripts/deploy/prune-images.sh" \
-    -o /opt/fleet/prune-images.sh
-chmod +x /opt/fleet/prune-images.sh
+# NOTE: prune-images.sh (#355) is deliberately NOT fetched here. It ships inside
+# the container image and is written to /opt/fleet by docker/entrypoint.sh on
+# every backend start. Fetching it from main at provisioning would freeze it at
+# that day's version forever (nothing refreshes host scripts afterwards) and
+# would bypass the ring system for a script that deletes images. The systemd
+# units that drive it are still installed here, in Phase 10.
 
 # Generate the device keypair + CSR on-device (CN = Device ID = Pi serial). The
 # private key is written owner-only (0600) and never leaves the Pi; only the CSR

--- a/scripts/deploy/deployment2_verify.sh
+++ b/scripts/deploy/deployment2_verify.sh
@@ -125,6 +125,13 @@ test_phase_10() {
     echo "── Phase 10: systemd Service"
     check 10 "service file exists" "test -f /etc/systemd/system/aquila-stack.service"
     check 10 "service enabled"     "systemctl is-enabled aquila-stack.service | grep -q enabled"
+
+    # Image retention (#355). "timer enabled" alone would pass while the script
+    # is missing or broken, so the dry run below asserts it actually executes.
+    check 10 "prune script present" "test -x /opt/fleet/prune-images.sh"
+    check 10 "prune timer enabled"  "systemctl is-enabled aquila-prune-images.timer | grep -q enabled"
+    check 10 "prune timer active"   "systemctl is-active aquila-prune-images.timer | grep -q active"
+    check 10 "prune script runs"    "DRY_RUN=1 /opt/fleet/prune-images.sh >/dev/null"
 }
 
 test_phase_11() {

--- a/scripts/deploy/fleet-update.sh
+++ b/scripts/deploy/fleet-update.sh
@@ -50,4 +50,12 @@ _upsert_env RUNNING_IMAGE_DIGEST_UI "${_DIGEST_UI:-}" "${FLEET_ENV}"
 #   (<hash>_aquila-backend) so they don't linger and fight for the same ports.
 docker compose --env-file "${FLEET_ENV}" -f /opt/fleet/docker-compose.yml up -d --force-recreate --remove-orphans
 
+# Cap retained images (#355). `compose pull` above leaves the replaced image
+# behind and nothing else removes it, so this is where the accumulation starts.
+# Never fail the update because pruning failed — the stack is already up, and a
+# missed prune costs disk, not availability. The timer catches the next run.
+if [[ -x /opt/fleet/prune-images.sh ]]; then
+    /opt/fleet/prune-images.sh || echo "prune-images.sh failed (non-fatal)"
+fi
+
 mkdir -p /opt/aquila/tests

--- a/scripts/deploy/prune-images.sh
+++ b/scripts/deploy/prune-images.sh
@@ -1,0 +1,125 @@
+#!/usr/bin/env bash
+# Cap the number of Aquila image sets retained on a device (issue #355).
+#
+# Nothing in any deploy path removes old images. fleet-update.sh runs
+# `docker compose pull` + `up -d --force-recreate`, and compose never deletes
+# the image it replaced. Watchtower's --cleanup would, but it runs without
+# --interval so it only acts on POST /v1/update and mostly never fires.
+# The result is unbounded accumulation: sn03 was measured holding 27 images,
+# 19 of them dangling, 8.84 GB reclaimable.
+#
+# A "set" is one API image plus its matching UI image. Retention rules, in
+# priority order:
+#
+#   1. Never remove an image a container references. Enforced by Docker itself
+#      -- `docker rmi` refuses, so a logic error here cannot take down a
+#      running container.
+#   2. Never remove a ring-tagged image (sandbox/dev/pilot/prod). Enforced by
+#      construction: only `dangling=true` images are considered, and a ring tag
+#      means an image is not dangling. These are deliberate offline rollback
+#      targets -- a device holding both api:sandbox and api:dev keeps both.
+#   3. Of what remains, keep the most recent (IMAGE_RETENTION_SETS - 1) per
+#      family. The running set is tagged, so untagged images are all previous
+#      versions.
+#   4. Remove the rest.
+#
+# Anything not positively identified as an Aquila API or UI image is left
+# alone, so Watchtower and any future images are never candidates.
+#
+# Env:
+#   IMAGE_RETENTION_SETS  total sets to keep, including the running one (default 3)
+#   DRY_RUN               set to 1 to report without removing
+set -euo pipefail
+
+RETENTION_SETS="${IMAGE_RETENTION_SETS:-3}"
+DRY_RUN="${DRY_RUN:-0}"
+
+log() { printf '[prune-images] %s\n' "$*"; }
+
+if ! [[ "${RETENTION_SETS}" =~ ^[0-9]+$ ]] || (( RETENTION_SETS < 1 )); then
+    log "IMAGE_RETENTION_SETS must be a positive integer (got '${RETENTION_SETS}')"
+    exit 1
+fi
+
+# The running set is tagged, not dangling, so it is never in the candidate list.
+KEEP_UNTAGGED=$(( RETENTION_SETS - 1 ))
+
+if ! command -v docker >/dev/null 2>&1; then
+    log "docker not found; nothing to do"
+    exit 0
+fi
+
+# Classify an untagged image using config baked in at build time.
+#
+# Dangling images have lost their repository name, so `docker images` output
+# cannot tell an orphaned API image from an orphaned UI one. These two markers
+# were verified on a live device:
+#   API -> WorkingDir=/opt/aquila, Cmd=[uvicorn aquila_web.main:app ...]
+#   UI  -> WorkingDir=/,           Cmd=[nginx -g daemon off;]
+# Once #351 bakes OCI labels into the images, this can key off
+# org.opencontainers.image.* instead and stop depending on the entrypoint.
+_classify() {
+    local id="$1" workdir cmd
+    workdir="$(docker inspect "${id}" --format '{{.Config.WorkingDir}}' 2>/dev/null || true)"
+    cmd="$(docker inspect "${id}" --format '{{json .Config.Cmd}}' 2>/dev/null || true)"
+
+    if [[ "${workdir}" == "/opt/aquila" ]]; then
+        echo api
+    elif [[ "${cmd}" == *nginx* ]]; then
+        echo ui
+    else
+        echo other
+    fi
+}
+
+total_removed=0
+
+for family in api ui; do
+    # Untagged images of this family, newest first.
+    candidates="$(
+        docker images --filter dangling=true --quiet 2>/dev/null | sort -u | while read -r id; do
+            [[ -n "${id}" ]] || continue
+            [[ "$(_classify "${id}")" == "${family}" ]] || continue
+            printf '%s %s\n' "$(docker inspect "${id}" --format '{{.Created}}' 2>/dev/null)" "${id}"
+        done | sort -r | awk '{ print $2 }'
+    )"
+
+    if [[ -z "${candidates}" ]]; then
+        log "${family}: no untagged images"
+        continue
+    fi
+
+    count="$(printf '%s\n' "${candidates}" | wc -l | tr -d ' ')"
+    stale="$(printf '%s\n' "${candidates}" | tail -n "+$(( KEEP_UNTAGGED + 1 ))")"
+
+    if [[ -z "${stale}" ]]; then
+        log "${family}: ${count} untagged, keeping all (limit ${KEEP_UNTAGGED})"
+        continue
+    fi
+
+    stale_count="$(printf '%s\n' "${stale}" | wc -l | tr -d ' ')"
+    log "${family}: ${count} untagged, keeping ${KEEP_UNTAGGED} newest, removing ${stale_count}"
+
+    printf '%s\n' "${stale}" | while read -r id; do
+        [[ -n "${id}" ]] || continue
+        if [[ "${DRY_RUN}" == "1" ]]; then
+            log "  would remove ${id}"
+            continue
+        fi
+        # Fails harmlessly when a container still references the image; that is
+        # rule 1 being enforced by Docker rather than by this script.
+        if docker rmi "${id}" >/dev/null 2>&1; then
+            log "  removed ${id}"
+        else
+            log "  skipped ${id} (in use or has children)"
+        fi
+    done
+
+    total_removed=$(( total_removed + stale_count ))
+done
+
+if [[ "${DRY_RUN}" == "1" ]]; then
+    log "dry run complete (IMAGE_RETENTION_SETS=${RETENTION_SETS})"
+else
+    log "done (IMAGE_RETENTION_SETS=${RETENTION_SETS})"
+fi

--- a/scripts/deploy/prune-images.sh
+++ b/scripts/deploy/prune-images.sh
@@ -1,81 +1,142 @@
 #!/usr/bin/env bash
-# Cap the number of Aquila image sets retained on a device (issue #355).
+# Image retention / rollback logic for a Sentri (issue #355).
 #
-# Nothing in any deploy path removes old images. fleet-update.sh runs
-# `docker compose pull` + `up -d --force-recreate`, and compose never deletes
-# the image it replaced. Watchtower's --cleanup would, but it runs without
-# --interval so it only acts on POST /v1/update and mostly never fires.
-# The result is unbounded accumulation: sn03 was measured holding 27 images,
-# 19 of them dangling, 8.84 GB reclaimable.
+# Nothing on a device has ever removed an image. Measured on sn03: 30 images,
+# ~9.8 GB reclaimable, the oldest being a telemetry image from 2023 belonging to
+# a stack replaced by Grafana Alloy.
 #
-# A "set" is one API image plus its matching UI image. Retention rules, in
-# priority order:
+# A device keeps at most TWO sets, both from its CURRENT ring:
 #
-#   1. Never remove an image a container references. Enforced by Docker itself
-#      -- `docker rmi` refuses, so a logic error here cannot take down a
-#      running container.
-#   2. Never remove a ring-tagged image (sandbox/dev/pilot/prod). Enforced by
-#      construction: only `dangling=true` images are considered, and a ring tag
-#      means an image is not dangling. These are deliberate offline rollback
-#      targets -- a device holding both api:sandbox and api:dev keeps both.
-#   3. Of what remains, keep the most recent (IMAGE_RETENTION_SETS - 1) per
-#      family. The running set is tagged, so untagged images are all previous
-#      versions.
-#   4. Remove the rest.
+#     current   the image it is running   (carries the ring tag)
+#     fallback  the build it replaced     (untagged)
 #
-# Anything not positively identified as an Aquila API or UI image is left
-# alone, so Watchtower and any future images are never candidates.
+# A "set" is one API image plus its matching UI image, so at most 4 Aquila
+# images on disk.
+#
+# ── The two cases ─────────────────────────────────────────────────────────────
+#
+# SAME-RING UPDATE (pilot v2 -> pilot v3)
+#     The replaced build becomes the fallback; the previous fallback is deleted.
+#     current=v3, fallback=v2, v1 removed.
+#
+# RING CHANGE (pilot -> prod)
+#     Every image from the old ring goes, current and fallback alike, and the
+#     device starts with NO fallback. Falling back across rings is not a
+#     rollback: promotion flows sandbox -> dev -> pilot -> prod, so the old
+#     ring's image is newer and *less* soaked than the one just promoted in.
+#
+# ── Why one ring name is the only state needed ────────────────────────────────
+#
+# An untagged image carries no record of its ring -- verified on-device, an
+# orphan has RepoTags: [], RepoDigests: [], Labels: map[]. So "the previous
+# pilot image" is not identifiable by inspection.
+#
+# The ring-change rule removes the need to identify it. Because a ring change
+# deletes every old-ring image, the invariant afterwards is zero orphans. Each
+# same-ring update then adds exactly one and removes the previous, so the orphan
+# pool is always <= 1 AND always from the current ring. Sorting by date is
+# therefore exact, not an approximation -- provided we know whether the ring
+# changed, which is the one thing recorded in STATE_FILE.
+#
+# ── Safety ────────────────────────────────────────────────────────────────────
+#   - An image a container references is never removed. Docker enforces this
+#     (`docker rmi` refuses), not this script, so a logic error here cannot take
+#     down a running container.
+#   - Anything not positively identified as an Aquila API or UI image is never
+#     touched: Watchtower and any future image are never candidates.
+#   - If the ring cannot be determined, the script exits without removing
+#     anything rather than guessing.
 #
 # Env:
-#   IMAGE_RETENTION_SETS  total sets to keep, including the running one (default 3)
-#   DRY_RUN               set to 1 to report without removing
+#   DEVICE_RING  override the detected ring (default: IMAGE_TAG from the .env files)
+#   STATE_FILE   where the last-seen ring is recorded
+#   DRY_RUN      set to 1 to report without removing
 set -euo pipefail
 
-RETENTION_SETS="${IMAGE_RETENTION_SETS:-3}"
 DRY_RUN="${DRY_RUN:-0}"
+FLEET_ENV="${FLEET_ENV:-/opt/fleet/.env}"
+DEVICE_ENV="${DEVICE_ENV:-/opt/aquila/config/device.env}"
+STATE_FILE="${STATE_FILE:-/opt/fleet/.prune-state}"
+
+KNOWN_RINGS="sandbox dev pilot prod"
+# `latest` is not a ring: it tracks whatever was built last and no device should
+# be running it, so it is always removable.
+NON_RING_TAGS="latest"
 
 log() { printf '[prune-images] %s\n' "$*"; }
 
-if ! [[ "${RETENTION_SETS}" =~ ^[0-9]+$ ]] || (( RETENTION_SETS < 1 )); then
-    log "IMAGE_RETENTION_SETS must be a positive integer (got '${RETENTION_SETS}')"
-    exit 1
-fi
+command -v docker >/dev/null 2>&1 || { log "docker not found; nothing to do"; exit 0; }
 
-# The running set is tagged, not dangling, so it is never in the candidate list.
-KEEP_UNTAGGED=$(( RETENTION_SETS - 1 ))
+_detect_ring() {
+    local f v
+    for f in "${FLEET_ENV}" "${DEVICE_ENV}"; do
+        [[ -r "${f}" ]] || continue
+        v="$(grep -E '^IMAGE_TAG=' "${f}" 2>/dev/null | tail -1 | cut -d= -f2- | tr -d '"'\''[:space:]')"
+        if [[ -n "${v}" ]]; then printf '%s' "${v}"; return; fi
+    done
+}
 
-if ! command -v docker >/dev/null 2>&1; then
-    log "docker not found; nothing to do"
+RING="${DEVICE_RING:-$(_detect_ring)}"
+if [[ -z "${RING}" ]]; then
+    log "ring unknown (no IMAGE_TAG in ${FLEET_ENV} or ${DEVICE_ENV})"
+    log "refusing to remove anything — will not guess"
     exit 0
 fi
 
-# Classify an untagged image using config baked in at build time.
-#
-# Dangling images have lost their repository name, so `docker images` output
-# cannot tell an orphaned API image from an orphaned UI one. These two markers
-# were verified on a live device:
+LAST_RING=""
+[[ -r "${STATE_FILE}" ]] && LAST_RING="$(cat "${STATE_FILE}" 2>/dev/null | tr -d '[:space:]')"
+
+# No state means either a fresh device or the first run on an existing one. Treat
+# it as a ring change: an unverifiable fallback is not a fallback, and this
+# establishes the zero-orphan invariant everything below relies on. Costs at most
+# one rollback target, once.
+if [[ -z "${LAST_RING}" ]]; then
+    MODE="ring-change"
+    log "ring: ${RING} (no previous state — treating as a ring change to establish a clean baseline)"
+elif [[ "${LAST_RING}" != "${RING}" ]]; then
+    MODE="ring-change"
+    log "ring changed: ${LAST_RING} -> ${RING} (all ${LAST_RING} images will be removed, no fallback)"
+else
+    MODE="same-ring"
+    log "ring: ${RING} (unchanged — keeping current + 1 fallback)"
+fi
+
+_rmi() {
+    local ref="$1"
+    if [[ "${DRY_RUN}" == "1" ]]; then
+        log "  would remove ${ref}"
+        return
+    fi
+    if docker rmi "${ref}" >/dev/null 2>&1; then
+        log "  removed ${ref}"
+    else
+        log "  skipped ${ref} (in use or has children)"
+    fi
+}
+
+# Untagged images have no repository name, so `docker images` cannot tell an
+# orphaned API image from an orphaned UI one. They are classified by config baked
+# in at build time, verified on-device:
 #   API -> WorkingDir=/opt/aquila, Cmd=[uvicorn aquila_web.main:app ...]
 #   UI  -> WorkingDir=/,           Cmd=[nginx -g daemon off;]
-# Once #351 bakes OCI labels into the images, this can key off
-# org.opencontainers.image.* instead and stop depending on the entrypoint.
+# Once #351 bakes OCI labels in, this can key off org.opencontainers.image.*
+# and stop depending on the entrypoint.
 _classify() {
     local id="$1" workdir cmd
     workdir="$(docker inspect "${id}" --format '{{.Config.WorkingDir}}' 2>/dev/null || true)"
     cmd="$(docker inspect "${id}" --format '{{json .Config.Cmd}}' 2>/dev/null || true)"
-
-    if [[ "${workdir}" == "/opt/aquila" ]]; then
-        echo api
-    elif [[ "${cmd}" == *nginx* ]]; then
-        echo ui
-    else
-        echo other
+    if [[ "${workdir}" == "/opt/aquila" ]]; then echo api
+    elif [[ "${cmd}" == *nginx* ]];           then echo ui
+    else                                           echo other
     fi
 }
 
-total_removed=0
+# ── Step 1: fallbacks (untagged Aquila images) ────────────────────────────────
+# ring-change keeps none; same-ring keeps the newest of each family.
+keep_n=0
+[[ "${MODE}" == "same-ring" ]] && keep_n=1
 
 for family in api ui; do
-    # Untagged images of this family, newest first.
     candidates="$(
         docker images --filter dangling=true --quiet 2>/dev/null | sort -u | while read -r id; do
             [[ -n "${id}" ]] || continue
@@ -83,43 +144,40 @@ for family in api ui; do
             printf '%s %s\n' "$(docker inspect "${id}" --format '{{.Created}}' 2>/dev/null)" "${id}"
         done | sort -r | awk '{ print $2 }'
     )"
+    [[ -n "${candidates}" ]] || { log "${family}: no fallback images"; continue; }
 
-    if [[ -z "${candidates}" ]]; then
-        log "${family}: no untagged images"
-        continue
-    fi
+    total="$(printf '%s\n' "${candidates}" | wc -l | tr -d ' ')"
+    stale="$(printf '%s\n' "${candidates}" | tail -n "+$(( keep_n + 1 ))")"
+    [[ -n "${stale}" ]] || { log "${family}: ${total} fallback, keeping it"; continue; }
 
-    count="$(printf '%s\n' "${candidates}" | wc -l | tr -d ' ')"
-    stale="$(printf '%s\n' "${candidates}" | tail -n "+$(( KEEP_UNTAGGED + 1 ))")"
-
-    if [[ -z "${stale}" ]]; then
-        log "${family}: ${count} untagged, keeping all (limit ${KEEP_UNTAGGED})"
-        continue
-    fi
-
-    stale_count="$(printf '%s\n' "${stale}" | wc -l | tr -d ' ')"
-    log "${family}: ${count} untagged, keeping ${KEEP_UNTAGGED} newest, removing ${stale_count}"
-
+    log "${family}: ${total} untagged, keeping ${keep_n}, removing $(printf '%s\n' "${stale}" | wc -l | tr -d ' ')"
     printf '%s\n' "${stale}" | while read -r id; do
         [[ -n "${id}" ]] || continue
-        if [[ "${DRY_RUN}" == "1" ]]; then
-            log "  would remove ${id}"
-            continue
-        fi
-        # Fails harmlessly when a container still references the image; that is
-        # rule 1 being enforced by Docker rather than by this script.
-        if docker rmi "${id}" >/dev/null 2>&1; then
-            log "  removed ${id}"
-        else
-            log "  skipped ${id} (in use or has children)"
-        fi
+        _rmi "${id}"
     done
+done
 
-    total_removed=$(( total_removed + stale_count ))
+# ── Step 2: tagged images from other rings ────────────────────────────────────
+# Runs after step 1 deliberately. Removing a tag turns that image into an orphan,
+# so doing this first would let a just-untagged foreign-ring image compete to be
+# kept as the fallback.
+for tag in ${KNOWN_RINGS} ${NON_RING_TAGS}; do
+    [[ "${tag}" == "${RING}" ]] && continue
+    while read -r ref; do
+        [[ -n "${ref}" ]] || continue
+        _rmi "${ref}"
+    done < <(docker images --format '{{.Repository}}:{{.Tag}}' 2>/dev/null \
+             | grep -E "aquilla-main-(api|ui):${tag}$" || true)
 done
 
 if [[ "${DRY_RUN}" == "1" ]]; then
-    log "dry run complete (IMAGE_RETENTION_SETS=${RETENTION_SETS})"
+    log "dry run complete (ring=${RING}, mode=${MODE}) — state not written"
 else
-    log "done (IMAGE_RETENTION_SETS=${RETENTION_SETS})"
+    if printf '%s\n' "${RING}" > "${STATE_FILE}" 2>/dev/null; then
+        log "done (ring=${RING}, mode=${MODE})"
+    else
+        # Without state every run looks like a ring change, so no fallback is
+        # ever kept. Safe, but worth surfacing.
+        log "done (ring=${RING}, mode=${MODE}) — WARNING: could not write ${STATE_FILE}"
+    fi
 fi

--- a/unit_tests/test_prune_images.py
+++ b/unit_tests/test_prune_images.py
@@ -1,0 +1,170 @@
+"""Retention logic for scripts/deploy/prune-images.sh (#355).
+
+The script cannot be imported, so each test builds a fake `docker` executable on
+PATH that answers the handful of subcommands the script uses. That keeps the
+real retention logic under test — classification, ordering, the keep-count —
+without needing Docker or a device.
+
+Hardware note: the script's rule 1 ("never remove an image a container
+references") is enforced by `docker rmi` refusing, not by the script, so it
+cannot be exercised here. It is covered by the on-device check in
+deployment2_verify.sh.
+"""
+
+import os
+import subprocess
+import textwrap
+from pathlib import Path
+
+import pytest
+
+SCRIPT = Path(__file__).resolve().parents[1] / "scripts" / "deploy" / "prune-images.sh"
+
+API_WORKDIR = "/opt/aquila"
+UI_CMD = '["nginx","-g","daemon off;"]'
+
+
+def _fake_docker(tmp_path, images):
+    """Write a stub `docker` onto PATH.
+
+    ``images`` maps image id -> (kind, created), where kind is "api", "ui" or
+    "other". Removals are appended to removed.txt so a test can assert on them.
+
+    The stub reads a TSV data file rather than having the table generated into
+    its source — embedding shell-quoted JSON in generated `case` branches is
+    fragile enough to produce false failures.
+    """
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir(exist_ok=True)
+
+    rows = []
+    for img_id, (kind, created) in images.items():
+        workdir = API_WORKDIR if kind == "api" else "/"
+        cmd = {"ui": UI_CMD, "api": '["uvicorn"]'}.get(kind, '["sleep"]')
+        rows.append(f"{img_id}\t{workdir}\t{cmd}\t{created}")
+    data = tmp_path / "images.tsv"
+    data.write_text("\n".join(rows) + ("\n" if rows else ""))
+
+    script = textwrap.dedent(
+        f"""\
+        #!/usr/bin/env bash
+        DATA="{data}"
+        field() {{ awk -F'\\t' -v id="$1" -v n="$2" '$1==id {{print $n}}' "$DATA"; }}
+        case "$1" in
+          images) cut -f1 "$DATA" ;;
+          inspect)
+            case "$*" in
+              *WorkingDir*) field "$2" 2 ;;
+              *Config.Cmd*) field "$2" 3 ;;
+              *Created*)    field "$2" 4 ;;
+            esac
+            ;;
+          rmi) echo "$2" >> "{tmp_path}/removed.txt" ;;
+        esac
+        exit 0
+        """
+    )
+    (bin_dir / "docker").write_text(script)
+    (bin_dir / "docker").chmod(0o755)
+    return bin_dir
+
+
+def _run(tmp_path, images, **env):
+    bin_dir = _fake_docker(tmp_path, images)
+    result = subprocess.run(
+        ["bash", str(SCRIPT)],
+        capture_output=True,
+        text=True,
+        env={**os.environ, "PATH": f"{bin_dir}:{os.environ['PATH']}", **env},
+    )
+    removed_file = tmp_path / "removed.txt"
+    removed = removed_file.read_text().split() if removed_file.exists() else []
+    return result, removed
+
+
+def test_keeps_two_previous_api_images_by_default(tmp_path):
+    """Default IMAGE_RETENTION_SETS=3 means the running (tagged) set plus 2 previous."""
+    images = {
+        "api1": ("api", "2026-07-20T00:00:00Z"),
+        "api2": ("api", "2026-07-21T00:00:00Z"),
+        "api3": ("api", "2026-07-22T00:00:00Z"),
+        "api4": ("api", "2026-07-23T00:00:00Z"),
+    }
+    result, removed = _run(tmp_path, images)
+    assert result.returncode == 0, result.stderr
+    # newest two (api4, api3) survive; the older two go
+    assert sorted(removed) == ["api1", "api2"]
+
+
+def test_removes_oldest_first(tmp_path):
+    """Ordering is by created time, not by id or docker's listing order."""
+    images = {
+        "newest": ("api", "2026-07-25T00:00:00Z"),
+        "oldest": ("api", "2026-01-01T00:00:00Z"),
+        "middle": ("api", "2026-07-01T00:00:00Z"),
+    }
+    _, removed = _run(tmp_path, images)
+    assert removed == ["oldest"]
+
+
+def test_api_and_ui_counted_separately(tmp_path):
+    """3 API sets and 3 UI sets, not 3 images total."""
+    images = {
+        "api1": ("api", "2026-07-20T00:00:00Z"),
+        "api2": ("api", "2026-07-21T00:00:00Z"),
+        "ui1": ("ui", "2026-07-20T00:00:00Z"),
+        "ui2": ("ui", "2026-07-21T00:00:00Z"),
+    }
+    _, removed = _run(tmp_path, images)
+    # two of each is exactly the limit — nothing should be removed
+    assert removed == []
+
+
+def test_never_touches_unrecognised_images(tmp_path):
+    """Watchtower and anything else must never be a candidate."""
+    images = {
+        "other1": ("other", "2026-01-01T00:00:00Z"),
+        "other2": ("other", "2026-01-02T00:00:00Z"),
+        "other3": ("other", "2026-01-03T00:00:00Z"),
+        "other4": ("other", "2026-01-04T00:00:00Z"),
+    }
+    _, removed = _run(tmp_path, images)
+    assert removed == []
+
+
+def test_dry_run_removes_nothing(tmp_path):
+    images = {f"api{i}": ("api", f"2026-07-2{i}T00:00:00Z") for i in range(1, 5)}
+    result, removed = _run(tmp_path, images, DRY_RUN="1")
+    assert result.returncode == 0
+    assert removed == []
+    assert "would remove" in result.stdout
+
+
+def test_retention_count_is_configurable(tmp_path):
+    """IMAGE_RETENTION_SETS=1 keeps only the running set, so all untagged go."""
+    images = {f"api{i}": ("api", f"2026-07-2{i}T00:00:00Z") for i in range(1, 4)}
+    _, removed = _run(tmp_path, images, IMAGE_RETENTION_SETS="1")
+    assert sorted(removed) == ["api1", "api2", "api3"]
+
+
+def test_no_dangling_images_is_not_an_error(tmp_path):
+    result, removed = _run(tmp_path, {})
+    assert result.returncode == 0
+    assert removed == []
+
+
+@pytest.mark.parametrize("bad", ["0", "-1", "abc", "2.5"])
+def test_rejects_invalid_retention_count(tmp_path, bad):
+    """A typo'd value must fail loudly rather than silently deleting everything."""
+    images = {"api1": ("api", "2026-07-20T00:00:00Z")}
+    result, removed = _run(tmp_path, images, IMAGE_RETENTION_SETS=bad)
+    assert result.returncode != 0
+    assert removed == []
+
+
+def test_empty_retention_count_falls_back_to_default(tmp_path):
+    """`IMAGE_RETENTION_SETS=` in device.env means "use the default", not "abort"."""
+    images = {f"api{i}": ("api", f"2026-07-2{i}T00:00:00Z") for i in range(1, 5)}
+    result, removed = _run(tmp_path, images, IMAGE_RETENTION_SETS="")
+    assert result.returncode == 0
+    assert sorted(removed) == ["api1", "api2"]  # default of 3 -> keep 2 untagged

--- a/unit_tests/test_prune_images.py
+++ b/unit_tests/test_prune_images.py
@@ -1,14 +1,17 @@
-"""Retention logic for scripts/deploy/prune-images.sh (#355).
+"""Image retention / rollback logic for scripts/deploy/prune-images.sh (#355).
 
-The script cannot be imported, so each test builds a fake `docker` executable on
-PATH that answers the handful of subcommands the script uses. That keeps the
-real retention logic under test — classification, ordering, the keep-count —
-without needing Docker or a device.
+A device keeps at most two sets, both from its current ring: the image it runs
+(ring-tagged) and the build it replaced (untagged). A ring change deletes every
+old-ring image and leaves no fallback.
 
-Hardware note: the script's rule 1 ("never remove an image a container
-references") is enforced by `docker rmi` refusing, not by the script, so it
-cannot be exercised here. It is covered by the on-device check in
-deployment2_verify.sh.
+The script cannot be imported, so each test builds a fake `docker` on PATH that
+answers the few subcommands it uses. That keeps the real logic under test —
+classification, ordering, the ring-change branch — without needing Docker or a
+device.
+
+Hardware note: "never remove an image a container references" is enforced by
+`docker rmi` refusing, not by the script, so it cannot be exercised here. It is
+covered by the on-device check in deployment2_verify.sh.
 """
 
 import os
@@ -19,39 +22,50 @@ from pathlib import Path
 import pytest
 
 SCRIPT = Path(__file__).resolve().parents[1] / "scripts" / "deploy" / "prune-images.sh"
+REPO = "ghcr.io/acorngenetics/aquilla-main"
 
 API_WORKDIR = "/opt/aquila"
 UI_CMD = '["nginx","-g","daemon off;"]'
 
 
-def _fake_docker(tmp_path, images):
-    """Write a stub `docker` onto PATH.
+def _fake_docker(tmp_path, untagged, tagged):
+    """Stub `docker` on PATH.
 
-    ``images`` maps image id -> (kind, created), where kind is "api", "ui" or
-    "other". Removals are appended to removed.txt so a test can assert on them.
+    ``untagged`` maps image id -> (kind, created); kind is "api", "ui" or "other".
+    ``tagged`` is a list of full refs, e.g. f"{REPO}-api:pilot".
+    Removals are appended to removed.txt for assertions.
 
-    The stub reads a TSV data file rather than having the table generated into
-    its source — embedding shell-quoted JSON in generated `case` branches is
-    fragile enough to produce false failures.
+    The stub reads TSV data files rather than having tables generated into its
+    source — embedding shell-quoted JSON in generated `case` branches is fragile
+    enough to produce false failures.
     """
     bin_dir = tmp_path / "bin"
     bin_dir.mkdir(exist_ok=True)
 
     rows = []
-    for img_id, (kind, created) in images.items():
+    for img_id, (kind, created) in untagged.items():
         workdir = API_WORKDIR if kind == "api" else "/"
         cmd = {"ui": UI_CMD, "api": '["uvicorn"]'}.get(kind, '["sleep"]')
         rows.append(f"{img_id}\t{workdir}\t{cmd}\t{created}")
     data = tmp_path / "images.tsv"
     data.write_text("\n".join(rows) + ("\n" if rows else ""))
 
+    tags = tmp_path / "tags.txt"
+    tags.write_text("\n".join(tagged or []) + ("\n" if tagged else ""))
+
     script = textwrap.dedent(
         f"""\
         #!/usr/bin/env bash
         DATA="{data}"
+        TAGS="{tags}"
         field() {{ awk -F'\\t' -v id="$1" -v n="$2" '$1==id {{print $n}}' "$DATA"; }}
         case "$1" in
-          images) cut -f1 "$DATA" ;;
+          images)
+            case "$*" in
+              *Repository*) cat "$TAGS" ;;
+              *)            cut -f1 "$DATA" ;;
+            esac
+            ;;
           inspect)
             case "$*" in
               *WorkingDir*) field "$2" 2 ;;
@@ -69,109 +83,206 @@ def _fake_docker(tmp_path, images):
     return bin_dir
 
 
-def _run(tmp_path, images, **env):
-    bin_dir = _fake_docker(tmp_path, images)
+def _run(tmp_path, untagged=None, tagged=None, ring="pilot", last_ring=None, **env):
+    bin_dir = _fake_docker(tmp_path, untagged or {}, tagged or [])
+
+    fleet_env = tmp_path / "fleet.env"
+    fleet_env.write_text(f"IMAGE_TAG={ring}\n" if ring else "")
+
+    state = tmp_path / "prune-state"
+    if last_ring:
+        state.write_text(f"{last_ring}\n")
+    elif state.exists():
+        state.unlink()
+
+    (tmp_path / "removed.txt").unlink(missing_ok=True)
+
     result = subprocess.run(
         ["bash", str(SCRIPT)],
         capture_output=True,
         text=True,
-        env={**os.environ, "PATH": f"{bin_dir}:{os.environ['PATH']}", **env},
+        env={
+            **os.environ,
+            "PATH": f"{bin_dir}:{os.environ['PATH']}",
+            "FLEET_ENV": str(fleet_env),
+            "DEVICE_ENV": str(tmp_path / "nonexistent.env"),
+            "STATE_FILE": str(state),
+            **env,
+        },
     )
     removed_file = tmp_path / "removed.txt"
     removed = removed_file.read_text().split() if removed_file.exists() else []
     return result, removed
 
 
-def test_keeps_two_previous_api_images_by_default(tmp_path):
-    """Default IMAGE_RETENTION_SETS=3 means the running (tagged) set plus 2 previous."""
-    images = {
-        "api1": ("api", "2026-07-20T00:00:00Z"),
-        "api2": ("api", "2026-07-21T00:00:00Z"),
-        "api3": ("api", "2026-07-22T00:00:00Z"),
-        "api4": ("api", "2026-07-23T00:00:00Z"),
+# ── Same-ring updates ─────────────────────────────────────────────────────────
+
+def test_same_ring_update_keeps_current_plus_one_fallback(tmp_path):
+    """Deploy pilot v3: current=v3 (tagged), fallback=v2, v1 removed."""
+    untagged = {
+        "pilot_v1": ("api", "2026-07-01T00:00:00Z"),
+        "pilot_v2": ("api", "2026-07-02T00:00:00Z"),
     }
-    result, removed = _run(tmp_path, images)
+    result, removed = _run(
+        tmp_path, untagged, tagged=[f"{REPO}-api:pilot"], ring="pilot", last_ring="pilot"
+    )
     assert result.returncode == 0, result.stderr
-    # newest two (api4, api3) survive; the older two go
-    assert sorted(removed) == ["api1", "api2"]
+    assert removed == ["pilot_v1"], "only the older fallback should go"
 
 
-def test_removes_oldest_first(tmp_path):
-    """Ordering is by created time, not by id or docker's listing order."""
-    images = {
-        "newest": ("api", "2026-07-25T00:00:00Z"),
-        "oldest": ("api", "2026-01-01T00:00:00Z"),
-        "middle": ("api", "2026-07-01T00:00:00Z"),
+def test_same_ring_keeps_exactly_one_fallback_per_family(tmp_path):
+    """A spare API image with no matching UI image would roll back to nothing."""
+    untagged = {
+        "api_old": ("api", "2026-07-01T00:00:00Z"),
+        "api_new": ("api", "2026-07-02T00:00:00Z"),
+        "ui_old": ("ui", "2026-07-01T00:00:00Z"),
+        "ui_new": ("ui", "2026-07-02T00:00:00Z"),
     }
-    _, removed = _run(tmp_path, images)
-    assert removed == ["oldest"]
+    _, removed = _run(tmp_path, untagged, ring="pilot", last_ring="pilot")
+    assert sorted(removed) == ["api_old", "ui_old"]
 
 
-def test_api_and_ui_counted_separately(tmp_path):
-    """3 API sets and 3 UI sets, not 3 images total."""
-    images = {
-        "api1": ("api", "2026-07-20T00:00:00Z"),
-        "api2": ("api", "2026-07-21T00:00:00Z"),
-        "ui1": ("ui", "2026-07-20T00:00:00Z"),
-        "ui2": ("ui", "2026-07-21T00:00:00Z"),
+def test_fallback_chosen_by_creation_date(tmp_path):
+    untagged = {
+        "middle": ("api", "2026-07-02T00:00:00Z"),
+        "newest": ("api", "2026-07-03T00:00:00Z"),
+        "oldest": ("api", "2026-07-01T00:00:00Z"),
     }
-    _, removed = _run(tmp_path, images)
-    # two of each is exactly the limit — nothing should be removed
+    _, removed = _run(tmp_path, untagged, ring="pilot", last_ring="pilot")
+    assert "newest" not in removed
+    assert sorted(removed) == ["middle", "oldest"]
+
+
+# ── Ring changes ──────────────────────────────────────────────────────────────
+
+def test_ring_change_removes_all_old_ring_images_and_keeps_no_fallback(tmp_path):
+    """Promote pilot -> prod: pilot v3 and v2 both go, prod v1 has no fallback."""
+    untagged = {
+        "pilot_v2": ("api", "2026-07-02T00:00:00Z"),
+        "pilot_v3": ("api", "2026-07-03T00:00:00Z"),
+    }
+    tagged = [f"{REPO}-api:pilot", f"{REPO}-api:prod"]
+    result, removed = _run(tmp_path, untagged, tagged, ring="prod", last_ring="pilot")
+    assert result.returncode == 0, result.stderr
+    assert "pilot_v2" in removed and "pilot_v3" in removed, "no fallback survives a ring change"
+    assert f"{REPO}-api:pilot" in removed, "the old ring tag goes too"
+    assert f"{REPO}-api:prod" not in removed, "the new current image must survive"
+
+
+def test_first_run_with_no_state_is_treated_as_a_ring_change(tmp_path):
+    """An unverifiable fallback is not a fallback; establish a clean baseline."""
+    untagged = {"unknown_origin": ("api", "2026-07-02T00:00:00Z")}
+    result, removed = _run(tmp_path, untagged, ring="pilot", last_ring=None)
+    assert removed == ["unknown_origin"]
+    assert "no previous state" in result.stdout
+
+
+def test_ring_is_recorded_so_the_next_run_can_tell(tmp_path):
+    _run(tmp_path, ring="prod", last_ring="pilot")
+    assert (tmp_path / "prune-state").read_text().strip() == "prod"
+
+
+def test_dry_run_does_not_write_state(tmp_path):
+    """A dry run must not make the next real run think the ring was unchanged."""
+    result, removed = _run(tmp_path, ring="prod", last_ring="pilot", DRY_RUN="1")
+    assert removed == []
+    assert not (tmp_path / "prune-state").read_text().strip() == "prod"
+    assert "state not written" in result.stdout
+
+
+# ── Foreign and non-ring tags ─────────────────────────────────────────────────
+
+def test_removes_tags_for_rings_the_device_is_not_on(tmp_path):
+    tagged = [f"{REPO}-api:dev", f"{REPO}-api:pilot", f"{REPO}-ui:dev", f"{REPO}-ui:pilot"]
+    _, removed = _run(tmp_path, tagged=tagged, ring="pilot", last_ring="pilot")
+    assert sorted(removed) == sorted([f"{REPO}-api:dev", f"{REPO}-ui:dev"])
+
+
+def test_removes_latest_which_is_not_a_ring(tmp_path):
+    """No device should run :latest — it tracks whatever was built last."""
+    tagged = [f"{REPO}-api:latest", f"{REPO}-api:sandbox"]
+    _, removed = _run(tmp_path, tagged=tagged, ring="sandbox", last_ring="sandbox")
+    assert removed == [f"{REPO}-api:latest"]
+
+
+def test_never_touches_non_aquila_images(tmp_path):
+    """Watchtower and the dead telemetry images must survive."""
+    tagged = [
+        "nickfedor/watchtower:latest",
+        "timberio/vector:0.33.1-alpine",
+        "prom/node-exporter:latest",
+        "victoriametrics/vmagent:latest",
+    ]
+    untagged = {f"other{i}": ("other", f"2026-01-0{i}T00:00:00Z") for i in range(1, 5)}
+    _, removed = _run(tmp_path, untagged, tagged, ring="pilot", last_ring="pilot")
     assert removed == []
 
 
-def test_never_touches_unrecognised_images(tmp_path):
-    """Watchtower and anything else must never be a candidate."""
-    images = {
-        "other1": ("other", "2026-01-01T00:00:00Z"),
-        "other2": ("other", "2026-01-02T00:00:00Z"),
-        "other3": ("other", "2026-01-03T00:00:00Z"),
-        "other4": ("other", "2026-01-04T00:00:00Z"),
-    }
-    _, removed = _run(tmp_path, images)
-    assert removed == []
+# ── Safety ────────────────────────────────────────────────────────────────────
 
-
-def test_dry_run_removes_nothing(tmp_path):
-    images = {f"api{i}": ("api", f"2026-07-2{i}T00:00:00Z") for i in range(1, 5)}
-    result, removed = _run(tmp_path, images, DRY_RUN="1")
+def test_unknown_ring_removes_nothing(tmp_path):
+    """Never guess the ring — guessing wrong deletes the running image's fallback."""
+    untagged = {"api1": ("api", "2026-07-01T00:00:00Z")}
+    tagged = [f"{REPO}-api:dev"]
+    result, removed = _run(tmp_path, untagged, tagged, ring=None)
     assert result.returncode == 0
     assert removed == []
-    assert "would remove" in result.stdout
+    assert "will not guess" in result.stdout
 
 
-def test_retention_count_is_configurable(tmp_path):
-    """IMAGE_RETENTION_SETS=1 keeps only the running set, so all untagged go."""
-    images = {f"api{i}": ("api", f"2026-07-2{i}T00:00:00Z") for i in range(1, 4)}
-    _, removed = _run(tmp_path, images, IMAGE_RETENTION_SETS="1")
-    assert sorted(removed) == ["api1", "api2", "api3"]
-
-
-def test_no_dangling_images_is_not_an_error(tmp_path):
-    result, removed = _run(tmp_path, {})
+def test_no_images_is_not_an_error(tmp_path):
+    result, removed = _run(tmp_path, ring="pilot", last_ring="pilot")
     assert result.returncode == 0
     assert removed == []
 
 
-@pytest.mark.parametrize("bad", ["0", "-1", "abc", "2.5"])
-def test_rejects_invalid_retention_count(tmp_path, bad):
-    """A typo'd value must fail loudly rather than silently deleting everything."""
-    images = {"api1": ("api", "2026-07-20T00:00:00Z")}
-    result, removed = _run(tmp_path, images, IMAGE_RETENTION_SETS=bad)
-    assert result.returncode != 0
+# ── The worked example from the spec ──────────────────────────────────────────
+
+def test_full_lifecycle_matches_the_spec(tmp_path):
+    """Pilot v1->v2->v3, promote to prod, then prod v1->v2->v3."""
+    api_pilot, api_prod = f"{REPO}-api:pilot", f"{REPO}-api:prod"
+
+    # Deploy pilot v2 — v1 becomes the fallback, nothing to delete yet.
+    _, removed = _run(
+        tmp_path, {"v1": ("api", "2026-07-01T00:00:00Z")},
+        [api_pilot], ring="pilot", last_ring="pilot",
+    )
     assert removed == []
 
+    # Deploy pilot v3 — v2 becomes the fallback, v1 goes.
+    _, removed = _run(
+        tmp_path,
+        {"v1": ("api", "2026-07-01T00:00:00Z"), "v2": ("api", "2026-07-02T00:00:00Z")},
+        [api_pilot], ring="pilot", last_ring="pilot",
+    )
+    assert removed == ["v1"]
 
-def test_empty_retention_count_falls_back_to_default(tmp_path):
-    """`IMAGE_RETENTION_SETS=` in device.env means "use the default", not "abort"."""
-    images = {f"api{i}": ("api", f"2026-07-2{i}T00:00:00Z") for i in range(1, 5)}
-    result, removed = _run(tmp_path, images, IMAGE_RETENTION_SETS="")
-    assert result.returncode == 0
-    assert sorted(removed) == ["api1", "api2"]  # default of 3 -> keep 2 untagged
+    # Promote to prod — every pilot image goes, no fallback.
+    _, removed = _run(
+        tmp_path,
+        {"v2": ("api", "2026-07-02T00:00:00Z"), "v3": ("api", "2026-07-03T00:00:00Z")},
+        [api_pilot, api_prod], ring="prod", last_ring="pilot",
+    )
+    assert sorted(removed) == sorted(["v2", "v3", api_pilot])
+
+    # Deploy prod v2 — prod v1 becomes the fallback.
+    _, removed = _run(
+        tmp_path, {"prod_v1": ("api", "2026-07-04T00:00:00Z")},
+        [api_prod], ring="prod", last_ring="prod",
+    )
+    assert removed == []
+
+    # Deploy prod v3 — prod v2 is the fallback, prod v1 goes.
+    _, removed = _run(
+        tmp_path,
+        {"prod_v1": ("api", "2026-07-04T00:00:00Z"), "prod_v2": ("api", "2026-07-05T00:00:00Z")},
+        [api_prod], ring="prod", last_ring="prod",
+    )
+    assert removed == ["prod_v1"]
 
 
-# ── entrypoint sync (#355) ────────────────────────────────────────────────────
-# The script reaches a device by riding in the container image: docker/entrypoint.sh
+# ── entrypoint sync ───────────────────────────────────────────────────────────
+# The script reaches a device by riding in the container image: entrypoint.sh
 # copies it to /opt/fleet, which is bind-mounted from the host. That is the only
 # automatic delivery path — nothing on a device fetches host-side scripts.
 
@@ -179,7 +290,6 @@ ENTRYPOINT = Path(__file__).resolve().parents[1] / "docker" / "entrypoint.sh"
 
 
 def _run_entrypoint(tmp_path, fleet_dir, make_writable=True):
-    """Run entrypoint.sh with a fake /opt/fleet and a stubbed command."""
     helper_src = tmp_path / "opt" / "aquila" / "scripts" / "deploy"
     helper_src.mkdir(parents=True, exist_ok=True)
     (helper_src / "prune-images.sh").write_text("#!/usr/bin/env bash\necho stub\n")
@@ -188,11 +298,8 @@ def _run_entrypoint(tmp_path, fleet_dir, make_writable=True):
     if not make_writable:
         fleet_dir.chmod(0o500)
 
-    # entrypoint.sh hardcodes /opt/aquila/scripts/deploy; rewrite it to the fake
-    # tree so the test does not need to run as root or inside a container.
     src = ENTRYPOINT.read_text().replace(
-        'helper_src="/opt/aquila/scripts/deploy"',
-        f'helper_src="{helper_src}"',
+        'helper_src="/opt/aquila/scripts/deploy"', f'helper_src="{helper_src}"'
     )
     patched = tmp_path / "entrypoint.sh"
     patched.write_text(src)
@@ -211,12 +318,12 @@ def test_entrypoint_syncs_prune_script_to_fleet_dir(tmp_path):
     result = _run_entrypoint(tmp_path, fleet)
     assert result.returncode == 0, result.stderr
     synced = fleet / "prune-images.sh"
-    assert synced.exists(), "prune-images.sh was not written to the fleet dir"
-    assert os.access(synced, os.X_OK), "synced script is not executable"
+    assert synced.exists()
+    assert os.access(synced, os.X_OK)
 
 
 def test_entrypoint_overwrites_an_older_copy(tmp_path):
-    """A device already holding an old copy must get the new one on restart."""
+    """A device holding an old copy must get the new one on restart."""
     fleet = tmp_path / "fleet"
     fleet.mkdir()
     (fleet / "prune-images.sh").write_text("#!/usr/bin/env bash\necho STALE\n")
@@ -225,14 +332,12 @@ def test_entrypoint_overwrites_an_older_copy(tmp_path):
 
 
 def test_entrypoint_survives_missing_fleet_mount(tmp_path):
-    """/opt/fleet is mounted into backend only — this is a no-op in the app container."""
+    """/opt/fleet is mounted into backend only — a no-op in the app container."""
     result = _run_entrypoint(tmp_path, tmp_path / "does-not-exist")
     assert result.returncode == 0, result.stderr
 
 
 def test_entrypoint_survives_readonly_fleet_mount(tmp_path):
-    """A read-only mount must not stop the backend from starting."""
-    fleet = tmp_path / "ro-fleet"
-    result = _run_entrypoint(tmp_path, fleet, make_writable=False)
-    fleet.chmod(0o700)  # restore so pytest can clean up
+    result = _run_entrypoint(tmp_path, tmp_path / "ro-fleet", make_writable=False)
+    (tmp_path / "ro-fleet").chmod(0o700)  # restore so pytest can clean up
     assert result.returncode == 0, result.stderr

--- a/unit_tests/test_prune_images.py
+++ b/unit_tests/test_prune_images.py
@@ -168,3 +168,71 @@ def test_empty_retention_count_falls_back_to_default(tmp_path):
     result, removed = _run(tmp_path, images, IMAGE_RETENTION_SETS="")
     assert result.returncode == 0
     assert sorted(removed) == ["api1", "api2"]  # default of 3 -> keep 2 untagged
+
+
+# ── entrypoint sync (#355) ────────────────────────────────────────────────────
+# The script reaches a device by riding in the container image: docker/entrypoint.sh
+# copies it to /opt/fleet, which is bind-mounted from the host. That is the only
+# automatic delivery path — nothing on a device fetches host-side scripts.
+
+ENTRYPOINT = Path(__file__).resolve().parents[1] / "docker" / "entrypoint.sh"
+
+
+def _run_entrypoint(tmp_path, fleet_dir, make_writable=True):
+    """Run entrypoint.sh with a fake /opt/fleet and a stubbed command."""
+    helper_src = tmp_path / "opt" / "aquila" / "scripts" / "deploy"
+    helper_src.mkdir(parents=True, exist_ok=True)
+    (helper_src / "prune-images.sh").write_text("#!/usr/bin/env bash\necho stub\n")
+
+    fleet_dir.mkdir(parents=True, exist_ok=True)
+    if not make_writable:
+        fleet_dir.chmod(0o500)
+
+    # entrypoint.sh hardcodes /opt/aquila/scripts/deploy; rewrite it to the fake
+    # tree so the test does not need to run as root or inside a container.
+    src = ENTRYPOINT.read_text().replace(
+        'helper_src="/opt/aquila/scripts/deploy"',
+        f'helper_src="{helper_src}"',
+    )
+    patched = tmp_path / "entrypoint.sh"
+    patched.write_text(src)
+    patched.chmod(0o755)
+
+    return subprocess.run(
+        ["bash", str(patched), "true"],
+        capture_output=True,
+        text=True,
+        env={**os.environ, "FLEET_DIR": str(fleet_dir), "PROFILE_DIR": str(tmp_path / "profiles")},
+    )
+
+
+def test_entrypoint_syncs_prune_script_to_fleet_dir(tmp_path):
+    fleet = tmp_path / "fleet"
+    result = _run_entrypoint(tmp_path, fleet)
+    assert result.returncode == 0, result.stderr
+    synced = fleet / "prune-images.sh"
+    assert synced.exists(), "prune-images.sh was not written to the fleet dir"
+    assert os.access(synced, os.X_OK), "synced script is not executable"
+
+
+def test_entrypoint_overwrites_an_older_copy(tmp_path):
+    """A device already holding an old copy must get the new one on restart."""
+    fleet = tmp_path / "fleet"
+    fleet.mkdir()
+    (fleet / "prune-images.sh").write_text("#!/usr/bin/env bash\necho STALE\n")
+    _run_entrypoint(tmp_path, fleet)
+    assert "STALE" not in (fleet / "prune-images.sh").read_text()
+
+
+def test_entrypoint_survives_missing_fleet_mount(tmp_path):
+    """/opt/fleet is mounted into backend only — this is a no-op in the app container."""
+    result = _run_entrypoint(tmp_path, tmp_path / "does-not-exist")
+    assert result.returncode == 0, result.stderr
+
+
+def test_entrypoint_survives_readonly_fleet_mount(tmp_path):
+    """A read-only mount must not stop the backend from starting."""
+    fleet = tmp_path / "ro-fleet"
+    result = _run_entrypoint(tmp_path, fleet, make_writable=False)
+    fleet.chmod(0o700)  # restore so pytest can clean up
+    assert result.returncode == 0, result.stderr


### PR DESCRIPTION
Implements #355.

## The problem

**Nothing on a device has ever removed an image.** Measured live:

| Device | Ring | Images | Untagged | Reclaimable | Disk |
|---|---|---|---|---|---|
| **sn03** | sandbox | 30 | **18** | ~9.8 GB (82%) | 40% of 58 GB |
| **sn07** | pilot | 8 | 5 | 2.32 GB (65%) | 22% of 58 GB |

The oldest image on sn03 is `timberio/vector` from **2023-10-30** — part of a telemetry stack replaced by Grafana Alloy and never cleaned up. sn03 has only ever pulled ~11 API images across 8 weeks, and every superseded one is still on disk.

So this is not intermittent cleanup failure. No image has ever been removed, by any path. The untagged images are fully orphaned — **zero container references, nothing blocking removal**. They were simply never deleted.

Watchtower runs with `--cleanup`, which should remove the image it replaces, but that evidently is not happening. The exact path that orphans them is **not established**, and this fix deliberately does not depend on knowing it: the prune removes orphaned images regardless of what orphaned them, and the timer runs regardless of how updates arrive.

*(219 CI builds is not 219 device pulls — only promoted builds get a ring tag, and a device only pulls when it updates.)*

## Retention rule

A device keeps **at most two sets**, both from its **current** ring:

| | |
|---|---|
| **current** | the image it runs — carries the ring tag |
| **fallback** | the build it replaced — untagged |

A set is one API + one UI image, so at most 4 Aquila images on disk.

**Same-ring update** (`pilot v2` → `pilot v3`)
The replaced build becomes the fallback; the previous fallback is deleted.
→ current `v3`, fallback `v2`, `v1` removed.

**Ring change** (`pilot` → `prod`)
Every image from the old ring goes — current and fallback alike — and the device starts with **no fallback**.

### Why no cross-ring fallback

Falling back to another ring is not a rollback. Promotion flows `sandbox → dev → pilot → prod`, so at any moment the old ring's image is **newer and less soaked** than the one just promoted in. "Falling back" onto it would mean running *less-tested* software.

The rollback that matters is the previous build of the device's own ring.

## Why one ring name is the only state needed

An untagged image carries no record of its ring. Verified on-device:

```
orphan 3aa691d30db1 ->
  RepoTags:    []
  RepoDigests: []
  Labels:      map[]
```

So "the previous pilot image" is not identifiable by inspection. And an image cannot carry its ring even in principle — a build is promoted `sandbox → dev → pilot → prod` by retagging the same digest *after* it is built.

**The ring-change rule removes the need to identify it.** Because a ring change deletes every old-ring image, the invariant afterwards is **zero orphans**. Each same-ring update then adds exactly one and removes the previous, so the orphan pool is always ≤ 1 **and always from the current ring**. Sorting by date is therefore exact rather than approximate — given only one recorded value: the ring seen on the previous run.

## ⚠️ Decision worth confirming: the first run keeps no fallback

**No state file — a fresh device, or the first run on an existing one — is treated as a ring change.** So the first run keeps no fallback.

Reasoning: an unverifiable fallback is not a fallback (it could be residue from a ring the device no longer runs), and treating it this way establishes the zero-orphan invariant everything above depends on. It costs at most one rollback target, once.

If the first run should instead preserve the newest orphan on faith, that is a one-line change — flagging it because it is a judgement call, not a forced one.

## Ordering

Fallbacks are pruned **before** foreign ring tags are removed. This is deliberate: `docker rmi api:dev` turns that image into an orphan, so the reverse order would let a just-untagged foreign-ring image compete to be kept as the fallback — potentially deleting every genuine own-ring rollback target and keeping a dev image as the spare.

## Safety

1. **An image a container references is never removed.** Enforced by Docker, not by this script — `docker rmi` refuses. A logic error here cannot take down a running container.
2. **Anything not positively identified as an Aquila API or UI image is never touched** — Watchtower and the dead Vector/VictoriaMetrics/node-exporter images are never candidates.
3. **If the ring cannot be determined, nothing is removed.** The script exits rather than guessing.

### Telling API from UI

Untagged images have lost their repository name, so they are classified by config baked in at build time, verified on a live device:

| | `.Config.WorkingDir` | `.Config.Cmd` |
|---|---|---|
| API | `/opt/aquila` | `[uvicorn aquila_web.main:app ...]` |
| UI | `/` | `[nginx -g daemon off;]` |

Once #351 bakes OCI labels into the images this can key off `org.opencontainers.image.*` and stop depending on the entrypoint.

## How the script reaches a device

**It ships inside the container image**, and `docker/entrypoint.sh` writes it to `/opt/fleet` — bind-mounted into the backend — on every start.

An earlier revision had `deployment2.sh` fetch it from `raw.githubusercontent.com/.../main` at provisioning, copying the convention used for `update.sh` and `docker-compose.yml`. That was wrong twice over:

- **`docker-compose.yml` is ring-agnostic by construction.** It is a template; the ring lives in the `${IMAGE_TAG}` variable, not the file. One copy is correct for the whole fleet. `prune-images.sh` contains behaviour, not parameters — there is no substitution that makes one version right everywhere, and its bugs delete images.
- **Fetching at provisioning freezes it forever.** Nothing refreshes host scripts afterwards, so a device flashed in June and one flashed today would run different prune logic indefinitely, with no way to tell them apart or fix either without SSH.

Shipping it in the image gives both properties that matter: it is **ring-versioned** (a pilot device runs the pilot build's script, so changes soak through `sandbox → dev → pilot → prod`) and it **updates automatically** (container images are the only automatic delivery path to a device).

Only the backend bind-mounts `/opt/fleet`, so the sync is a no-op in the app container, and it is best-effort — an absent or read-only mount must never stop the backend from starting.

## Where it runs

**A systemd timer** (daily, `RandomizedDelaySec=6h`, `Persistent=true`), following the existing `aquila-cert-renew` pattern. `Persistent=true` matters — devices are routinely offline for days.

A timer rather than only the `fleet-update.sh` hook, because there are **two update paths and the hook covers one**: `/opt/fleet/update.sh` is manual (nothing schedules it — no timer, no cron on sn03), while the UI's "Update Now" goes through Watchtower's `POST /v1/update` and never touches it.

`fleet-update.sh` calls it too, non-fatally — a missed prune costs disk, not availability.

## Verification

**Dry run against sn03's real state, all three modes:**

```
first run (no state)   ring: sandbox (no previous state — treating as a ring change)
                       api: 11 untagged, keeping 0, removing 11
                       ui:   7 untagged, keeping 0, removing 7

same ring              ring: sandbox (unchanged — keeping current + 1 fallback)
                       api: 11 untagged, keeping 1, removing 10
                       ui:   7 untagged, keeping 1, removing 6

ring change (dev→sandbox)  api/ui: keeping 0
```

All three also remove `api:dev`, `ui:dev` and `api:latest`, and leave Watchtower and the dead telemetry images alone.

**17 unit tests** (`unit_tests/test_prune_images.py`) — including the full worked lifecycle from the spec: pilot v1→v2→v3, promotion to prod, prod v1→v2→v3. They stub `docker` on PATH, so no Docker or device is needed.

Rule 1 cannot be unit-tested (Docker enforces it, not the script) and is covered by the on-device check instead.

**Full suite:** 37 failed / 859 passed / 237 skipped. The 37 are pre-existing hardware-test pollution failures present on clean `main`; passed count is up 17 from the new tests. All touched scripts pass `bash -n`.

## Deployment constraint

The systemd `.timer` and `.service` files are installed by `deployment2.sh` and **need a one-time bootstrap on existing devices** — a container cannot run `systemctl` on the host. After that the script behind them updates itself forever via the image.

There is no OTA path for host-side unit files. Existing devices can be run manually over SSH in the meantime:

```bash
ssh pi@<device> 'DRY_RUN=1 bash -s' < scripts/deploy/prune-images.sh   # preview
ssh pi@<device> 'bash -s' < scripts/deploy/prune-images.sh             # apply
```

Note there is deliberately **no separate bulk-cleanup step**. The rule is count-based, so the first run fixes the existing backlog and prevents future growth in the same pass — an earlier draft recommended running `docker image prune -f` first, which would have been both redundant and harmful, since it deletes *all* untagged images including the fallback this issue exists to keep.

## Verify checks

`deployment2_verify.sh` asserts the script **actually runs** (`DRY_RUN=1`), not merely that the timer is enabled — a check that only tested `systemctl is-enabled` would pass with a missing or broken script.

Part of #355.
