### PR TITLE
feat(ota): detect and announce a build identity mismatch

### DIFF
--- a/aquila_web/main.py
+++ b/aquila_web/main.py
@@ -1941,6 +1941,12 @@ async def websocket_endpoint(websocket: WebSocket):
             panel_with_timer["drawer_state_open"] = drawer_state_open
             panel_with_timer["drawer_state_closed"] = drawer_state_closed
 
+            # Build identity (#352). Pushed over the socket the UI already holds
+            # open rather than polled: detection is immediate and costs no extra
+            # requests. Only false is actionable — null means the check could not
+            # run, which must not be rendered as a problem OR as a pass.
+            panel_with_timer["identity_ok"] = _identity_state.get("identity_ok")
+
             # Server-authoritative run identity for the Run-card header (issue #265).
             # The header must keep showing the active run's profile/run name even
             # when the dropdown cannot re-select it after navigating back to /run.
@@ -2533,6 +2539,230 @@ async def _background_update_poller() -> None:
         await asyncio.sleep(_OTA_POLL_INTERVAL)
 
 
+# ── Build identity verification (#352) ────────────────────────────────────────
+#
+# Two questions, both answered by comparing git SHAs — never build timestamps.
+# Posit hit exactly this: timestamp-based client/server version tracking proved
+# unreliable because build nodes disagreed on the clock. These Pis have no RTC
+# and can boot with a badly wrong clock (see the device-clock issue), so
+# build_time is for humans reading a screen and must never be a comparison key.
+#
+#   A. Do the API and UI images come from the same build?
+#      Both report their own baked SHA, so this needs no network.
+#
+#   B. Is the running build the one the fleet config claims?
+#      The baked SHA is what is running. RUNNING_IMAGE_DIGEST is what /opt/fleet
+#      claims. They are different types — a git commit hash vs an OCI content
+#      digest — so they cannot be compared directly. The bridge is the
+#      org.opencontainers.image.revision label added in #351, read from the
+#      registry manifest without pulling the image.
+_UI_IDENTITY_URL = os.getenv("AQ_UI_IDENTITY_URL", "http://aquila-ui/version.json")
+
+_identity_state: dict = {
+    "api_git_sha": None,
+    "ui_git_sha": None,
+    "images_match": None,
+    "expected_git_sha": None,
+    "digest_matches": None,
+    "identity_ok": None,
+    "checked_at": None,
+    "error": None,
+}
+
+
+async def _fetch_ui_identity() -> tuple[str | None, str | None]:
+    """The UI image's own baked SHA, served by nginx from its own filesystem.
+
+    nginx.conf has an explicit `location = /version.json` for exactly this: the
+    catch-all proxies to this backend, so without it we would fetch our own
+    identity and the comparison would always pass (#351).
+    """
+    try:
+        async with httpx.AsyncClient(timeout=10.0) as client:
+            r = await client.get(_UI_IDENTITY_URL)
+        if r.status_code != 200:
+            return None, f"UI identity unavailable (HTTP {r.status_code})"
+        return (r.json().get("git_sha") or None), None
+    except Exception:  # noqa: BLE001
+        return None, "Could not reach the UI container"
+
+
+async def _ghcr_revision_for_digest(
+    repo: str, digest: str, user: str, token: str
+) -> tuple[str | None, str | None]:
+    """Resolve an image digest to the git SHA it was built from.
+
+    Reads the OCI label out of the image's config blob. Registry reads only — the
+    image is never pulled.
+    """
+    bearer, err = await _ghcr_bearer_token(user, token, repo)
+    if bearer is None:
+        return None, err
+    owner = repo.split("/")[0]
+    name = "/".join(repo.split("/")[1:]) or repo
+    base = f"https://ghcr.io/v2/{owner}/{name}"
+    headers = {
+        "Authorization": f"Bearer {bearer}",
+        "Accept": (
+            "application/vnd.oci.image.index.v1+json,"
+            "application/vnd.oci.image.manifest.v1+json,"
+            "application/vnd.docker.distribution.manifest.list.v2+json,"
+            "application/vnd.docker.distribution.manifest.v2+json"
+        ),
+    }
+    try:
+        async with httpx.AsyncClient(timeout=15.0) as client:
+            r = await client.get(f"{base}/manifests/{digest}", headers=headers)
+            if r.status_code >= 400:
+                return None, _ERR_REGISTRY
+            doc = r.json()
+
+            # A multi-arch tag resolves to an index; descend into the single
+            # platform manifest. The fleet is arm64-only since #348, but the
+            # index wrapper can still be present.
+            if "manifests" in doc and doc.get("manifests"):
+                child = doc["manifests"][0]["digest"]
+                r = await client.get(f"{base}/manifests/{child}", headers=headers)
+                if r.status_code >= 400:
+                    return None, _ERR_REGISTRY
+                doc = r.json()
+
+            config_digest = (doc.get("config") or {}).get("digest")
+            if not config_digest:
+                return None, _ERR_REGISTRY
+
+            r = await client.get(f"{base}/blobs/{config_digest}", headers=headers)
+            if r.status_code >= 400:
+                return None, _ERR_REGISTRY
+            labels = ((r.json().get("config") or {}).get("Labels")) or {}
+    except httpx.RequestError:
+        return None, _ERR_NETWORK
+    except Exception:  # noqa: BLE001
+        logger.exception("could not resolve image revision from registry")
+        return None, _ERR_REGISTRY
+
+    return labels.get("org.opencontainers.image.revision"), None
+
+
+def _resolve_identity_ok(images_match, digest_matches) -> bool | None:
+    """False beats None beats True.
+
+    `null` when a check could not run — never `true`. A check that could not run
+    reporting the same result as a check that passed is the exact failure the OTA
+    status issue documents, and it would be easy to reintroduce here as a fix for
+    noisy alerts.
+    """
+    if images_match is False or digest_matches is False:
+        return False
+    if images_match is None or digest_matches is None:
+        return None
+    return True
+
+
+async def _check_build_identity() -> None:
+    global _identity_state
+    api_sha = _BUILD_IDENTITY.get("git_sha")
+    if api_sha in (None, "", "unknown"):
+        api_sha = None
+
+    ui_sha, ui_err = await _fetch_ui_identity()
+    images_match = None if (api_sha is None or ui_sha is None) else (api_sha == ui_sha)
+
+    expected_sha = None
+    digest_matches = None
+    reg_err = None
+    running_digest = os.getenv("RUNNING_IMAGE_DIGEST") or None
+    if running_digest and _OTA_GHCR_TOKEN and api_sha:
+        expected_sha, reg_err = await _ghcr_revision_for_digest(
+            _OTA_GHCR_REPO_API, running_digest, _OTA_GHCR_USER, _OTA_GHCR_TOKEN
+        )
+        if expected_sha:
+            digest_matches = expected_sha == api_sha
+
+    identity_ok = _resolve_identity_ok(images_match, digest_matches)
+    was_ok = _identity_state.get("identity_ok")
+
+    _identity_state = {
+        "api_git_sha": api_sha,
+        "ui_git_sha": ui_sha,
+        "images_match": images_match,
+        "expected_git_sha": expected_sha,
+        "digest_matches": digest_matches,
+        "identity_ok": identity_ok,
+        "checked_at": datetime.utcnow().isoformat() + "Z",
+        "error": ui_err or (_ERR_MESSAGES.get(reg_err) if reg_err else None),
+    }
+
+    if identity_ok is False:
+        # Push it to the screen immediately over the websocket the UI already
+        # holds open, rather than waiting for a poll.
+        state_change_event.set()
+        state_change_event.clear()
+        if was_ok is not False:  # only on transition, not every poll
+            logger.error("build identity mismatch: %s", _identity_state)
+            _emit_identity_mismatch_event()
+
+
+def _emit_identity_mismatch_event() -> None:
+    """Report the mismatch to the analytics platform.
+
+    An on-screen warning only helps someone standing at the device. Without this
+    a mismatch on an unattended Sentri stays invisible, which is the original
+    problem simply relocated. Follows the ADR-021 telemetry pattern.
+    """
+    try:
+        enqueue_event(
+            "identity_mismatch",
+            {k: v for k, v in _identity_state.items()},
+            dedup_key=f"identity:{_identity_state.get('api_git_sha')}:"
+                      f"{_identity_state.get('ui_git_sha')}:"
+                      f"{_identity_state.get('expected_git_sha')}",
+        )
+    except Exception:  # noqa: BLE001 - telemetry must never break the check
+        logger.exception("could not enqueue identity mismatch event")
+
+
+@app.get("/identity")
+async def get_identity():
+    """This device's build provenance and whether it verifies."""
+    return {**_BUILD_IDENTITY,
+            "running_image_digest": os.getenv("RUNNING_IMAGE_DIGEST") or "unknown",
+            **_identity_state}
+
+
+@app.post("/identity/check")
+async def trigger_identity_check():
+    """Re-run the check now rather than waiting for the poll.
+
+    Used by the post-deploy verification, and by the operator's "Try again".
+    """
+    await _check_build_identity()
+    return {"ok": True, **_identity_state}
+
+
+async def _background_identity_poller() -> None:
+    # All four containers start together on a device, so the UI is frequently not
+    # yet serving when this first runs — which would leave the check unresolved
+    # until the next poll five minutes later. Retry quickly a few times first,
+    # then settle onto the update-check cadence, which already runs at the right
+    # interval and already talks to GHCR.
+    for delay in (5, 15, 30):
+        await asyncio.sleep(delay)
+        try:
+            await _check_build_identity()
+        except Exception:  # noqa: BLE001
+            logger.exception("identity check failed")
+        if _identity_state.get("images_match") is not None:
+            break  # the UI answered; no need to keep retrying fast
+
+    while True:
+        await asyncio.sleep(_OTA_POLL_INTERVAL)
+        try:
+            await _check_build_identity()
+        except Exception:  # noqa: BLE001 - the poller must survive anything
+            logger.exception("identity check failed")
+
+
 _SYNC_INTERVAL_SECONDS = int(os.getenv("AQ_SYNC_INTERVAL_SECONDS", "900"))
 
 
