### PR TITLE
fix(ota): report update outcomes honestly in both directions

### DIFF
--- a/aquila_web/main.py
+++ b/aquila_web/main.py
@@ -10,7 +10,8 @@ from pathlib import Path
 from fastapi import WebSocket
 import asyncio
 import logging
-from datetime import datetime
+import time
+from datetime import datetime, timezone
 import os
 import sys
 from pydantic import BaseModel
@@ -2003,6 +2004,16 @@ _OTA_GHCR_REPO_API = _OTA_GHCR_BASE + "-api"
 _OTA_GHCR_REPO_UI  = _OTA_GHCR_BASE + "-ui"
 _OTA_IMAGE_TAG = os.getenv("IMAGE_TAG", "")   # dev | pilot | prod — set by device.env
 _OTA_POLL_INTERVAL = int(os.getenv("UPDATE_CHECK_INTERVAL", "300"))  # seconds
+# How long to wait for an update to complete before declaring it failed. Sized to
+# the pull, not to a request timeout: the old code allowed 60s for a synchronous
+# call that had to download the whole image, so any update slower than a minute
+# was reported as a failure while it was still succeeding (#350 mode 1).
+_OTA_APPLY_TIMEOUT = int(os.getenv("AQ_UPDATE_APPLY_TIMEOUT", "900"))  # seconds
+_FLEET_ENV_PATH = os.getenv("AQ_FLEET_ENV_PATH", "/opt/fleet/.env")
+# A successful check older than this means the device has not verified its
+# software in a long time — surfaced to the operator, since a device that cannot
+# check looks identical to one that is up to date (#350 mode 2).
+_OTA_STALE_AFTER = int(os.getenv("AQ_UPDATE_STALE_AFTER", "86400"))  # seconds
 
 _update_available: bool = False
 _update_dismissed: bool = False
@@ -2069,8 +2080,26 @@ def _resolve_startup_update_state() -> None:
 # ------------------------------------------------------------------------------
 
 
-async def _ghcr_bearer_token(user: str, token: str, repo: str) -> str | None:
-    """Exchange Basic credentials for a short-lived GHCR Bearer token."""
+# Why a registry check failed. These previously all collapsed to None, which is
+# why the operator-facing message had to say "Registry unreachable OR credentials
+# invalid" — the code genuinely could not tell. They need different actions
+# ("check the network" vs "escalate"), so they are distinguished here. See #350.
+_ERR_NETWORK = "network"
+_ERR_AUTH = "auth"
+_ERR_REGISTRY = "registry"
+
+_ERR_MESSAGES = {
+    _ERR_NETWORK: "No internet connection",
+    _ERR_AUTH: "The update server rejected this device's credentials",
+    _ERR_REGISTRY: "The update server returned an unexpected response",
+}
+
+
+async def _ghcr_bearer_token(user: str, token: str, repo: str) -> tuple[str | None, str | None]:
+    """Exchange Basic credentials for a short-lived GHCR Bearer token.
+
+    Returns (token, error_kind). Exactly one is non-None.
+    """
     cred = base64.b64encode(f"{user}:{token}".encode()).decode()
     owner = repo.split("/")[0]
     name = "/".join(repo.split("/")[1:]) or repo
@@ -2078,18 +2107,28 @@ async def _ghcr_bearer_token(user: str, token: str, repo: str) -> str | None:
     try:
         async with httpx.AsyncClient(timeout=15.0) as client:
             r = await client.get(url, headers={"Authorization": f"Basic {cred}"})
-        if r.status_code == 200:
-            return r.json().get("token")
-    except Exception:
-        pass
-    return None
+    except httpx.RequestError:
+        # Connect failure, DNS failure, timeout — the device cannot reach GHCR.
+        return None, _ERR_NETWORK
+    except Exception:  # noqa: BLE001 - an update check must never crash the poller
+        logger.exception("unexpected error fetching GHCR token")
+        return None, _ERR_REGISTRY
+
+    if r.status_code in (401, 403):
+        return None, _ERR_AUTH
+    if r.status_code != 200:
+        return None, _ERR_REGISTRY
+    bearer = r.json().get("token")
+    return (bearer, None) if bearer else (None, _ERR_REGISTRY)
 
 
-async def _ghcr_manifest_digest(repo: str, tag: str, user: str, token: str) -> str | None:
-    """Return the manifest digest for a GHCR image tag without pulling it."""
-    bearer = await _ghcr_bearer_token(user, token, repo)
+async def _ghcr_manifest_digest(
+    repo: str, tag: str, user: str, token: str
+) -> tuple[str | None, str | None]:
+    """Return (manifest digest, error_kind) for a GHCR image tag without pulling it."""
+    bearer, err = await _ghcr_bearer_token(user, token, repo)
     if bearer is None:
-        return None
+        return None, err
     owner = repo.split("/")[0]
     name = "/".join(repo.split("/")[1:]) or repo
     url = f"https://ghcr.io/v2/{owner}/{name}/manifests/{tag}"
@@ -2104,47 +2143,78 @@ async def _ghcr_manifest_digest(repo: str, tag: str, user: str, token: str) -> s
     try:
         async with httpx.AsyncClient(timeout=15.0) as client:
             r = await client.head(url, headers=headers, follow_redirects=True)
-        return r.headers.get("docker-content-digest")
-    except Exception:
-        return None
+    except httpx.RequestError:
+        return None, _ERR_NETWORK
+    except Exception:  # noqa: BLE001
+        logger.exception("unexpected error fetching GHCR manifest")
+        return None, _ERR_REGISTRY
+
+    if r.status_code in (401, 403):
+        return None, _ERR_AUTH
+    if r.status_code >= 400:
+        return None, _ERR_REGISTRY
+    digest = r.headers.get("docker-content-digest")
+    return (digest, None) if digest else (None, _ERR_REGISTRY)
 
 
 async def _do_check_update() -> None:
