### PR TITLE
feat(ota): bake build identity into each image

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -24,6 +24,12 @@ jobs:
       - name: Set lowercase repo
         run: echo "REPO_LOWER=$(echo "$GITHUB_REPOSITORY" | tr '[:upper:]' '[:lower:]')" >> $GITHUB_ENV
 
+      # Computed in a step rather than read from github.event.head_commit, which
+      # is absent on workflow_dispatch. Baked into both images so a device can
+      # report its own provenance — see #351.
+      - name: Stamp build time
+        run: echo "BUILD_TIME=$(date -u +%Y-%m-%dT%H:%M:%SZ)" >> $GITHUB_ENV
+
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
 
@@ -47,6 +53,9 @@ jobs:
           # build is emulated. See #348.
           platforms: linux/arm64
           push: true
+          build-args: |
+            GIT_SHA=${{ github.sha }}
+            BUILD_TIME=${{ env.BUILD_TIME }}
           tags: |
             ghcr.io/${{ env.REPO_LOWER }}-api:latest
             ghcr.io/${{ env.REPO_LOWER }}-api:${{ github.sha }}
@@ -67,6 +76,9 @@ jobs:
           file: docker/Dockerfile.ui
           platforms: linux/arm64
           push: true
+          build-args: |
+            GIT_SHA=${{ github.sha }}
+            BUILD_TIME=${{ env.BUILD_TIME }}
           tags: |
             ghcr.io/${{ env.REPO_LOWER }}-ui:latest
             ghcr.io/${{ env.REPO_LOWER }}-ui:${{ github.sha }}

--- a/aquila_web/main.py
+++ b/aquila_web/main.py
@@ -845,9 +845,44 @@ async def timer(payload: TimerControl):
         raise HTTPException(status_code=400, detail="Invalid action")
 
 
+def _read_build_identity() -> dict:
+    """This image's own baked provenance (#351).
+
+    Written into config_files/version.json at build time by docker/Dockerfile.api.
+    config_files/ is not a mounted volume, so nothing can overwrite it at runtime
+    — unlike RUNNING_IMAGE_DIGEST, which is an env var supplied by whoever started
+    the container and is written by /update/apply BEFORE the swap, recording
+    intent rather than outcome.
+
+    Tolerates the keys being absent: images built before #351 have only
+    app_version, and a device running one must not crash on startup.
+    """
+    identity = {"app_version": "unknown", "git_sha": "unknown", "build_time": "unknown"}
+    try:
+        data = json.loads((BASE_DIR / "config_files" / "version.json").read_text())
+        for key in identity:
+            if data.get(key):
+                identity[key] = str(data[key])
+    except Exception:  # noqa: BLE001 - identity must never break startup
+        logger.warning("could not read build identity from version.json")
+    return identity
+
+
+# Resolved once: the values are baked into the image and cannot change while the
+# container runs, and /health is polled every 30s by the Docker healthcheck.
+_BUILD_IDENTITY = _read_build_identity()
+
+
 @app.get("/health")
 async def health_check():
-    return {"status": "ok"}
+    return {
+        "status": "ok",
+        **_BUILD_IDENTITY,
+        # Deliberately reported alongside the baked values rather than instead of
+        # them: their disagreement is the signal that a device is not running what
+        # the fleet config claims. See #352.
+        "running_image_digest": os.getenv("RUNNING_IMAGE_DIGEST") or "unknown",
+    }
 
 
 def _read_app_version() -> str:

--- a/docker/Dockerfile.api
+++ b/docker/Dockerfile.api
@@ -40,6 +40,24 @@ COPY profiles/bundled/ /opt/aquila/profiles_bundled/
 COPY docker/entrypoint.sh /opt/aquila/entrypoint.sh
 RUN chmod +x /opt/aquila/entrypoint.sh
 