@@ -2612,3 +2842,8 @@ async def start_background_update_poller() -> None:
 @app.on_event("startup")
 async def start_background_sync_poller() -> None:
     asyncio.create_task(_background_sync_poller())
+
+
+@app.on_event("startup")
+async def start_background_identity_poller() -> None:
+    asyncio.create_task(_background_identity_poller())

--- a/aquila_web/main.py
+++ b/aquila_web/main.py
@@ -10,7 +10,8 @@ from pathlib import Path
 from fastapi import WebSocket
 import asyncio
 import logging
-from datetime import datetime
+import time
+from datetime import datetime, timezone
 import os
 import sys
 from pydantic import BaseModel
@@ -2003,6 +2004,16 @@ _OTA_GHCR_REPO_API = _OTA_GHCR_BASE + "-api"
 _OTA_GHCR_REPO_UI  = _OTA_GHCR_BASE + "-ui"
 _OTA_IMAGE_TAG = os.getenv("IMAGE_TAG", "")   # dev | pilot | prod — set by device.env
 _OTA_POLL_INTERVAL = int(os.getenv("UPDATE_CHECK_INTERVAL", "300"))  # seconds
+# How long to wait for an update to complete before declaring it failed. Sized to
+# the pull, not to a request timeout: the old code allowed 60s for a synchronous
+# call that had to download the whole image, so any update slower than a minute
+# was reported as a failure while it was still succeeding (#350 mode 1).
+_OTA_APPLY_TIMEOUT = int(os.getenv("AQ_UPDATE_APPLY_TIMEOUT", "900"))  # seconds
+_FLEET_ENV_PATH = os.getenv("AQ_FLEET_ENV_PATH", "/opt/fleet/.env")
+# A successful check older than this means the device has not verified its
+# software in a long time — surfaced to the operator, since a device that cannot
+# check looks identical to one that is up to date (#350 mode 2).
+_OTA_STALE_AFTER = int(os.getenv("AQ_UPDATE_STALE_AFTER", "86400"))  # seconds
 
 _update_available: bool = False
 _update_dismissed: bool = False
@@ -2069,8 +2080,26 @@ def _resolve_startup_update_state() -> None:
 # ------------------------------------------------------------------------------
 
 
-async def _ghcr_bearer_token(user: str, token: str, repo: str) -> str | None:
-    """Exchange Basic credentials for a short-lived GHCR Bearer token."""
+# Why a registry check failed. These previously all collapsed to None, which is
+# why the operator-facing message had to say "Registry unreachable OR credentials
+# invalid" — the code genuinely could not tell. They need different actions
+# ("check the network" vs "escalate"), so they are distinguished here. See #350.
+_ERR_NETWORK = "network"
+_ERR_AUTH = "auth"
+_ERR_REGISTRY = "registry"
+
+_ERR_MESSAGES = {
+    _ERR_NETWORK: "No internet connection",
+    _ERR_AUTH: "The update server rejected this device's credentials",
+    _ERR_REGISTRY: "The update server returned an unexpected response",
+}
+
+
+async def _ghcr_bearer_token(user: str, token: str, repo: str) -> tuple[str | None, str | None]:
+    """Exchange Basic credentials for a short-lived GHCR Bearer token.
+
+    Returns (token, error_kind). Exactly one is non-None.
+    """
     cred = base64.b64encode(f"{user}:{token}".encode()).decode()
     owner = repo.split("/")[0]
     name = "/".join(repo.split("/")[1:]) or repo
@@ -2078,18 +2107,28 @@ async def _ghcr_bearer_token(user: str, token: str, repo: str) -> str | None:
     try:
         async with httpx.AsyncClient(timeout=15.0) as client:
             r = await client.get(url, headers={"Authorization": f"Basic {cred}"})
-        if r.status_code == 200:
-            return r.json().get("token")
-    except Exception:
-        pass
-    return None
+    except httpx.RequestError:
+        # Connect failure, DNS failure, timeout — the device cannot reach GHCR.
+        return None, _ERR_NETWORK
+    except Exception:  # noqa: BLE001 - an update check must never crash the poller
+        logger.exception("unexpected error fetching GHCR token")
+        return None, _ERR_REGISTRY
+
+    if r.status_code in (401, 403):
+        return None, _ERR_AUTH
+    if r.status_code != 200:
+        return None, _ERR_REGISTRY
+    bearer = r.json().get("token")
+    return (bearer, None) if bearer else (None, _ERR_REGISTRY)
 
 
-async def _ghcr_manifest_digest(repo: str, tag: str, user: str, token: str) -> str | None:
-    """Return the manifest digest for a GHCR image tag without pulling it."""
-    bearer = await _ghcr_bearer_token(user, token, repo)
+async def _ghcr_manifest_digest(
+    repo: str, tag: str, user: str, token: str
+) -> tuple[str | None, str | None]:
+    """Return (manifest digest, error_kind) for a GHCR image tag without pulling it."""
+    bearer, err = await _ghcr_bearer_token(user, token, repo)
     if bearer is None:
-        return None
+        return None, err
     owner = repo.split("/")[0]
     name = "/".join(repo.split("/")[1:]) or repo
     url = f"https://ghcr.io/v2/{owner}/{name}/manifests/{tag}"
@@ -2104,47 +2143,78 @@ async def _ghcr_manifest_digest(repo: str, tag: str, user: str, token: str) -> s
     try:
         async with httpx.AsyncClient(timeout=15.0) as client:
             r = await client.head(url, headers=headers, follow_redirects=True)
-        return r.headers.get("docker-content-digest")
-    except Exception:
-        return None
+    except httpx.RequestError:
+        return None, _ERR_NETWORK
+    except Exception:  # noqa: BLE001
+        logger.exception("unexpected error fetching GHCR manifest")
+        return None, _ERR_REGISTRY
+
+    if r.status_code in (401, 403):
+        return None, _ERR_AUTH
+    if r.status_code >= 400:
+        return None, _ERR_REGISTRY
+    digest = r.headers.get("docker-content-digest")
+    return (digest, None) if digest else (None, _ERR_REGISTRY)
 
 
 async def _do_check_update() -> None:
+    """Ask GHCR whether a newer image exists. Never pulls.
+
+    `idle` means "checked successfully, nothing new". A check that could not run
+    reports `offline` instead — previously both produced `idle`, and the UI
+    rendered that as a green "Software is up to date" on a device that had in
+    fact failed to reach the registry (#350 mode 2).
+    """
     global _update_available, _update_status, _update_error, _update_last_checked
     global _startup_image_digest, _startup_image_digest_ui, _latest_ghcr_digest, _latest_ghcr_digest_ui
     _update_status = "checking"
     try:
         if not _OTA_GHCR_TOKEN or not _OTA_IMAGE_TAG:
-            _update_status = "idle"
-            _update_error = "Registry credentials or IMAGE_TAG not configured"
+            _update_status = "offline"
+            _update_error = "This device is not configured to receive updates"
             return
-        latest_api, latest_ui = await asyncio.gather(
+
+        (latest_api, err_api), (latest_ui, err_ui) = await asyncio.gather(
             _ghcr_manifest_digest(_OTA_GHCR_REPO_API, _OTA_IMAGE_TAG, _OTA_GHCR_USER, _OTA_GHCR_TOKEN),
             _ghcr_manifest_digest(_OTA_GHCR_REPO_UI,  _OTA_IMAGE_TAG, _OTA_GHCR_USER, _OTA_GHCR_TOKEN),
         )
-        _update_last_checked = datetime.utcnow().isoformat() + "Z"
-        if latest_api is None and latest_ui is None:
-            _update_status = "idle"
-            _update_error = "Registry unreachable or credentials invalid"
+
+        # A partial result is a failed check, not a partial success. Accepting one
+        # digest while the other is unknown is exactly how the API and UI end up on
+        # different builds: the update gets offered and applied with only one digest
+        # recorded (#350 mode 5).
+        err = err_api or err_ui
+        if err:
+            _update_status = "offline"
+            _update_error = _ERR_MESSAGES.get(err, "Could not reach the update server")
+            # Drop any previously-known availability. It may well still be true,
+            # but offering "Update Now" against a registry we cannot reach sends
+            # the operator into a failing apply — and the UI checks `available`
+            # before `status`, so leaving it set would hide the offline warning
+            # entirely. The next successful check re-establishes it.
+            _update_available = False
             return
-        if latest_api is not None:
-            _latest_ghcr_digest = latest_api
-        if latest_ui is not None:
-            _latest_ghcr_digest_ui = latest_ui
+
+        # Only a successful check updates this. It is shown to the operator as
+        # "last successful check", so a failed attempt must not refresh it.
+        _update_last_checked = datetime.utcnow().isoformat() + "Z"
+
+        _latest_ghcr_digest = latest_api
+        _latest_ghcr_digest_ui = latest_ui
         if _startup_image_digest is None:
             _startup_image_digest = latest_api
         if _startup_image_digest_ui is None:
             _startup_image_digest_ui = latest_ui
-        api_changed = latest_api is not None and latest_api != _startup_image_digest
-        ui_changed  = latest_ui  is not None and latest_ui  != _startup_image_digest_ui
-        if api_changed or ui_changed:
+
+        if latest_api != _startup_image_digest or latest_ui != _startup_image_digest_ui:
             _update_available = True
             _update_status = "available"
         else:
             _update_available = False
             _update_status = "idle"
         _update_error = None
-    except Exception as e:
+    except Exception as e:  # noqa: BLE001 - the poller must survive anything
+        logger.exception("update check failed")
         _update_status = "error"
         _update_error = str(e)
 
@@ -2160,12 +2230,26 @@ async def get_update_status():
     if DEV_UPDATE_AVAILABLE and not _update_dismissed:
         available = True
         status = "available"
+
+    # A device that cannot reach the registry looks identical to one that is up
+    # to date, so the age of the last SUCCESSFUL check is surfaced. `stale` is
+    # true when that is too long ago — or when there has never been one.
+    age = None
+    if _update_last_checked:
+        try:
+            last = datetime.fromisoformat(_update_last_checked.replace("Z", "+00:00"))
+            age = max(0, int((datetime.now(timezone.utc) - last).total_seconds()))
+        except (ValueError, AttributeError):
+            age = None
+
     return {
         "available": available,
         "dismissed": _update_dismissed,
         "status": status,
         "error": _update_error,
         "last_checked": _update_last_checked,
+        "last_checked_age_seconds": age,
+        "stale": age is None or age > _OTA_STALE_AFTER,
     }
 
 
@@ -2177,6 +2261,131 @@ async def trigger_update_check():
     return {"ok": True, "message": "checking"}
 
 
+def _parse_prom_metric(body: str, name: str) -> float | None:
+    """Pull a single value out of Prometheus text exposition format."""
+    for line in body.splitlines():
+        line = line.strip()
+        if not line or line.startswith("#"):
+            continue
+        if line.split("{")[0].split(" ")[0] != name:
+            continue
+        try:
+            return float(line.rsplit(" ", 1)[1])
+        except (IndexError, ValueError):
+            return None
+    return None
+
+
+async def _watchtower_metrics() -> dict | None:
+    """Read Watchtower's scan counters. None if the endpoint is unavailable.
+
+    Requires `--http-api-metrics` on the Watchtower container. Without it this
+    returns None and an update's outcome cannot be confirmed — in which case the
+    status is left as `updating` for the poller to resolve, never reported as
+    success.
+    """
+    headers = {"Authorization": f"Bearer {WATCHTOWER_TOKEN}"} if WATCHTOWER_TOKEN else {}
+    try:
+        async with httpx.AsyncClient(timeout=10.0) as client:
+            r = await client.get(f"{WATCHTOWER_URL}/v1/metrics", headers=headers)
+        if r.status_code != 200:
+            return None
+        return {
+            "scans": _parse_prom_metric(r.text, "watchtower_scans_total"),
+            "updated": _parse_prom_metric(r.text, "watchtower_containers_updated"),
+            "failed": _parse_prom_metric(r.text, "watchtower_containers_failed"),
+        }
+    except Exception:  # noqa: BLE001 - never let metrics polling raise into the caller
+        return None
+
+
+async def _await_update_outcome(scans_before: float | None, prev_digests: tuple) -> None:
+    """Watch for the update to finish, and report failure if it does not.
+
+    On success this coroutine never completes: Watchtower replaces the backend
+    container and the process is killed. Surviving to the end therefore means the
+    update did NOT apply, which is exactly the case the previous code reported as
+    success (#350 mode 3).
+    """
+    global _update_status, _update_error, _update_available
+
+    deadline = time.monotonic() + _OTA_APPLY_TIMEOUT
+    while time.monotonic() < deadline:
+        await asyncio.sleep(10)
+        m = await _watchtower_metrics()
+        if m is None:
+            continue
+        # Wait for OUR scan to land rather than reading the previous one's numbers.
+        if scans_before is not None and m["scans"] is not None and m["scans"] <= scans_before:
+            continue
+        if m["failed"]:
+            _fail_update("The update could not be downloaded. The device is still "
+                         "running the previous version.", prev_digests)
+            return
+        if m["updated"]:
+            # Containers were replaced but this process is somehow still alive.
+            # Leave the sentinel in place and let the poller settle the state.
+            return
+
+    _fail_update("The update timed out. The device is still running the previous "
+                 "version.", prev_digests)
+
+
+def _fail_update(message: str, prev_digests: tuple) -> None:
+    """Record a confirmed failure and undo everything the apply wrote up front."""
+    global _update_status, _update_error, _update_available
+    _update_status = "update_failed"
+    _update_error = message
+    _update_available = True  # the update is still outstanding
+
+    # Disarm the reboot. The sentinel is written before triggering Watchtower
+    # because a kill mid-swap must still leave it behind — but if the swap never
+    # happened, a stale `reboot_pending` reboots the device for an update that did
+    # not apply, then shows "Update Complete" (#350 mode 4).
+    try:
+        _sentinel.clear_sentinel(_UPDATE_SENTINEL_PATH)
+    except OSError:
+        logger.warning("could not clear update sentinel at %s", _UPDATE_SENTINEL_PATH)
+
+    # Put the recorded digests back so /opt/fleet/.env does not claim a version
+    # the device is not running.
+    _write_fleet_digests(*prev_digests)
+
+
+def _read_fleet_digests() -> tuple:
+    api = ui = None
+    try:
+        with open(_FLEET_ENV_PATH, "r") as f:
+            for line in f:
+                if line.startswith("RUNNING_IMAGE_DIGEST_UI="):
+                    ui = line.split("=", 1)[1].strip()
+                elif line.startswith("RUNNING_IMAGE_DIGEST="):
+                    api = line.split("=", 1)[1].strip()
+    except OSError:
+        pass
+    return api, ui
+
+
+def _write_fleet_digests(api: str | None, ui: str | None) -> None:
+    if not os.path.exists(_FLEET_ENV_PATH):
+        return
+    try:
+        with open(_FLEET_ENV_PATH, "r") as f:
+            lines = f.readlines()
+        out = []
+        for line in lines:
+            if line.startswith("RUNNING_IMAGE_DIGEST_UI=") and ui is not None:
+                out.append(f"RUNNING_IMAGE_DIGEST_UI={ui}\n")
+            elif line.startswith("RUNNING_IMAGE_DIGEST=") and api is not None:
+                out.append(f"RUNNING_IMAGE_DIGEST={api}\n")
+            else:
+                out.append(line)
+        with open(_FLEET_ENV_PATH, "w") as f:
+            f.writelines(out)
+    except OSError:
+        logger.warning("could not update digests in %s", _FLEET_ENV_PATH)
+
+
 @app.post("/update/apply")
 async def apply_update():
     global _update_status, _update_error, _startup_image_digest, _startup_image_digest_ui, _update_available
@@ -2185,59 +2394,58 @@ async def apply_update():
             status_code=409,
             content={"ok": False, "error": "Cannot update during an active run. Stop the run first."},
         )