+    """Ask GHCR whether a newer image exists. Never pulls.
+
+    `idle` means "checked successfully, nothing new". A check that could not run
+    reports `offline` instead — previously both produced `idle`, and the UI
+    rendered that as a green "Software is up to date" on a device that had in
+    fact failed to reach the registry (#350 mode 2).
+    """
     global _update_available, _update_status, _update_error, _update_last_checked
     global _startup_image_digest, _startup_image_digest_ui, _latest_ghcr_digest, _latest_ghcr_digest_ui
     _update_status = "checking"
     try:
         if not _OTA_GHCR_TOKEN or not _OTA_IMAGE_TAG:
-            _update_status = "idle"
-            _update_error = "Registry credentials or IMAGE_TAG not configured"
+            _update_status = "offline"
+            _update_error = "This device is not configured to receive updates"
             return
-        latest_api, latest_ui = await asyncio.gather(
+
+        (latest_api, err_api), (latest_ui, err_ui) = await asyncio.gather(
             _ghcr_manifest_digest(_OTA_GHCR_REPO_API, _OTA_IMAGE_TAG, _OTA_GHCR_USER, _OTA_GHCR_TOKEN),
             _ghcr_manifest_digest(_OTA_GHCR_REPO_UI,  _OTA_IMAGE_TAG, _OTA_GHCR_USER, _OTA_GHCR_TOKEN),
         )
-        _update_last_checked = datetime.utcnow().isoformat() + "Z"
-        if latest_api is None and latest_ui is None:
-            _update_status = "idle"
-            _update_error = "Registry unreachable or credentials invalid"
+
+        # A partial result is a failed check, not a partial success. Accepting one
+        # digest while the other is unknown is exactly how the API and UI end up on
+        # different builds: the update gets offered and applied with only one digest
+        # recorded (#350 mode 5).
+        err = err_api or err_ui
+        if err:
+            _update_status = "offline"
+            _update_error = _ERR_MESSAGES.get(err, "Could not reach the update server")
+            # Drop any previously-known availability. It may well still be true,
+            # but offering "Update Now" against a registry we cannot reach sends
+            # the operator into a failing apply — and the UI checks `available`
+            # before `status`, so leaving it set would hide the offline warning
+            # entirely. The next successful check re-establishes it.
+            _update_available = False
             return
-        if latest_api is not None:
-            _latest_ghcr_digest = latest_api
-        if latest_ui is not None:
-            _latest_ghcr_digest_ui = latest_ui
+
+        # Only a successful check updates this. It is shown to the operator as
+        # "last successful check", so a failed attempt must not refresh it.
+        _update_last_checked = datetime.utcnow().isoformat() + "Z"
+
+        _latest_ghcr_digest = latest_api
+        _latest_ghcr_digest_ui = latest_ui
         if _startup_image_digest is None:
             _startup_image_digest = latest_api
         if _startup_image_digest_ui is None:
             _startup_image_digest_ui = latest_ui
-        api_changed = latest_api is not None and latest_api != _startup_image_digest
-        ui_changed  = latest_ui  is not None and latest_ui  != _startup_image_digest_ui
-        if api_changed or ui_changed:
+
+        if latest_api != _startup_image_digest or latest_ui != _startup_image_digest_ui:
             _update_available = True
             _update_status = "available"
         else:
             _update_available = False
             _update_status = "idle"
         _update_error = None
-    except Exception as e:
+    except Exception as e:  # noqa: BLE001 - the poller must survive anything
+        logger.exception("update check failed")
         _update_status = "error"
         _update_error = str(e)
 
@@ -2160,12 +2230,26 @@ async def get_update_status():
     if DEV_UPDATE_AVAILABLE and not _update_dismissed:
         available = True
         status = "available"
+
+    # A device that cannot reach the registry looks identical to one that is up
+    # to date, so the age of the last SUCCESSFUL check is surfaced. `stale` is
+    # true when that is too long ago — or when there has never been one.
+    age = None
+    if _update_last_checked:
+        try:
+            last = datetime.fromisoformat(_update_last_checked.replace("Z", "+00:00"))
+            age = max(0, int((datetime.now(timezone.utc) - last).total_seconds()))
+        except (ValueError, AttributeError):
+            age = None
+
     return {
         "available": available,
         "dismissed": _update_dismissed,
         "status": status,
         "error": _update_error,
         "last_checked": _update_last_checked,
+        "last_checked_age_seconds": age,
+        "stale": age is None or age > _OTA_STALE_AFTER,
     }
 
 
@@ -2177,6 +2261,131 @@ async def trigger_update_check():
     return {"ok": True, "message": "checking"}
 
 
+def _parse_prom_metric(body: str, name: str) -> float | None:
+    """Pull a single value out of Prometheus text exposition format."""
+    for line in body.splitlines():
+        line = line.strip()
+        if not line or line.startswith("#"):
+            continue
+        if line.split("{")[0].split(" ")[0] != name:
+            continue
+        try:
+            return float(line.rsplit(" ", 1)[1])
+        except (IndexError, ValueError):
+            return None
+    return None
+
+
+async def _watchtower_metrics() -> dict | None:
+    """Read Watchtower's scan counters. None if the endpoint is unavailable.
+
+    Requires `--http-api-metrics` on the Watchtower container. Without it this
+    returns None and an update's outcome cannot be confirmed — in which case the
+    status is left as `updating` for the poller to resolve, never reported as
+    success.
+    """
+    headers = {"Authorization": f"Bearer {WATCHTOWER_TOKEN}"} if WATCHTOWER_TOKEN else {}
+    try:
+        async with httpx.AsyncClient(timeout=10.0) as client:
+            r = await client.get(f"{WATCHTOWER_URL}/v1/metrics", headers=headers)
+        if r.status_code != 200:
+            return None
+        return {
+            "scans": _parse_prom_metric(r.text, "watchtower_scans_total"),
+            "updated": _parse_prom_metric(r.text, "watchtower_containers_updated"),
+            "failed": _parse_prom_metric(r.text, "watchtower_containers_failed"),
+        }
+    except Exception:  # noqa: BLE001 - never let metrics polling raise into the caller
+        return None
+
+
+async def _await_update_outcome(scans_before: float | None, prev_digests: tuple) -> None:
+    """Watch for the update to finish, and report failure if it does not.
+
+    On success this coroutine never completes: Watchtower replaces the backend
+    container and the process is killed. Surviving to the end therefore means the
+    update did NOT apply, which is exactly the case the previous code reported as
+    success (#350 mode 3).
+    """
+    global _update_status, _update_error, _update_available
+
+    deadline = time.monotonic() + _OTA_APPLY_TIMEOUT
+    while time.monotonic() < deadline:
+        await asyncio.sleep(10)
+        m = await _watchtower_metrics()
+        if m is None:
+            continue
+        # Wait for OUR scan to land rather than reading the previous one's numbers.
+        if scans_before is not None and m["scans"] is not None and m["scans"] <= scans_before:
+            continue
+        if m["failed"]:
+            _fail_update("The update could not be downloaded. The device is still "
+                         "running the previous version.", prev_digests)
+            return
+        if m["updated"]:
+            # Containers were replaced but this process is somehow still alive.
+            # Leave the sentinel in place and let the poller settle the state.
+            return
+
+    _fail_update("The update timed out. The device is still running the previous "
+                 "version.", prev_digests)
+
+
+def _fail_update(message: str, prev_digests: tuple) -> None:
+    """Record a confirmed failure and undo everything the apply wrote up front."""
+    global _update_status, _update_error, _update_available
+    _update_status = "update_failed"
+    _update_error = message
+    _update_available = True  # the update is still outstanding
+
+    # Disarm the reboot. The sentinel is written before triggering Watchtower
+    # because a kill mid-swap must still leave it behind — but if the swap never
+    # happened, a stale `reboot_pending` reboots the device for an update that did
+    # not apply, then shows "Update Complete" (#350 mode 4).
+    try:
+        _sentinel.clear_sentinel(_UPDATE_SENTINEL_PATH)
+    except OSError:
+        logger.warning("could not clear update sentinel at %s", _UPDATE_SENTINEL_PATH)
+
+    # Put the recorded digests back so /opt/fleet/.env does not claim a version
+    # the device is not running.
+    _write_fleet_digests(*prev_digests)
+
+
+def _read_fleet_digests() -> tuple:
+    api = ui = None
+    try:
+        with open(_FLEET_ENV_PATH, "r") as f:
+            for line in f:
+                if line.startswith("RUNNING_IMAGE_DIGEST_UI="):
+                    ui = line.split("=", 1)[1].strip()
+                elif line.startswith("RUNNING_IMAGE_DIGEST="):
+                    api = line.split("=", 1)[1].strip()
+    except OSError:
+        pass
+    return api, ui
+
+
+def _write_fleet_digests(api: str | None, ui: str | None) -> None:
+    if not os.path.exists(_FLEET_ENV_PATH):
+        return
+    try:
+        with open(_FLEET_ENV_PATH, "r") as f:
+            lines = f.readlines()
+        out = []
+        for line in lines:
+            if line.startswith("RUNNING_IMAGE_DIGEST_UI=") and ui is not None:
+                out.append(f"RUNNING_IMAGE_DIGEST_UI={ui}\n")
+            elif line.startswith("RUNNING_IMAGE_DIGEST=") and api is not None:
+                out.append(f"RUNNING_IMAGE_DIGEST={api}\n")
+            else:
+                out.append(line)
+        with open(_FLEET_ENV_PATH, "w") as f:
+            f.writelines(out)
+    except OSError:
+        logger.warning("could not update digests in %s", _FLEET_ENV_PATH)
+
+
 @app.post("/update/apply")
 async def apply_update():
     global _update_status, _update_error, _startup_image_digest, _startup_image_digest_ui, _update_available
@@ -2185,59 +2394,58 @@ async def apply_update():
             status_code=409,
             content={"ok": False, "error": "Cannot update during an active run. Stop the run first."},
         )