+# Bake build provenance into the image (#351).
+#
+# An injected env var like RUNNING_IMAGE_DIGEST is a claim made by whoever
+# started the container — /update/apply writes it BEFORE the swap, so it records
+# intent, not outcome. A value baked into the image bytes cannot misreport what
+# is running. config_files/ is not a mounted volume, so nothing can overwrite
+# this at runtime.
+#
+# Declared here, after the dependency layers, so a new SHA invalidates only this
+# tiny layer and the build cache from #348 still applies.
+ARG GIT_SHA=unknown
+ARG BUILD_TIME=unknown
+LABEL org.opencontainers.image.revision=$GIT_SHA
+LABEL org.opencontainers.image.created=$BUILD_TIME
+# Extends the version.json introduced in #340 rather than replacing it —
+# _read_app_version() reads data["app_version"] and is unaffected by extra keys.
+RUN python -c "import json,os,pathlib;p=pathlib.Path('config_files/version.json');d=json.loads(p.read_text());d['git_sha']=os.environ.get('GIT_SHA','unknown');d['build_time']=os.environ.get('BUILD_TIME','unknown');p.write_text(json.dumps(d,indent=4)+'\n')"
+
 ENV DATA_DIR=/opt/aquila \
     PROFILE_DIR=/opt/aquila/profiles \
     RESULTS_PATH=/opt/aquila/results/results.json

--- a/docker/Dockerfile.ui
+++ b/docker/Dockerfile.ui
@@ -3,5 +3,17 @@ FROM nginx:1.27-alpine
 COPY docker/nginx.conf /etc/nginx/conf.d/default.conf
 COPY aquila_web/static/ /usr/share/nginx/html/
 
+# Bake build provenance (#351). This image is nginx serving static files — there
+# is no application to answer a request — so the identity is a static file that
+# nginx serves directly. See the `location = /version.json` block in nginx.conf:
+# without it this path falls through to the catch-all proxy and is answered by
+# the API container, which would silently compare that image against itself.
+ARG GIT_SHA=unknown
+ARG BUILD_TIME=unknown
+LABEL org.opencontainers.image.revision=$GIT_SHA
+LABEL org.opencontainers.image.created=$BUILD_TIME
+RUN printf '{"git_sha":"%s","build_time":"%s"}\n' "$GIT_SHA" "$BUILD_TIME" \
+    > /usr/share/nginx/html/version.json
+
 HEALTHCHECK --interval=30s --timeout=5s --start-period=10s --retries=3 \
     CMD wget -qO- http://127.0.0.1/ > /dev/null

--- a/docker/nginx.conf
+++ b/docker/nginx.conf
@@ -25,6 +25,14 @@ server {
         try_files $uri =404;
     }
 