+
+    prev_digests = _read_fleet_digests()
+    # Capture before triggering so we can tell OUR scan's results from the
+    # previous scan's leftovers.
+    before = await _watchtower_metrics()
+    scans_before = before["scans"] if before else None
+    if before is None:
+        logger.warning(
+            "Watchtower metrics unavailable (needs --http-api-metrics); "
+            "an update's outcome cannot be confirmed"
+        )
+
     # Breadcrumb the new container reads on startup to drive the auto-reboot (#183).
-    # Written before triggering Watchtower so a kill mid-swap still leaves it behind.
+    # Written before triggering Watchtower so a kill mid-swap still leaves it
+    # behind; _fail_update() clears it again if the swap is confirmed not to have
+    # happened.
     try:
         _sentinel.write_sentinel(_UPDATE_SENTINEL_PATH, "reboot_pending", _utcnow_iso())
     except OSError:
         logger.warning("could not write update sentinel at %s", _UPDATE_SENTINEL_PATH)
+
     _update_status = "updating"
+    _write_fleet_digests(_latest_ghcr_digest, _latest_ghcr_digest_ui)
+
     headers = {"Authorization": f"Bearer {WATCHTOWER_TOKEN}"} if WATCHTOWER_TOKEN else {}
     try:
-        # Write new digests to /opt/fleet/.env before triggering Watchtower so the
-        # restarted container picks up the correct baseline even if we are killed mid-restart.
-        _fleet_env = "/opt/fleet/.env"
-        if (_latest_ghcr_digest or _latest_ghcr_digest_ui) and os.path.exists(_fleet_env):
-            try:
-                with open(_fleet_env, "r") as f:
-                    lines = f.readlines()
-                updated = []
-                for line in lines:
-                    if line.startswith("RUNNING_IMAGE_DIGEST=") and not line.startswith("RUNNING_IMAGE_DIGEST_UI=") and _latest_ghcr_digest:
-                        updated.append(f"RUNNING_IMAGE_DIGEST={_latest_ghcr_digest}\n")
-                    elif line.startswith("RUNNING_IMAGE_DIGEST_UI=") and _latest_ghcr_digest_ui:
-                        updated.append(f"RUNNING_IMAGE_DIGEST_UI={_latest_ghcr_digest_ui}\n")
-                    else:
-                        updated.append(line)
-                with open(_fleet_env, "w") as f:
-                    f.writelines(updated)
-            except OSError:
-                pass
-        async with httpx.AsyncClient(timeout=60.0) as client:
-            r = await client.post(f"{WATCHTOWER_URL}/v1/update", headers=headers)
-        if r.status_code == 200:
-            if _latest_ghcr_digest:
-                _startup_image_digest = _latest_ghcr_digest
-            if _latest_ghcr_digest_ui:
-                _startup_image_digest_ui = _latest_ghcr_digest_ui
-            _update_available = False
-            _update_status = "updating"
-            # If containers don't restart (nothing to update), the in-memory status
-            # would stay "updating" until the next 5-min poller tick. Schedule a
-            # check after 3 minutes so the UI gets a timely resolution either way.
-            async def _deferred_status_reset() -> None:
-                await asyncio.sleep(180)
-                if _update_status == "updating":
-                    await _do_check_update()
-            asyncio.create_task(_deferred_status_reset())
-            return {"ok": True, "message": "Update triggered — containers will restart shortly."}
-        _update_status = "error"
-        _update_error = f"Watchtower returned HTTP {r.status_code}"
+        # ?async=true returns 202 immediately. POST /v1/update is synchronous by
+        # default, and the previous 60s timeout was shorter than the pull it was
+        # waiting on — so a slow-but-successful update raised ReadTimeout and was
+        # reported to the operator as "Update failed" (#350 mode 1).
+        async with httpx.AsyncClient(timeout=30.0) as client:
+            r = await client.post(f"{WATCHTOWER_URL}/v1/update?async=true", headers=headers)
+    except Exception as e:  # noqa: BLE001
+        _fail_update(f"Could not start the update: {e}", prev_digests)
         return {"ok": False, "error": _update_error}
-    except Exception as e:
-        _update_status = "error"
-        _update_error = str(e)
-        return {"ok": False, "error": str(e)}
+
+    if r.status_code == 429:
+        _update_status = "updating"
+        return {"ok": True, "message": "An update is already in progress."}
+    if r.status_code not in (200, 202):
+        _fail_update(f"The update service rejected the request (HTTP {r.status_code}).",
+                     prev_digests)
+        return {"ok": False, "error": _update_error}
+
+    if _latest_ghcr_digest:
+        _startup_image_digest = _latest_ghcr_digest
+    if _latest_ghcr_digest_ui:
+        _startup_image_digest_ui = _latest_ghcr_digest_ui
+    _update_available = False
+
+    asyncio.create_task(_await_update_outcome(scans_before, prev_digests))
+    return {"ok": True, "message": "Update started — the device will restart when it completes."}
 
 
 @app.post("/update/dismiss")
@@ -2282,8 +2490,11 @@ async def reboot_device():
 async def _background_update_poller() -> None:
     """Poll GHCR every UPDATE_CHECK_INTERVAL seconds. Never pulls the image."""
     while True:
-        if _OTA_GHCR_TOKEN and _OTA_IMAGE_TAG:
-            await _do_check_update()
+        # Called unconditionally: _do_check_update() reports `offline` when the
+        # device has no registry credentials. Skipping it here left an
+        # unconfigured or mis-provisioned device sitting at the initial `idle`
+        # forever, which the UI renders as "✓ Software is up to date" (#350).
+        await _do_check_update()
         await asyncio.sleep(_OTA_POLL_INTERVAL)
 
 