+
+    prev_digests = _read_fleet_digests()
+    # Capture before triggering so we can tell OUR scan's results from the
+    # previous scan's leftovers.
+    before = await _watchtower_metrics()
+    scans_before = before["scans"] if before else None
+    if before is None:
+        logger.warning(
+            "Watchtower metrics unavailable (needs --http-api-metrics); "
+            "an update's outcome cannot be confirmed"
+        )
+
     # Breadcrumb the new container reads on startup to drive the auto-reboot (#183).
-    # Written before triggering Watchtower so a kill mid-swap still leaves it behind.
+    # Written before triggering Watchtower so a kill mid-swap still leaves it
+    # behind; _fail_update() clears it again if the swap is confirmed not to have
+    # happened.
     try:
         _sentinel.write_sentinel(_UPDATE_SENTINEL_PATH, "reboot_pending", _utcnow_iso())
     except OSError:
         logger.warning("could not write update sentinel at %s", _UPDATE_SENTINEL_PATH)
+
     _update_status = "updating"
+    _write_fleet_digests(_latest_ghcr_digest, _latest_ghcr_digest_ui)
+
     headers = {"Authorization": f"Bearer {WATCHTOWER_TOKEN}"} if WATCHTOWER_TOKEN else {}
     try:
-        # Write new digests to /opt/fleet/.env before triggering Watchtower so the
-        # restarted container picks up the correct baseline even if we are killed mid-restart.
-        _fleet_env = "/opt/fleet/.env"
-        if (_latest_ghcr_digest or _latest_ghcr_digest_ui) and os.path.exists(_fleet_env):
-            try:
-                with open(_fleet_env, "r") as f:
-                    lines = f.readlines()
-                updated = []
-                for line in lines:
-                    if line.startswith("RUNNING_IMAGE_DIGEST=") and not line.startswith("RUNNING_IMAGE_DIGEST_UI=") and _latest_ghcr_digest:
-                        updated.append(f"RUNNING_IMAGE_DIGEST={_latest_ghcr_digest}\n")
-                    elif line.startswith("RUNNING_IMAGE_DIGEST_UI=") and _latest_ghcr_digest_ui:
-                        updated.append(f"RUNNING_IMAGE_DIGEST_UI={_latest_ghcr_digest_ui}\n")
-                    else:
-                        updated.append(line)
-                with open(_fleet_env, "w") as f:
-                    f.writelines(updated)
-            except OSError:
-                pass
-        async with httpx.AsyncClient(timeout=60.0) as client:
-            r = await client.post(f"{WATCHTOWER_URL}/v1/update", headers=headers)
-        if r.status_code == 200:
-            if _latest_ghcr_digest:
-                _startup_image_digest = _latest_ghcr_digest
-            if _latest_ghcr_digest_ui:
-                _startup_image_digest_ui = _latest_ghcr_digest_ui
-            _update_available = False
-            _update_status = "updating"
-            # If containers don't restart (nothing to update), the in-memory status
-            # would stay "updating" until the next 5-min poller tick. Schedule a
-            # check after 3 minutes so the UI gets a timely resolution either way.
-            async def _deferred_status_reset() -> None:
-                await asyncio.sleep(180)
-                if _update_status == "updating":
-                    await _do_check_update()
-            asyncio.create_task(_deferred_status_reset())
-            return {"ok": True, "message": "Update triggered — containers will restart shortly."}
-        _update_status = "error"
-        _update_error = f"Watchtower returned HTTP {r.status_code}"
+        # ?async=true returns 202 immediately. POST /v1/update is synchronous by
+        # default, and the previous 60s timeout was shorter than the pull it was
+        # waiting on — so a slow-but-successful update raised ReadTimeout and was
+        # reported to the operator as "Update failed" (#350 mode 1).
+        async with httpx.AsyncClient(timeout=30.0) as client:
+            r = await client.post(f"{WATCHTOWER_URL}/v1/update?async=true", headers=headers)
+    except Exception as e:  # noqa: BLE001
+        _fail_update(f"Could not start the update: {e}", prev_digests)
         return {"ok": False, "error": _update_error}