+    # The UI image's own baked identity (#351). This MUST be served locally: the
+    # catch-all `location /` below proxies to aquila-backend, so without this the
+    # request is answered by the API container and the UI would appear to match
+    # itself no matter how far the two images had drifted apart.
+    location = /version.json {
+        try_files $uri =404;
+    }
+
     location /kiosk-control/ {
         limit_except POST { deny all; }
         resolver 127.0.0.11 valid=10s ipv6=off;

--- a/tests/contract/test_build_identity.py
+++ b/tests/contract/test_build_identity.py
@@ -1,0 +1,111 @@
+"""Each image reports its own baked build provenance (#351).
+
+The point of baking rather than injecting: an env var like RUNNING_IMAGE_DIGEST
+is a claim made by whoever started the container — and /update/apply writes it
+BEFORE triggering the swap, so it records intent, not outcome. A value baked into
+the image bytes cannot misreport what is actually running.
+"""
+import json
+import pathlib
+import re
+
+import pytest
+
+from aquila_web import main
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parents[2]
+
+
+def test_health_reports_build_identity(client):
+    body = client.get("/health").json()
+    assert body["status"] == "ok"
+    for key in ("app_version", "git_sha", "build_time", "running_image_digest"):
+        assert key in body, f"/health must report {key}"
+
+
+def test_health_still_reports_ok(client):
+    """It is the Docker HEALTHCHECK target — the contract must not regress."""
+    assert client.get("/health").json()["status"] == "ok"
+
+
+def test_app_version_still_matches_the_config_file(client):
+    """#340 made version.json the single source; #351 only adds keys to it."""
+    expected = json.loads((REPO_ROOT / "config_files" / "version.json").read_text())["app_version"]
+    assert client.get("/health").json()["app_version"] == expected
+    assert client.get("/version").json()["version"] == expected
+
+
+def test_identity_tolerates_an_image_built_before_this_change(tmp_path, monkeypatch):
+    """Older images have only app_version. A device running one must not crash."""
+    cfg = tmp_path / "config_files"
+    cfg.mkdir()
+    (cfg / "version.json").write_text('{"app_version": "2.1.0.5"}')
+    monkeypatch.setattr(main, "BASE_DIR", tmp_path)
+
+    identity = main._read_build_identity()
+    assert identity["app_version"] == "2.1.0.5"
+    assert identity["git_sha"] == "unknown"
+    assert identity["build_time"] == "unknown"
+
+
+def test_identity_tolerates_a_missing_or_corrupt_file(tmp_path, monkeypatch):
+    monkeypatch.setattr(main, "BASE_DIR", tmp_path)
+    identity = main._read_build_identity()
+    assert identity == {"app_version": "unknown", "git_sha": "unknown", "build_time": "unknown"}
+
+    cfg = tmp_path / "config_files"
+    cfg.mkdir()
+    (cfg / "version.json").write_text("{ not json")
+    assert main._read_build_identity()["git_sha"] == "unknown"
+
+
+def test_identity_reads_the_baked_values(tmp_path, monkeypatch):
+    cfg = tmp_path / "config_files"
+    cfg.mkdir()
+    (cfg / "version.json").write_text(json.dumps({
+        "app_version": "2.1.0.5",
+        "git_sha": "a1b2c3d4",
+        "build_time": "2026-07-28T12:00:00Z",
+    }))
+    monkeypatch.setattr(main, "BASE_DIR", tmp_path)
+    identity = main._read_build_identity()
+    assert identity["git_sha"] == "a1b2c3d4"
+    assert identity["build_time"] == "2026-07-28T12:00:00Z"
+
+
+# ── The delivery path has to be right, or the check compares an image to itself ──
+
+def test_nginx_serves_version_json_locally():
+    """Without an explicit location block, /version.json falls through to the
+    catch-all proxy and is answered by the API container — so the UI would appear
+    to match itself no matter how far the two images had drifted."""
+    conf = (REPO_ROOT / "docker" / "nginx.conf").read_text()
+    assert re.search(r"location\s*=\s*/version\.json", conf), (
+        "nginx.conf must serve /version.json locally, not proxy it to the backend"
+    )
+    # And it must come before the catch-all, or nginx never reaches it.
+    assert conf.index("/version.json") < conf.rindex("location / {")
+
+
+@pytest.mark.parametrize("dockerfile", ["Dockerfile.api", "Dockerfile.ui"])
+def test_both_images_accept_the_build_args(dockerfile):
+    text = (REPO_ROOT / "docker" / dockerfile).read_text()
+    assert "ARG GIT_SHA" in text
+    assert "ARG BUILD_TIME" in text
+
+
+@pytest.mark.parametrize("dockerfile", ["Dockerfile.api", "Dockerfile.ui"])
+def test_both_images_carry_an_oci_revision_label(dockerfile):
+    """#352 reads this from the registry manifest to resolve a digest back to a
+    build, without pulling the image."""
+    text = (REPO_ROOT / "docker" / dockerfile).read_text()
+    assert "org.opencontainers.image.revision" in text
+
+
+def test_ci_passes_the_build_args_to_both_images():
+    wf = (REPO_ROOT / ".github" / "workflows" / "docker-build.yml").read_text()
+    assert wf.count("GIT_SHA=${{ github.sha }}") == 2, "both api and ui builds"
+    assert wf.count("BUILD_TIME=${{ env.BUILD_TIME }}") == 2
+    assert "BUILD_TIME=$(date -u" in wf, (
+        "computed in a step — github.event.head_commit is absent on workflow_dispatch"
+    )


### PR DESCRIPTION
Implements #351 (P1).

## The problem

There is no reliable way to know what software a Sentri is running. The only identity signals today:

| Signal | Problem |
|---|---|
| `app_version` in version.json | hand-bumped; says nothing about which build |
| `RUNNING_IMAGE_DIGEST` env var | **not trustworthy** — see below |
| `GET /health` | returns `{"status": "ok"}` and nothing else |

`RUNNING_IMAGE_DIGEST` is written by `/update/apply` into `/opt/fleet/.env` **before** triggering Watchtower (`main.py:2197`), so it records what we *intended* to run, not what is running. If the pull fails, the recorded digest is simply wrong and nothing notices.

## What this does

CI stamps the git SHA and build time into **both** images:

- **API** — `config_files/version.json` gains `git_sha` and `build_time`
- **UI** — `/usr/share/nginx/html/version.json` written at build time
- **Both** — `org.opencontainers.image.revision` / `.created` labels

Because these are baked into the image bytes they **physically cannot misreport**. `config_files/` is not a mounted volume, so nothing can overwrite it at runtime.

The OCI labels exist for #352: they travel in the registry manifest, so a digest can be resolved back to a build **without pulling the image** — using the same GHCR query `main.py` already performs.

`GET /health` now returns:

```json
{
  "status": "ok",
  "app_version": "2.1.0.5",
  "git_sha": "a1b2c3d4...",
  "build_time": "2026-07-28T12:00:00Z",
  "running_image_digest": "sha256:..."
}
```

The injected digest is reported **alongside** the baked values rather than instead of them — their disagreement is the signal that a device is not running what the fleet config claims.

## ⚠️ The nginx trap

`docker/nginx.conf` gains an explicit block:

```nginx
location = /version.json {
    try_files $uri =404;
}
```

Without it, `/version.json` falls through to the catch-all `location /` that proxies to `aquila-backend` — so **the UI would appear to match itself** no matter how far the two images had drifted apart. The check would silently always pass.

Verified by building the two images with deliberately different SHAs and running them behind the real proxy:

```
GET /version.json  ->  {"git_sha":"BBBBBBB", ...}   ← the UI's own
GET /health        ->  {"git_sha":"AAAAAAA", ...}   ← the backend's, proxied
```

Two different values, correctly distinguished. A test asserts both that the block exists and that it precedes the catch-all, since nginx would never reach it otherwise.

## Backward compatibility

Identity reading tolerates:

- **images built before this change** — they have only `app_version`, and a device running one must not crash on startup
- **a missing or corrupt version.json**
- **an unset build arg** — verified: a build with no `--build-arg` produces `git_sha: "unknown"` rather than failing

All degrade to `"unknown"`.

## Build cache

The `ARG`s are declared **after** the dependency layers, so a new SHA invalidates only a tiny layer and the caching from #348 still applies. `BUILD_TIME` is computed in a workflow step rather than read from `github.event.head_commit`, which is absent on `workflow_dispatch`.

## Verification

- **12 tests** — `/health` contract, backward compatibility with older images, corrupt-file handling, the nginx location block and its ordering, build args on both Dockerfiles, OCI labels, and CI wiring.
- **Real containers** — both images built with different SHAs, run behind the actual nginx proxy on a Docker network; `/version.json` and `/health` return the right image's identity.
- **OCI labels confirmed** via `docker inspect` on both images.
- **Full suite:** 37 failed / 854 passed / 237 skipped — the 37 match clean `main`.

## What this does not do

Detection and alerting are #352: comparing `api.git_sha == ui.git_sha`, comparing the running build against what the registry says the recorded digest should be, and surfacing a mismatch. This PR only makes those comparisons *possible*.

Part of #351.