--- a/aquila_web/static/settings.html
+++ b/aquila_web/static/settings.html
@@ -300,6 +300,35 @@
         `;
       } else if (data.status === "updating") {
         _showUpdateOverlay();
+      } else if (data.status === "update_failed") {
+        // A confirmed failure: the update was triggered and did not apply. The
+        // reassurance line matters — an interrupted update sounds alarming and
+        // this failure is genuinely safe (#350).
+        _hideUpdateOverlay();
+        if (dot) dot.style.display = "block";
+        area.innerHTML = `
+          <p style="color:#b45309;font-size:15px;font-weight:600;margin:0 0 6px;">⚠ Update did not complete</p>
+          <p style="font-size:15px;color:#1a1c1c;margin:0 0 4px;">${_escHtml(data.error || "The update was interrupted.")}</p>
+          <p style="font-size:14px;color:#4b5563;margin:0;">Your data and settings are unaffected.</p>
+          <button onclick="openUpdateTab()"
+            style="margin-top:12px;padding:8px 18px;border-radius:8px;border:1px solid #cbd5e1;background:#fff;font-size:14px;cursor:pointer;color:#374151;">Try again</button>
+        `;
+      } else if (data.status === "offline") {
+        // Deliberately amber, not the red used for `error`. The device works
+        // fine — it just could not verify whether it is current. Previously this
+        // state produced `idle`, which rendered as a green "up to date" on a
+        // device that had failed to reach the registry (#350 mode 2).
+        if (dot) dot.style.display = "none";
+        let html = `
+          <p style="color:#b45309;font-size:15px;font-weight:600;margin:0 0 6px;">⚠ Could not check for updates</p>
+          <p style="font-size:15px;color:#1a1c1c;margin:0 0 4px;">${_escHtml(data.error || "The update server could not be reached.")}</p>`;
+        html += data.last_checked
+          ? `<p style="font-size:13px;color:#4b5563;margin:0;">Last successful check: ${_fmtChecked(data.last_checked)}${_ageSuffix(data)}</p>`
+          : `<p style="font-size:13px;color:#4b5563;margin:0;">This device has never successfully checked for updates.</p>`;
+        html += `<p style="font-size:14px;color:#4b5563;margin:8px 0 0;">The device may be missing important updates.</p>
+          <button onclick="openUpdateTab()"
+            style="margin-top:12px;padding:8px 18px;border-radius:8px;border:1px solid #cbd5e1;background:#fff;font-size:14px;cursor:pointer;color:#374151;">Try again</button>`;
+        area.innerHTML = html;
       } else if (data.status === "error") {
         area.innerHTML = `
           <p style="color:#dc2626;font-size:15px;">Could not check for updates: ${_escHtml(data.error || "unknown error")}</p>
@@ -309,9 +338,25 @@
       } else {
         if (dot) dot.style.display = "none";
         let html = '<p style="color:#16a34a;font-size:15px;font-weight:600;">✓ Software is up to date.</p>';
-        if (data.last_checked) html += `<p style="font-size:12px;color:#6b7280;margin-top:6px;">Last checked: ${_escHtml(data.last_checked.replace("T"," ").replace("Z"," UTC"))}</p>`;
+        if (data.last_checked) html += `<p style="font-size:12px;color:#6b7280;margin-top:6px;">Last checked: ${_fmtChecked(data.last_checked)}${_ageSuffix(data)}</p>`;
+        // A successful but long-ago check still means the device is not being
+        // kept current, so say so even on the healthy path.
+        if (data.stale) html += `<p style="color:#b45309;font-size:13px;margin-top:8px;">⚠ This check is out of date — the device may be missing newer updates.</p>`;
         area.innerHTML = html;
       }
+    }
+
+    function _fmtChecked(ts) {
+      return _escHtml(String(ts).replace("T", " ").replace("Z", " UTC"));
+    }
+
+    function _ageSuffix(data) {
+      const s = data.last_checked_age_seconds;
+      if (s === null || s === undefined) return "";
+      const d = Math.floor(s / 86400), h = Math.floor(s / 3600);
+      if (d >= 1) return ` (${d} day${d === 1 ? "" : "s"} ago)`;
+      if (h >= 1) return ` (${h} hour${h === 1 ? "" : "s"} ago)`;
+      return " (just now)";
     }
 
     function _showUpdateOverlay() {
@@ -366,22 +411,31 @@
         const r = await fetch("/update/status").catch(() => null);
         const data = r ? await r.json().catch(() => null) : null;
         if (!data || data.status === "updating" || data.available) { _pollForUpdateComplete(attempt + 1, fallbackError); return; }
-        if (data.status === "error") {
+
+        // Only these two states are conclusive. Anything else — notably
+        // `offline`, which a mid-update network blip produces — means we still
+        // do not know, so keep polling. Falling through to the success branch on
+        // an inconclusive status is how a failed pull came to render
+        // "✓ Update complete" (#350 mode 3).
+        if (data.status === "error" || data.status === "update_failed") {
           _hideUpdateOverlay();
-          const errMsg = fallbackError || data.error || "unknown error";
-          document.getElementById("update-status-area").innerHTML =
-            `<p style="color:#dc2626;font-size:15px;">Update failed: ${_escHtml(errMsg)}</p>`;
+          renderUpdateStatus({ ...data, status: data.status,
+                               error: fallbackError || data.error });
           return;
         }
+        if (data.status !== "idle") { _pollForUpdateComplete(attempt + 1, fallbackError); return; }
+
+        // status === "idle" means a check completed successfully and found
+        // nothing newer — i.e. the device is now running the target build.
         _hideUpdateOverlay();
         const area = document.getElementById("update-status-area");
         const dot = document.getElementById("updates-tab-dot");
         if (dot) dot.style.display = "none";
-        const checkedAt = data.last_checked ? data.last_checked.replace("T", " ").replace("Z", " UTC") : "";
+        const checkedAt = data.last_checked ? _fmtChecked(data.last_checked) : "";
         area.innerHTML = `
           <p style="font-size:20px;font-weight:700;color:#16a34a;margin:0 0 8px;">✓ Update complete</p>
           <p style="font-size:15px;color:#1a1c1c;margin:0 0 6px;">The device is running the latest software.</p>
-          ${checkedAt ? `<p style="font-size:12px;color:#6b7280;margin:0;">Verified: ${_escHtml(checkedAt)}</p>` : ""}
+          ${checkedAt ? `<p style="font-size:12px;color:#6b7280;margin:0;">Verified: ${checkedAt}</p>` : ""}
         `;
       }, 3000);
     }

--- a/fleet-config/docker-compose.yml
+++ b/fleet-config/docker-compose.yml
@@ -149,9 +149,13 @@ services:
     environment:
       WATCHTOWER_LABEL_ENABLE: "true"
       WATCHTOWER_HTTP_API_UPDATE: "true"
+      # Exposes /v1/metrics, which is how the backend confirms whether an update
+      # actually applied. Without it the outcome is unknowable and the backend
+      # cannot distinguish a slow success from a failed pull (#350).
+      WATCHTOWER_HTTP_API_METRICS: "true"
       WATCHTOWER_CLEANUP: "true"
       WATCHTOWER_CONFIG_FILE: "/config.json"
-    command: --label-enable --http-api-update --cleanup --api-version 1.54
+    command: --label-enable --http-api-update --http-api-metrics --cleanup --api-version 1.54
     restart: unless-stopped
     logging:
       driver: json-file