-    except Exception as e:
-        _update_status = "error"
-        _update_error = str(e)
-        return {"ok": False, "error": str(e)}
+
+    if r.status_code == 429:
+        _update_status = "updating"
+        return {"ok": True, "message": "An update is already in progress."}
+    if r.status_code not in (200, 202):
+        _fail_update(f"The update service rejected the request (HTTP {r.status_code}).",
+                     prev_digests)
+        return {"ok": False, "error": _update_error}
+
+    if _latest_ghcr_digest:
+        _startup_image_digest = _latest_ghcr_digest
+    if _latest_ghcr_digest_ui:
+        _startup_image_digest_ui = _latest_ghcr_digest_ui
+    _update_available = False
+
+    asyncio.create_task(_await_update_outcome(scans_before, prev_digests))
+    return {"ok": True, "message": "Update started — the device will restart when it completes."}
 
 
 @app.post("/update/dismiss")
@@ -2282,8 +2490,11 @@ async def reboot_device():
 async def _background_update_poller() -> None:
     """Poll GHCR every UPDATE_CHECK_INTERVAL seconds. Never pulls the image."""
     while True:
-        if _OTA_GHCR_TOKEN and _OTA_IMAGE_TAG:
-            await _do_check_update()
+        # Called unconditionally: _do_check_update() reports `offline` when the
+        # device has no registry credentials. Skipping it here left an
+        # unconfigured or mis-provisioned device sitting at the initial `idle`
+        # forever, which the UI renders as "✓ Software is up to date" (#350).
+        await _do_check_update()
         await asyncio.sleep(_OTA_POLL_INTERVAL)
 
 

--- a/aquila_web/static/settings.html
+++ b/aquila_web/static/settings.html
@@ -300,6 +300,35 @@
         `;
       } else if (data.status === "updating") {
         _showUpdateOverlay();
+      } else if (data.status === "update_failed") {
+        // A confirmed failure: the update was triggered and did not apply. The
+        // reassurance line matters — an interrupted update sounds alarming and
+        // this failure is genuinely safe (#350).
+        _hideUpdateOverlay();
+        if (dot) dot.style.display = "block";
+        area.innerHTML = `
+          <p style="color:#b45309;font-size:15px;font-weight:600;margin:0 0 6px;">⚠ Update did not complete</p>
+          <p style="font-size:15px;color:#1a1c1c;margin:0 0 4px;">${_escHtml(data.error || "The update was interrupted.")}</p>
+          <p style="font-size:14px;color:#4b5563;margin:0;">Your data and settings are unaffected.</p>
+          <button onclick="openUpdateTab()"
+            style="margin-top:12px;padding:8px 18px;border-radius:8px;border:1px solid #cbd5e1;background:#fff;font-size:14px;cursor:pointer;color:#374151;">Try again</button>
+        `;
+      } else if (data.status === "offline") {
+        // Deliberately amber, not the red used for `error`. The device works
+        // fine — it just could not verify whether it is current. Previously this
+        // state produced `idle`, which rendered as a green "up to date" on a
+        // device that had failed to reach the registry (#350 mode 2).
+        if (dot) dot.style.display = "none";
+        let html = `
+          <p style="color:#b45309;font-size:15px;font-weight:600;margin:0 0 6px;">⚠ Could not check for updates</p>
+          <p style="font-size:15px;color:#1a1c1c;margin:0 0 4px;">${_escHtml(data.error || "The update server could not be reached.")}</p>`;
+        html += data.last_checked
+          ? `<p style="font-size:13px;color:#4b5563;margin:0;">Last successful check: ${_fmtChecked(data.last_checked)}${_ageSuffix(data)}</p>`
+          : `<p style="font-size:13px;color:#4b5563;margin:0;">This device has never successfully checked for updates.</p>`;
+        html += `<p style="font-size:14px;color:#4b5563;margin:8px 0 0;">The device may be missing important updates.</p>
+          <button onclick="openUpdateTab()"
+            style="margin-top:12px;padding:8px 18px;border-radius:8px;border:1px solid #cbd5e1;background:#fff;font-size:14px;cursor:pointer;color:#374151;">Try again</button>`;
+        area.innerHTML = html;
       } else if (data.status === "error") {
         area.innerHTML = `
           <p style="color:#dc2626;font-size:15px;">Could not check for updates: ${_escHtml(data.error || "unknown error")}</p>
@@ -309,9 +338,25 @@
       } else {
         if (dot) dot.style.display = "none";
         let html = '<p style="color:#16a34a;font-size:15px;font-weight:600;">✓ Software is up to date.</p>';
-        if (data.last_checked) html += `<p style="font-size:12px;color:#6b7280;margin-top:6px;">Last checked: ${_escHtml(data.last_checked.replace("T"," ").replace("Z"," UTC"))}</p>`;
+        if (data.last_checked) html += `<p style="font-size:12px;color:#6b7280;margin-top:6px;">Last checked: ${_fmtChecked(data.last_checked)}${_ageSuffix(data)}</p>`;
+        // A successful but long-ago check still means the device is not being
+        // kept current, so say so even on the healthy path.
+        if (data.stale) html += `<p style="color:#b45309;font-size:13px;margin-top:8px;">⚠ This check is out of date — the device may be missing newer updates.</p>`;
         area.innerHTML = html;
       }
+    }
+
+    function _fmtChecked(ts) {
+      return _escHtml(String(ts).replace("T", " ").replace("Z", " UTC"));
+    }
+
+    function _ageSuffix(data) {
+      const s = data.last_checked_age_seconds;
+      if (s === null || s === undefined) return "";
+      const d = Math.floor(s / 86400), h = Math.floor(s / 3600);
+      if (d >= 1) return ` (${d} day${d === 1 ? "" : "s"} ago)`;
+      if (h >= 1) return ` (${h} hour${h === 1 ? "" : "s"} ago)`;
+      return " (just now)";
     }
 
     function _showUpdateOverlay() {
@@ -366,22 +411,31 @@
         const r = await fetch("/update/status").catch(() => null);
         const data = r ? await r.json().catch(() => null) : null;
         if (!data || data.status === "updating" || data.available) { _pollForUpdateComplete(attempt + 1, fallbackError); return; }
-        if (data.status === "error") {
+
+        // Only these two states are conclusive. Anything else — notably
+        // `offline`, which a mid-update network blip produces — means we still
+        // do not know, so keep polling. Falling through to the success branch on
+        // an inconclusive status is how a failed pull came to render
+        // "✓ Update complete" (#350 mode 3).
+        if (data.status === "error" || data.status === "update_failed") {
           _hideUpdateOverlay();
-          const errMsg = fallbackError || data.error || "unknown error";
-          document.getElementById("update-status-area").innerHTML =
-            `<p style="color:#dc2626;font-size:15px;">Update failed: ${_escHtml(errMsg)}</p>`;
+          renderUpdateStatus({ ...data, status: data.status,
+                               error: fallbackError || data.error });
           return;
         }
+        if (data.status !== "idle") { _pollForUpdateComplete(attempt + 1, fallbackError); return; }
+
+        // status === "idle" means a check completed successfully and found
+        // nothing newer — i.e. the device is now running the target build.
         _hideUpdateOverlay();
         const area = document.getElementById("update-status-area");
         const dot = document.getElementById("updates-tab-dot");
         if (dot) dot.style.display = "none";
-        const checkedAt = data.last_checked ? data.last_checked.replace("T", " ").replace("Z", " UTC") : "";
+        const checkedAt = data.last_checked ? _fmtChecked(data.last_checked) : "";
         area.innerHTML = `
           <p style="font-size:20px;font-weight:700;color:#16a34a;margin:0 0 8px;">✓ Update complete</p>
           <p style="font-size:15px;color:#1a1c1c;margin:0 0 6px;">The device is running the latest software.</p>
-          ${checkedAt ? `<p style="font-size:12px;color:#6b7280;margin:0;">Verified: ${_escHtml(checkedAt)}</p>` : ""}
+          ${checkedAt ? `<p style="font-size:12px;color:#6b7280;margin:0;">Verified: ${checkedAt}</p>` : ""}
         `;
       }, 3000);
     }

--- a/fleet-config/docker-compose.yml
+++ b/fleet-config/docker-compose.yml
@@ -149,9 +149,13 @@ services:
     environment:
       WATCHTOWER_LABEL_ENABLE: "true"
       WATCHTOWER_HTTP_API_UPDATE: "true"
+      # Exposes /v1/metrics, which is how the backend confirms whether an update
+      # actually applied. Without it the outcome is unknowable and the backend
+      # cannot distinguish a slow success from a failed pull (#350).
+      WATCHTOWER_HTTP_API_METRICS: "true"
       WATCHTOWER_CLEANUP: "true"
       WATCHTOWER_CONFIG_FILE: "/config.json"
-    command: --label-enable --http-api-update --cleanup --api-version 1.54
+    command: --label-enable --http-api-update --http-api-metrics --cleanup --api-version 1.54
     restart: unless-stopped
     logging:
       driver: json-file