--- a/scripts/deploy/deployment2_verify.sh
+++ b/scripts/deploy/deployment2_verify.sh
@@ -140,6 +140,18 @@ test_phase_11() {
     check 11 "aquila-ui running"         \
         "docker ps --filter name=aquila-ui --format '{{.Status}}' | grep -q Up"
     check 11 "backend reachable :8090"   "curl -sf http://localhost:8090/health"
+
+    # Build identity (#351/#352). "backend reachable" passes on an image with no
+    # provenance at all, and a version mismatch is invisible without this.
+    check 11 "backend reports a build SHA" \
+        "curl -sf http://localhost:8090/health | grep -qv '\"git_sha\": *\"unknown\"'"
+    # nginx must serve the UI's own identity, not proxy the request to the
+    # backend — otherwise the UI appears to match itself no matter what.
+    check 11 "UI serves its own identity" \
+        "curl -sf http://localhost:8080/version.json | grep -q git_sha"
+    # false means a confirmed mismatch. null (could not verify) is not a failure.
+    check 11 "no confirmed identity mismatch" \
+        "! curl -sf http://localhost:8090/identity | grep -q '\"identity_ok\": *false'"
     check 11 "aquila-watchtower running" \
         "docker ps --filter name=aquila-watchtower --format '{{.Status}}' | grep -q Up"
     check 11 "watchtower webhook responds" \

--- a/tests/contract/test_identity_mismatch.py
+++ b/tests/contract/test_identity_mismatch.py
@@ -1,0 +1,186 @@
+"""A version mismatch announces itself rather than waiting to be found (#352).
+
+Two checks, both on git SHAs and never on build timestamps:
+
+  A. api.git_sha == ui.git_sha      — same build, no network needed
+  B. running build == what the fleet config claims, bridged through the
+     org.opencontainers.image.revision label from #351
+
+`identity_ok` is deliberately three-valued. A check that could not run must
+report null, never true — a check that silently passes when it could not run is
+the exact failure the OTA status issue documents.
+"""
+import asyncio
+
+import pytest
+
+from aquila_web import main
+
+
+@pytest.fixture(autouse=True)
+def _reset_identity(monkeypatch):
+    monkeypatch.setattr(main, "_identity_state", dict(main._identity_state))
+    monkeypatch.setattr(main, "_BUILD_IDENTITY",
+                        {"app_version": "2.1.0.5", "git_sha": "aaa111", "build_time": "t"})
+    monkeypatch.setenv("RUNNING_IMAGE_DIGEST", "sha256:deadbeef")
+    monkeypatch.setattr(main, "_OTA_GHCR_TOKEN", "token")
+    yield
+
+
+def _ui(monkeypatch, sha, err=None):
+    async def fake():
+        return sha, err
+    monkeypatch.setattr(main, "_fetch_ui_identity", fake)
+
+
+def _registry(monkeypatch, sha, err=None):
+    async def fake(repo, digest, user, token):
+        return sha, err
+    monkeypatch.setattr(main, "_ghcr_revision_for_digest", fake)
+
+
+# ── The three-valued rule ─────────────────────────────────────────────────────
+
+@pytest.mark.parametrize("images,digest,expected", [
+    (True,  True,  True),
+    (True,  False, False),
+    (False, True,  False),
+    (False, False, False),
+    (True,  None,  None),   # could not verify — NOT true
+    (None,  True,  None),
+    (None,  None,  None),
+    (False, None,  False),  # a known failure beats an unknown
+    (None,  False, False),
+])
+def test_identity_ok_resolution(images, digest, expected):
+    assert main._resolve_identity_ok(images, digest) is expected
+
+
+# ── Check A: do the two images come from the same build? ──────────────────────
+
+def test_matching_images_and_digest_verify(monkeypatch):
+    _ui(monkeypatch, "aaa111")
+    _registry(monkeypatch, "aaa111")
+    asyncio.run(main._check_build_identity())
+    assert main._identity_state["images_match"] is True
+    assert main._identity_state["digest_matches"] is True
+    assert main._identity_state["identity_ok"] is True
+
+
+def test_api_and_ui_from_different_builds_is_a_mismatch(monkeypatch):
+    _ui(monkeypatch, "bbb222")
+    _registry(monkeypatch, "aaa111")
+    asyncio.run(main._check_build_identity())
+    assert main._identity_state["images_match"] is False
+    assert main._identity_state["identity_ok"] is False
+
+
+def test_unreachable_ui_is_unknown_not_a_pass(monkeypatch):
+    _ui(monkeypatch, None, "Could not reach the UI container")
+    _registry(monkeypatch, "aaa111")
+    asyncio.run(main._check_build_identity())
+    assert main._identity_state["images_match"] is None
+    assert main._identity_state["identity_ok"] is None
+    assert main._identity_state["error"]
+
+
+# ── Check B: is the running build the one the config claims? ──────────────────
+
+def test_running_build_differing_from_the_recorded_digest_is_a_mismatch(monkeypatch):
+    """RUNNING_IMAGE_DIGEST is written before the swap, so it can claim a build
+    the device never actually started running."""
+    _ui(monkeypatch, "aaa111")
+    _registry(monkeypatch, "ccc333")  # the digest was built from a different commit
+    asyncio.run(main._check_build_identity())
+    assert main._identity_state["digest_matches"] is False
+    assert main._identity_state["identity_ok"] is False
+
+
+def test_unreachable_registry_is_unknown_not_a_pass(monkeypatch):
+    _ui(monkeypatch, "aaa111")
+    _registry(monkeypatch, None, main._ERR_NETWORK)
+    asyncio.run(main._check_build_identity())
+    assert main._identity_state["digest_matches"] is None
+    assert main._identity_state["identity_ok"] is None
+
+
+def test_no_recorded_digest_leaves_check_b_unknown(monkeypatch):
+    monkeypatch.delenv("RUNNING_IMAGE_DIGEST", raising=False)
+    _ui(monkeypatch, "aaa111")
+    asyncio.run(main._check_build_identity())
+    assert main._identity_state["images_match"] is True
+    assert main._identity_state["digest_matches"] is None
+    assert main._identity_state["identity_ok"] is None
+
+
+def test_image_built_before_351_cannot_verify(monkeypatch):
+    """No baked SHA — degrade to unknown rather than claiming a pass."""
+    monkeypatch.setattr(main, "_BUILD_IDENTITY",
+                        {"app_version": "2.1.0.5", "git_sha": "unknown", "build_time": "unknown"})
+    _ui(monkeypatch, "aaa111")
+    _registry(monkeypatch, "aaa111")
+    asyncio.run(main._check_build_identity())
+    assert main._identity_state["identity_ok"] is None
+
+
+# ── Reporting ─────────────────────────────────────────────────────────────────
+
+def test_identity_endpoint_reports_the_state(client, monkeypatch):
+    _ui(monkeypatch, "bbb222")
+    _registry(monkeypatch, "aaa111")
+    asyncio.run(main._check_build_identity())
+    body = client.get("/identity").json()
+    assert body["identity_ok"] is False
+    assert body["api_git_sha"] == "aaa111"
+    assert body["ui_git_sha"] == "bbb222"
+    assert body["checked_at"]
+
+
+def test_mismatch_is_emitted_to_the_outbox(monkeypatch):
+    """An on-screen warning only helps someone standing at the device."""
+    sent = []
+    monkeypatch.setattr(main, "enqueue_event",
+                        lambda t, p, **kw: sent.append((t, p, kw)) or 1)
+    _ui(monkeypatch, "bbb222")
+    _registry(monkeypatch, "aaa111")
+    asyncio.run(main._check_build_identity())
+    assert sent and sent[0][0] == "identity_mismatch"
+    assert sent[0][2].get("dedup_key"), "must dedup or every poll re-sends it"
+
+
+def test_matching_identity_emits_nothing(monkeypatch):
+    sent = []
+    monkeypatch.setattr(main, "enqueue_event", lambda t, p, **kw: sent.append(t) or 1)
+    _ui(monkeypatch, "aaa111")
+    _registry(monkeypatch, "aaa111")
+    asyncio.run(main._check_build_identity())
+    assert sent == []
+
+
+def test_repeated_mismatch_emits_once(monkeypatch):
+    """Only on transition — otherwise every poll floods the outbox."""
+    sent = []
+    monkeypatch.setattr(main, "enqueue_event", lambda t, p, **kw: sent.append(t) or 1)
+    _ui(monkeypatch, "bbb222")
+    _registry(monkeypatch, "aaa111")
+    asyncio.run(main._check_build_identity())
+    asyncio.run(main._check_build_identity())
+    assert len(sent) == 1
+
+
+def test_build_time_is_never_a_comparison_key():
+    """Posit found timestamp-based tracking unreliable across build nodes, and
+    these Pis have no RTC. build_time is informational only."""
+    import inspect
+    src = inspect.getsource(main._check_build_identity)
+    assert "build_time" not in src, "identity comparison must key off git_sha only"
+
+
+def test_manual_check_endpoint_reruns_the_check(client, monkeypatch):
+    """Used by post-deploy verification and by the operator's "Try again"."""
+    _ui(monkeypatch, "bbb222")
+    _registry(monkeypatch, "aaa111")
+    body = client.post("/identity/check").json()
+    assert body["ok"] is True
+    assert body["identity_ok"] is False
+    assert body["ui_git_sha"] == "bbb222"

--- a/tests/contract/test_update_complete_flow.py
+++ b/tests/contract/test_update_complete_flow.py
@@ -44,6 +44,12 @@ def test_reboot_pending_triggers_reboot_and_advances_sentinel(client, tmp_path, 
 
 
 def test_apply_writes_reboot_pending_sentinel(client, tmp_path, monkeypatch):
+    """The sentinel is armed before Watchtower is triggered.
+
+    It has to be: on success this container is killed mid-swap, so there is no
+    "after" in which to write it. The successor reads it on startup to drive the
+    reboot (#183).
+    """
     from aquila_web import main as web_main
     from aquila_web import update_sentinel as us
 
@@ -51,10 +57,40 @@ def test_apply_writes_reboot_pending_sentinel(client, tmp_path, monkeypatch):
     monkeypatch.setattr(web_main, "_UPDATE_SENTINEL_PATH", path)
     monkeypatch.setattr(web_main.current_item, "screen", "ready")  # not mid-run
 
-    # Watchtower is unreachable in tests; the sentinel must be written first regardless.
+    seen = []
+    # web_main._sentinel IS the update_sentinel module, so keep a reference to the
+    # original before patching or the wrapper calls itself.
+    original = us.write_sentinel
+
+    def _capture(p, state, ts):
+        seen.append(state)
+        return original(p, state, ts)
+
+    monkeypatch.setattr(web_main._sentinel, "write_sentinel", _capture)
     client.post("/update/apply")
-    rec = us.read_sentinel(path)
-    assert rec is not None and rec["state"] == "reboot_pending"
+    assert seen == ["reboot_pending"]
+
+
+def test_apply_disarms_the_sentinel_when_the_trigger_fails(client, tmp_path, monkeypatch):
+    """Previously this left `reboot_pending` on disk for an update that never ran.
+
+    Watchtower is unreachable under test, so the trigger fails. Any backend
+    restart within the sentinel's 600s TTL would then reboot the device and show
+    "Update Complete" for an update that never applied (#350 mode 4).
+    """
+    from aquila_web import main as web_main
+    from aquila_web import update_sentinel as us
+
+    path = str(tmp_path / "last_update.json")
+    monkeypatch.setattr(web_main, "_UPDATE_SENTINEL_PATH", path)
+    monkeypatch.setattr(web_main, "_FLEET_ENV_PATH", str(tmp_path / "no-such.env"))
+    monkeypatch.setattr(web_main.current_item, "screen", "ready")
+
+    resp = client.post("/update/apply")
+
+    assert resp.json()["ok"] is False
+    assert us.read_sentinel(path) is None, "a failed trigger must leave no armed reboot"
+    assert web_main._update_status == "update_failed"
 
 
 def test_apply_during_active_run_is_rejected_and_writes_no_sentinel(client, tmp_path, monkeypatch):

--- a/tests/contract/test_update_status_reliability.py
+++ b/tests/contract/test_update_status_reliability.py
@@ -1,0 +1,221 @@
+"""OTA status must be honest in both directions (#350).
+
+The failures this guards against are not "no message shown" — they are wrong
+messages shown confidently:
+
+  - a failed registry check reported `idle`, which the UI renders as a green
+    "✓ Software is up to date"
+  - a failed pull left the poll loop falling through to "✓ Update complete"
+  - a slow-but-successful update raised ReadTimeout on a 60s budget and was
+    reported as "Update failed"
+
+So these tests assert on the *distinction* between "checked, nothing new" and
+"could not check", which is the thing that was collapsed.
+"""
+import asyncio
+
+import pytest
+
+from aquila_web import main
+
+
+@pytest.fixture(autouse=True)
+def _reset_update_state():
+    """Module-level globals hold the OTA state; isolate each test."""
+    saved = {
+        k: getattr(main, k)
+        for k in (
+            "_update_available", "_update_status", "_update_error",
+            "_update_last_checked", "_startup_image_digest",
+            "_startup_image_digest_ui", "_latest_ghcr_digest",
+            "_latest_ghcr_digest_ui", "_OTA_GHCR_TOKEN", "_OTA_IMAGE_TAG",
+        )
+    }
+    main._OTA_GHCR_TOKEN = "token"
+    main._OTA_IMAGE_TAG = "pilot"
+    # Reset, not just save/restore: an earlier test in another file may have left
+    # these set, and several assertions here are about what a failed check does
+    # to them.
+    main._update_available = False
+    main._update_status = "idle"
+    main._update_error = None
+    main._startup_image_digest = "sha256:api-old"
+    main._startup_image_digest_ui = "sha256:ui-old"
+    main._update_last_checked = None
+    yield
+    for k, v in saved.items():
+        setattr(main, k, v)
+
+
+def _digests(monkeypatch, api, ui):
+    """Stub the registry so each call returns a (digest, error_kind) pair."""
+    async def fake(repo, tag, user, token):
+        return api if "api" in repo else ui
+    monkeypatch.setattr(main, "_ghcr_manifest_digest", fake)
+
+
+# ── A failed check must not look like a successful one ────────────────────────
+
+def test_unreachable_registry_reports_offline_not_idle(monkeypatch):
+    """`idle` means "checked, nothing new" — the UI paints it green."""
+    _digests(monkeypatch, (None, main._ERR_NETWORK), (None, main._ERR_NETWORK))
+    asyncio.run(main._do_check_update())
+    assert main._update_status == "offline"
+    assert main._update_status != "idle"
+
+
+def test_network_and_auth_failures_are_distinguishable(monkeypatch):
+    """They need different operator actions, so they cannot share a message."""
+    _digests(monkeypatch, (None, main._ERR_NETWORK), (None, main._ERR_NETWORK))
+    asyncio.run(main._do_check_update())
+    network_msg = main._update_error
+
+    _digests(monkeypatch, (None, main._ERR_AUTH), (None, main._ERR_AUTH))
+    asyncio.run(main._do_check_update())
+    assert main._update_error != network_msg
+    assert "credential" in main._update_error.lower()
+
+
+def test_failed_check_does_not_refresh_last_checked(monkeypatch):
+    """It is shown as "last successful check"; a failed attempt must not bump it."""
+    _digests(monkeypatch, ("sha256:api-old", None), ("sha256:ui-old", None))
+    asyncio.run(main._do_check_update())
+    good = main._update_last_checked
+    assert good is not None
+
+    _digests(monkeypatch, (None, main._ERR_NETWORK), (None, main._ERR_NETWORK))
+    asyncio.run(main._do_check_update())
+    assert main._update_last_checked == good
+
+
+# ── Partial failure is a failed check, not a partial success ──────────────────
+
+def test_partial_digest_failure_does_not_offer_an_update(monkeypatch):
+    """One digest resolving while the other blips is how api/ui end up skewed."""
+    _digests(monkeypatch, ("sha256:api-new", None), (None, main._ERR_NETWORK))
+    asyncio.run(main._do_check_update())
+    assert main._update_status == "offline"
+    assert main._update_available is False
+
+
+def test_failed_check_withdraws_a_previously_known_update(monkeypatch):
+    """Otherwise the UI shows "Update Now" against a registry it cannot reach.
+
+    renderUpdateStatus checks `available` before `status`, so leaving it set
+    would also hide the offline warning entirely.
+    """
+    _digests(monkeypatch, ("sha256:api-new", None), ("sha256:ui-new", None))
+    asyncio.run(main._do_check_update())
+    assert main._update_available is True
+
+    _digests(monkeypatch, (None, main._ERR_NETWORK), (None, main._ERR_NETWORK))
+    asyncio.run(main._do_check_update())
+    assert main._update_available is False
+    assert main._update_status == "offline"
+
+
+def test_both_digests_resolving_and_changing_offers_an_update(monkeypatch):
+    _digests(monkeypatch, ("sha256:api-new", None), ("sha256:ui-new", None))
+    asyncio.run(main._do_check_update())
+    assert main._update_status == "available"
+    assert main._update_available is True
+
+
+def test_no_change_reports_idle(monkeypatch):
+    _digests(monkeypatch, ("sha256:api-old", None), ("sha256:ui-old", None))
+    asyncio.run(main._do_check_update())
+    assert main._update_status == "idle"
+    assert main._update_available is False
+
+
+# ── The status endpoint ───────────────────────────────────────────────────────
+
+def test_status_exposes_staleness(client, monkeypatch):
+    """A device that has never checked is stale — it cannot claim to be current."""
+    main._update_last_checked = None
+    body = client.get("/update/status").json()
+    assert body["stale"] is True
+    assert body["last_checked_age_seconds"] is None
+
+
+def test_recent_successful_check_is_not_stale(client, monkeypatch):
+    _digests(monkeypatch, ("sha256:api-old", None), ("sha256:ui-old", None))
+    asyncio.run(main._do_check_update())
+    body = client.get("/update/status").json()
+    assert body["stale"] is False
+    assert body["last_checked_age_seconds"] is not None
+    assert body["last_checked_age_seconds"] < 60
+
+
+def test_offline_status_is_reported_to_the_ui(client, monkeypatch):
+    _digests(monkeypatch, (None, main._ERR_NETWORK), (None, main._ERR_NETWORK))
+    asyncio.run(main._do_check_update())
+    body = client.get("/update/status").json()
+    assert body["status"] == "offline"
+    assert body["error"]
+
+
+# ── Watchtower metrics parsing ────────────────────────────────────────────────
+
+def test_parses_prometheus_metrics():
+    body = (
+        "# HELP watchtower_containers_updated Number of containers updated\n"
+        "# TYPE watchtower_containers_updated gauge\n"
+        "watchtower_containers_updated 2\n"
+        "watchtower_containers_failed 0\n"
+        "watchtower_scans_total 17\n"
+    )
+    assert main._parse_prom_metric(body, "watchtower_containers_updated") == 2
+    assert main._parse_prom_metric(body, "watchtower_containers_failed") == 0
+    assert main._parse_prom_metric(body, "watchtower_scans_total") == 17
+
+
+def test_missing_metric_returns_none():
+    assert main._parse_prom_metric("watchtower_scans_total 3\n", "nope") is None
+
+
+def test_comment_lines_are_not_mistaken_for_values():
+    """A HELP line contains the metric name and must not be parsed as a value."""
+    body = "# HELP watchtower_containers_failed some text 99\nwatchtower_containers_failed 0\n"
+    assert main._parse_prom_metric(body, "watchtower_containers_failed") == 0
+
+
+# ── A confirmed failure must disarm the reboot ────────────────────────────────
+
+def test_confirmed_failure_clears_the_sentinel(tmp_path, monkeypatch):
+    """A stale `reboot_pending` reboots the device for an update that never applied."""
+    sentinel = tmp_path / "last_update.json"
+    monkeypatch.setattr(main, "_UPDATE_SENTINEL_PATH", str(sentinel))
+    monkeypatch.setattr(main, "_FLEET_ENV_PATH", str(tmp_path / "no-such.env"))
+    main._sentinel.write_sentinel(str(sentinel), "reboot_pending", main._utcnow_iso())
+    assert sentinel.exists()
+
+    main._fail_update("pull failed", (None, None))
+
+    assert main._update_status == "update_failed"
+    assert main._sentinel.read_sentinel(str(sentinel)) in (None, {})
+
+
+def test_confirmed_failure_leaves_the_update_outstanding(tmp_path, monkeypatch):
+    """The update still needs applying, so it must not be marked done."""
+    monkeypatch.setattr(main, "_UPDATE_SENTINEL_PATH", str(tmp_path / "s.json"))
+    monkeypatch.setattr(main, "_FLEET_ENV_PATH", str(tmp_path / "no-such.env"))
+    main._fail_update("pull failed", (None, None))
+    assert main._update_available is True
+
+
+def test_confirmed_failure_restores_the_recorded_digests(tmp_path, monkeypatch):
+    """/opt/fleet/.env must not claim a version the device is not running."""
+    env = tmp_path / "fleet.env"
+    env.write_text("RUNNING_IMAGE_DIGEST=sha256:old\nRUNNING_IMAGE_DIGEST_UI=sha256:oldui\nOTHER=keep\n")
+    monkeypatch.setattr(main, "_FLEET_ENV_PATH", str(env))
+    monkeypatch.setattr(main, "_UPDATE_SENTINEL_PATH", str(tmp_path / "s.json"))
+
+    main._write_fleet_digests("sha256:new", "sha256:newui")
+    assert "sha256:new" in env.read_text()
+
+    main._fail_update("pull failed", ("sha256:old", "sha256:oldui"))
+    text = env.read_text()
+    assert "RUNNING_IMAGE_DIGEST=sha256:old" in text
+    assert "RUNNING_IMAGE_DIGEST_UI=sha256:oldui" in text
+    assert "OTHER=keep" in text, "unrelated lines must survive"


### PR DESCRIPTION
Implements #352 (P2). **Stacked on #365 (#351) and merges #364 (#350)** — see Dependencies below.

## What it does

Two checks, both on git SHAs, **never on build timestamps**:

**A — do the API and UI images come from the same build?**
Each reports its own baked SHA (#351), so this needs no network.

**B — is the running build the one the fleet config claims?**
The baked SHA is what is *running*. `RUNNING_IMAGE_DIGEST` is what `/opt/fleet/.env` *claims*. They are different types — a git commit hash vs an OCI content digest — so they cannot be compared directly. The bridge is the `org.opencontainers.image.revision` label from #351, read out of the image's config blob in the registry **without pulling it**.

## `identity_ok` is three-valued, and that is load-bearing

**false beats null beats true.** A check that could not run reports `null`, **never** `true`.

Reference implementations of this pattern commonly do:

```js
} catch (err) {
  // Silently swallow network errors to prevent false alarms
}
```

That is precisely the "verified the wrong thing, concluded success" failure #350 documents. There is a parametrised test asserting the whole resolution table so it cannot be quietly simplified back later.

## Timestamps are never compared

Posit found timestamp-based version tracking unreliable because build nodes disagreed on the clock. These Pis have no RTC and can boot badly wrong (#353). `build_time` is for humans reading a screen — a test asserts it does not appear in the comparison at all.

## Reporting

| | |
|---|---|
| `GET /identity` | full state |
| `POST /identity/check` | re-run now — for post-deploy verification and "Try again" |
| **websocket** | `identity_ok` rides the payload the UI already receives |
| **outbox** | `identity_mismatch` Event, deduped, emitted only on transition |

**Push, not poll.** `script.js:779` already holds a socket open and `main.py` already has `state_change_event`. A mismatch reaches the screen immediately, with no extra requests and no new infrastructure — better than either option the published guidance recommends.

**Fleet visibility.** An on-screen warning only helps someone standing at the device. Without the outbox Event, a mismatch on an unattended Sentri stays invisible — the original problem simply relocated. Follows the ADR-021 telemetry pattern.

## A startup race worth knowing about

The poller retries at **5s, 15s, 30s** before settling onto the update-check cadence.

All four containers start together on a device, so the UI is frequently not yet serving when the first check runs. Without the fast retries the result stayed `null` for five minutes after every boot. Found by running it in real containers, not by reading the code.

## Post-deploy verification

`deployment2_verify.sh` gains three checks: the backend reports a real SHA (not `"unknown"`), nginx serves the UI's **own** identity rather than proxying it, and there is no confirmed mismatch.

The last one treats **only `false`** as a failure — `null` means could-not-verify, which is not the same thing and must not fail a deploy.

## Verification

**22 tests** — the full three-valued resolution table, each check failing independently, degradation for images built before #351, dedup and transition-only emission, and that `build_time` is not a comparison key.

**Real containers**, built with deliberately different SHAs:

```json
{ "api_git_sha": "AAAAAAA",
  "ui_git_sha":  "BBBBBBB",
  "images_match": false,
  "expected_git_sha": null,
  "identity_ok": false }
```

Check A confirms the mismatch; check B correctly reports `null` with no registry credentials present — and `false` still wins, as designed.

**Full suite:** 37 failed / 893 passed / 237 skipped — the 37 match clean `main`.

## Dependencies

This branch **merges `fix/ota-status-reliability` (#364)**. The registry helpers here depend on that branch's error taxonomy (`_ERR_NETWORK` / `_ERR_AUTH` / `_ERR_REGISTRY`) and on its tuple-returning `_ghcr_bearer_token`. I found this the honest way — by writing code that referenced them and watching the test fail.

Merge order into the epic: **#365 (#351) → #364 (#350) → this**.

Part of #352.