--- a/tests/contract/test_update_complete_flow.py
+++ b/tests/contract/test_update_complete_flow.py
@@ -44,6 +44,12 @@ def test_reboot_pending_triggers_reboot_and_advances_sentinel(client, tmp_path, 
 
 
 def test_apply_writes_reboot_pending_sentinel(client, tmp_path, monkeypatch):
+    """The sentinel is armed before Watchtower is triggered.
+
+    It has to be: on success this container is killed mid-swap, so there is no
+    "after" in which to write it. The successor reads it on startup to drive the
+    reboot (#183).
+    """
     from aquila_web import main as web_main
     from aquila_web import update_sentinel as us
 
@@ -51,10 +57,40 @@ def test_apply_writes_reboot_pending_sentinel(client, tmp_path, monkeypatch):
     monkeypatch.setattr(web_main, "_UPDATE_SENTINEL_PATH", path)
     monkeypatch.setattr(web_main.current_item, "screen", "ready")  # not mid-run
 
-    # Watchtower is unreachable in tests; the sentinel must be written first regardless.
+    seen = []
+    # web_main._sentinel IS the update_sentinel module, so keep a reference to the
+    # original before patching or the wrapper calls itself.
+    original = us.write_sentinel
+
+    def _capture(p, state, ts):
+        seen.append(state)
+        return original(p, state, ts)
+
+    monkeypatch.setattr(web_main._sentinel, "write_sentinel", _capture)
     client.post("/update/apply")
-    rec = us.read_sentinel(path)
-    assert rec is not None and rec["state"] == "reboot_pending"
+    assert seen == ["reboot_pending"]
+
+
+def test_apply_disarms_the_sentinel_when_the_trigger_fails(client, tmp_path, monkeypatch):
+    """Previously this left `reboot_pending` on disk for an update that never ran.
+
+    Watchtower is unreachable under test, so the trigger fails. Any backend
+    restart within the sentinel's 600s TTL would then reboot the device and show
+    "Update Complete" for an update that never applied (#350 mode 4).
+    """
+    from aquila_web import main as web_main
+    from aquila_web import update_sentinel as us
+
+    path = str(tmp_path / "last_update.json")
+    monkeypatch.setattr(web_main, "_UPDATE_SENTINEL_PATH", path)
+    monkeypatch.setattr(web_main, "_FLEET_ENV_PATH", str(tmp_path / "no-such.env"))
+    monkeypatch.setattr(web_main.current_item, "screen", "ready")
+
+    resp = client.post("/update/apply")
+
+    assert resp.json()["ok"] is False
+    assert us.read_sentinel(path) is None, "a failed trigger must leave no armed reboot"
+    assert web_main._update_status == "update_failed"
 
 
 def test_apply_during_active_run_is_rejected_and_writes_no_sentinel(client, tmp_path, monkeypatch):

--- a/tests/contract/test_update_status_reliability.py
+++ b/tests/contract/test_update_status_reliability.py
@@ -1,0 +1,221 @@
+"""OTA status must be honest in both directions (#350).
+
+The failures this guards against are not "no message shown" — they are wrong
+messages shown confidently:
+
+  - a failed registry check reported `idle`, which the UI renders as a green
+    "✓ Software is up to date"
+  - a failed pull left the poll loop falling through to "✓ Update complete"
+  - a slow-but-successful update raised ReadTimeout on a 60s budget and was
+    reported as "Update failed"
+
+So these tests assert on the *distinction* between "checked, nothing new" and
+"could not check", which is the thing that was collapsed.
+"""
+import asyncio
+
+import pytest
+
+from aquila_web import main
+
+
+@pytest.fixture(autouse=True)
+def _reset_update_state():
+    """Module-level globals hold the OTA state; isolate each test."""
+    saved = {
+        k: getattr(main, k)
+        for k in (
+            "_update_available", "_update_status", "_update_error",
+            "_update_last_checked", "_startup_image_digest",
+            "_startup_image_digest_ui", "_latest_ghcr_digest",
+            "_latest_ghcr_digest_ui", "_OTA_GHCR_TOKEN", "_OTA_IMAGE_TAG",
+        )
+    }
+    main._OTA_GHCR_TOKEN = "token"
+    main._OTA_IMAGE_TAG = "pilot"
+    # Reset, not just save/restore: an earlier test in another file may have left
+    # these set, and several assertions here are about what a failed check does
+    # to them.
+    main._update_available = False
+    main._update_status = "idle"
+    main._update_error = None
+    main._startup_image_digest = "sha256:api-old"
+    main._startup_image_digest_ui = "sha256:ui-old"
+    main._update_last_checked = None
+    yield
+    for k, v in saved.items():
+        setattr(main, k, v)
+
+
+def _digests(monkeypatch, api, ui):
+    """Stub the registry so each call returns a (digest, error_kind) pair."""
+    async def fake(repo, tag, user, token):
+        return api if "api" in repo else ui
+    monkeypatch.setattr(main, "_ghcr_manifest_digest", fake)
+
+
+# ── A failed check must not look like a successful one ────────────────────────
+
+def test_unreachable_registry_reports_offline_not_idle(monkeypatch):
+    """`idle` means "checked, nothing new" — the UI paints it green."""
+    _digests(monkeypatch, (None, main._ERR_NETWORK), (None, main._ERR_NETWORK))
+    asyncio.run(main._do_check_update())
+    assert main._update_status == "offline"
+    assert main._update_status != "idle"
+
+
+def test_network_and_auth_failures_are_distinguishable(monkeypatch):
+    """They need different operator actions, so they cannot share a message."""
+    _digests(monkeypatch, (None, main._ERR_NETWORK), (None, main._ERR_NETWORK))
+    asyncio.run(main._do_check_update())
+    network_msg = main._update_error
+
+    _digests(monkeypatch, (None, main._ERR_AUTH), (None, main._ERR_AUTH))
+    asyncio.run(main._do_check_update())
+    assert main._update_error != network_msg
+    assert "credential" in main._update_error.lower()
+
+
+def test_failed_check_does_not_refresh_last_checked(monkeypatch):
+    """It is shown as "last successful check"; a failed attempt must not bump it."""
+    _digests(monkeypatch, ("sha256:api-old", None), ("sha256:ui-old", None))
+    asyncio.run(main._do_check_update())
+    good = main._update_last_checked
+    assert good is not None
+
+    _digests(monkeypatch, (None, main._ERR_NETWORK), (None, main._ERR_NETWORK))
+    asyncio.run(main._do_check_update())
+    assert main._update_last_checked == good
+
+
+# ── Partial failure is a failed check, not a partial success ──────────────────
+
+def test_partial_digest_failure_does_not_offer_an_update(monkeypatch):
+    """One digest resolving while the other blips is how api/ui end up skewed."""
+    _digests(monkeypatch, ("sha256:api-new", None), (None, main._ERR_NETWORK))
+    asyncio.run(main._do_check_update())
+    assert main._update_status == "offline"
+    assert main._update_available is False
+
+
+def test_failed_check_withdraws_a_previously_known_update(monkeypatch):
+    """Otherwise the UI shows "Update Now" against a registry it cannot reach.
+
+    renderUpdateStatus checks `available` before `status`, so leaving it set
+    would also hide the offline warning entirely.
+    """
+    _digests(monkeypatch, ("sha256:api-new", None), ("sha256:ui-new", None))
+    asyncio.run(main._do_check_update())
+    assert main._update_available is True
+
+    _digests(monkeypatch, (None, main._ERR_NETWORK), (None, main._ERR_NETWORK))
+    asyncio.run(main._do_check_update())
+    assert main._update_available is False
+    assert main._update_status == "offline"
+
+
+def test_both_digests_resolving_and_changing_offers_an_update(monkeypatch):
+    _digests(monkeypatch, ("sha256:api-new", None), ("sha256:ui-new", None))
+    asyncio.run(main._do_check_update())
+    assert main._update_status == "available"
+    assert main._update_available is True
+
+
+def test_no_change_reports_idle(monkeypatch):
+    _digests(monkeypatch, ("sha256:api-old", None), ("sha256:ui-old", None))
+    asyncio.run(main._do_check_update())
+    assert main._update_status == "idle"
+    assert main._update_available is False
+
+
+# ── The status endpoint ───────────────────────────────────────────────────────
+
+def test_status_exposes_staleness(client, monkeypatch):
+    """A device that has never checked is stale — it cannot claim to be current."""
+    main._update_last_checked = None
+    body = client.get("/update/status").json()
+    assert body["stale"] is True
+    assert body["last_checked_age_seconds"] is None
+
+
+def test_recent_successful_check_is_not_stale(client, monkeypatch):
+    _digests(monkeypatch, ("sha256:api-old", None), ("sha256:ui-old", None))
+    asyncio.run(main._do_check_update())
+    body = client.get("/update/status").json()
+    assert body["stale"] is False
+    assert body["last_checked_age_seconds"] is not None
+    assert body["last_checked_age_seconds"] < 60
+
+
+def test_offline_status_is_reported_to_the_ui(client, monkeypatch):
+    _digests(monkeypatch, (None, main._ERR_NETWORK), (None, main._ERR_NETWORK))
+    asyncio.run(main._do_check_update())
+    body = client.get("/update/status").json()
+    assert body["status"] == "offline"
+    assert body["error"]
+
+
+# ── Watchtower metrics parsing ────────────────────────────────────────────────
+
+def test_parses_prometheus_metrics():
+    body = (
+        "# HELP watchtower_containers_updated Number of containers updated\n"
+        "# TYPE watchtower_containers_updated gauge\n"
+        "watchtower_containers_updated 2\n"
+        "watchtower_containers_failed 0\n"
+        "watchtower_scans_total 17\n"
+    )
+    assert main._parse_prom_metric(body, "watchtower_containers_updated") == 2
+    assert main._parse_prom_metric(body, "watchtower_containers_failed") == 0
+    assert main._parse_prom_metric(body, "watchtower_scans_total") == 17
+
+
+def test_missing_metric_returns_none():
+    assert main._parse_prom_metric("watchtower_scans_total 3\n", "nope") is None
+
+
+def test_comment_lines_are_not_mistaken_for_values():
+    """A HELP line contains the metric name and must not be parsed as a value."""
+    body = "# HELP watchtower_containers_failed some text 99\nwatchtower_containers_failed 0\n"
+    assert main._parse_prom_metric(body, "watchtower_containers_failed") == 0
+
+
+# ── A confirmed failure must disarm the reboot ────────────────────────────────
+
+def test_confirmed_failure_clears_the_sentinel(tmp_path, monkeypatch):
+    """A stale `reboot_pending` reboots the device for an update that never applied."""
+    sentinel = tmp_path / "last_update.json"
+    monkeypatch.setattr(main, "_UPDATE_SENTINEL_PATH", str(sentinel))
+    monkeypatch.setattr(main, "_FLEET_ENV_PATH", str(tmp_path / "no-such.env"))
+    main._sentinel.write_sentinel(str(sentinel), "reboot_pending", main._utcnow_iso())
+    assert sentinel.exists()
+
+    main._fail_update("pull failed", (None, None))
+
+    assert main._update_status == "update_failed"
+    assert main._sentinel.read_sentinel(str(sentinel)) in (None, {})
+
+
+def test_confirmed_failure_leaves_the_update_outstanding(tmp_path, monkeypatch):
+    """The update still needs applying, so it must not be marked done."""
+    monkeypatch.setattr(main, "_UPDATE_SENTINEL_PATH", str(tmp_path / "s.json"))
+    monkeypatch.setattr(main, "_FLEET_ENV_PATH", str(tmp_path / "no-such.env"))
+    main._fail_update("pull failed", (None, None))
+    assert main._update_available is True
+
+
+def test_confirmed_failure_restores_the_recorded_digests(tmp_path, monkeypatch):
+    """/opt/fleet/.env must not claim a version the device is not running."""
+    env = tmp_path / "fleet.env"
+    env.write_text("RUNNING_IMAGE_DIGEST=sha256:old\nRUNNING_IMAGE_DIGEST_UI=sha256:oldui\nOTHER=keep\n")
+    monkeypatch.setattr(main, "_FLEET_ENV_PATH", str(env))
+    monkeypatch.setattr(main, "_UPDATE_SENTINEL_PATH", str(tmp_path / "s.json"))
+
+    main._write_fleet_digests("sha256:new", "sha256:newui")
+    assert "sha256:new" in env.read_text()
+
+    main._fail_update("pull failed", ("sha256:old", "sha256:oldui"))
+    text = env.read_text()
+    assert "RUNNING_IMAGE_DIGEST=sha256:old" in text
+    assert "RUNNING_IMAGE_DIGEST_UI=sha256:oldui" in text
+    assert "OTHER=keep" in text, "unrelated lines must survive"


### PR DESCRIPTION
Implements #350.

## The problem

OTA status was wrong **in both directions**, and confidently so:

| What happened | What the operator saw |
|---|---|
| Slow but successful update | **"Update failed"** |
| Failed registry check | **"✓ Software is up to date"** |
| Failed pull | **"✓ Update complete"** |

One root cause: the outcome was never *observed*, only inferred. Watchtower has been returning a report of what it did on every call, and `main.py:2218` checked only the HTTP status code and threw the body away.

## Backend

**`offline`, distinct from `idle`.** `idle` means "checked successfully, nothing new" — the UI paints that green. A check that could not run now says so.

**Registry failures are distinguished** — network, auth, bad response. Previously all three collapsed to `None`, which is why the operator-facing message had to read *"Registry unreachable **or** credentials invalid"*: the code genuinely could not tell. Those need different actions ("check the network" vs "escalate").

**A partial digest result is a failed check.** Accepting one digest while the other is unknown is how the API and UI end up on different builds.

**A failed check no longer refreshes `last_checked`** (it is shown as "last *successful* check") **and withdraws any previously-known availability** — offering "Update Now" against an unreachable registry sends the operator into a failing apply, and the UI checks `available` before `status`, so leaving it set would hide the offline warning entirely.

**The poller now runs unconditionally.** Guarding on credentials left an unconfigured device sitting at the initial `idle` forever — a green tick on a device that can never update. Verified in a container:

```json
{ "status": "offline",
  "error": "This device is not configured to receive updates",
  "stale": true }
```

## Apply path

**Triggers with `?async=true`.** `POST /v1/update` is synchronous by default and the old 60s timeout was shorter than the pull it was waiting on — so any update slower than a minute raised `ReadTimeout` and was reported as failure *while it was still succeeding*. This is likely the most frequently hit mode, since it fires on updates that are merely slow rather than broken.

**Outcome confirmed from Watchtower's metrics** — `containers_updated` / `containers_failed`, compared against a scan counter captured *before* the trigger so the previous scan's numbers are not misread. Requires `--http-api-metrics`, added to `fleet-config/docker-compose.yml`.

If metrics are unavailable the outcome is left as `updating` for the poller to settle — **never reported as success**.

**On confirmed failure the sentinel is cleared.** It is still written *before* triggering — on success this container is killed mid-swap, so there is no "after", and #183 depends on the breadcrumb surviving that. But a stale `reboot_pending` otherwise reboots the device for an update that never applied, then shows "Update Complete".

**On confirmed failure the recorded digests are restored**, so `/opt/fleet/.env` does not claim a version the device is not running.

**HTTP 429** (an update already running) is no longer surfaced as an error.

## Frontend

**`offline`** renders an amber warning with the age of the last successful check. Amber deliberately, not the red used for `error` — the device works fine, it just cannot verify it is current.

**`update_failed`** renders an explicit failure including *"Your data and settings are unaffected"*. An interrupted update sounds alarming and this failure is genuinely safe.

**The post-apply poll now only treats `idle` as success.** Previously anything that was not `updating` or `error` fell through to "Update complete" — including the `offline` that a mid-update network blip produces.

**A successful but long-ago check is flagged**, since a device that stopped checking looks identical to one that is current.

## Verification

**21 tests** covering the offline/idle distinction, error-kind separation, partial-failure handling, staleness, Prometheus parsing, sentinel disarming, and digest restoration.

**Full suite: 37 failed / 859 passed / 237 skipped — the 37 match clean `main` exactly**, verified by stashing the changes and diffing the failure lists. Those are pre-existing hardware-test pollution failures.

**Container check:** backend starts, `/health` and `/update/status` respond, no tracebacks.

### One existing test changed

`test_apply_writes_reboot_pending_sentinel` asserted *"Watchtower is unreachable in tests; the sentinel must be written first regardless"* — which encoded the bug. It is now split in two: one test that the sentinel is armed before triggering (still required by #183), one that a failed trigger disarms it again.

## Not covered here

- **Verifying the digest actually changed after an update.** #351 bakes build identity into the image, which is the better mechanism; this PR relies on Watchtower's own report instead.
- **The `RUNNING_IMAGE_DIGEST` trust problem.** It is written before the swap, so it records intent rather than outcome. Restoring it on failure keeps it honest here, but #351/#352 replace it properly.
- **Reproducing mode 4 on hardware.** sn03 is a sandbox unit and reachable, so pulling its network mid-update would confirm the spurious-reboot path end to end. Not done yet.

Part of #350.
