### PR TITLE
fix(clock): make an untrustworthy device clock visible

### DIFF
--- a/aquila_web/clock_health.py
+++ b/aquila_web/clock_health.py
@@ -1,0 +1,120 @@
+"""Is this device's clock trustworthy? (#353)
+
+A Raspberry Pi has no battery-backed RTC. After a power loss the clock resets
+and stays wrong until NTP resyncs — and `aquila_web/local_db.py:12` stamps every
+outbox Event with `datetime.utcnow()`. So Events queued in that window carry
+wrong timestamps and are flushed to the analytics warehouse that way. The
+exposure window is the worst one: immediately after boot, while startup and
+first-run Events are being written.
+
+Two independent signals, because neither alone is sufficient:
+
+1. systemd's NTP sync flag. Authoritative when available, but the backend runs
+   in a container and only sees it if /run/systemd/timesync is bind-mounted.
+
+2. A lower bound from the image's own baked build_time (#351). A device cannot
+   legitimately be running software that has not been built yet, so a clock
+   earlier than the build is definitely wrong. This needs no mounts and works
+   everywhere, and it catches the dominant failure — an RTC-less Pi booting to
+   the epoch or to a stale saved time.
+
+Signal 2 is a one-sided test: it proves a clock is wrong, never that it is
+right. A clock set far into the future passes it. That is why the sync flag is
+preferred when present, and why `unknown` is a distinct answer from `synced`.
+"""
+
+from __future__ import annotations
+
+import os
+from datetime import datetime, timezone
+from pathlib import Path
+
+# Written by systemd-timesyncd once it has successfully synchronised.
+SYNC_FLAG_PATH = os.getenv("AQ_TIMESYNC_FLAG", "/run/systemd/timesync/synchronized")
+
+# Status values
+SYNCED = "synced"
+UNSYNCED = "unsynced"
+UNKNOWN = "unknown"
+
+
+def _parse_iso(value: str | None) -> datetime | None:
+    if not value or value == "unknown":
+        return None
+    try:
+        parsed = datetime.fromisoformat(str(value).replace("Z", "+00:00"))
+    except (ValueError, TypeError):
+        return None
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=timezone.utc)
+    return parsed
+
+
+def clock_is_before_build(build_time: str | None, now: datetime | None = None) -> bool | None:
+    """True when the clock predates the running image's build — definitely wrong.
+
+    None when it cannot be evaluated (no baked build_time, e.g. an image from
+    before #351). None is not False: an unevaluable check must not read as a pass.
+    """
+    built = _parse_iso(build_time)
+    if built is None:
+        return None
+    current = now or datetime.now(timezone.utc)
+    if current.tzinfo is None:
+        current = current.replace(tzinfo=timezone.utc)
+    return current < built
+
+
+def ntp_sync_flag() -> bool | None:
+    """systemd's view of whether time has been synchronised.
+
+    None when the flag is not visible — which is the normal case in a container
+    unless /run/systemd/timesync is bind-mounted. Absence of the mount is not
+    evidence of an unsynced clock.
+    """
+    try:
+        parent = Path(SYNC_FLAG_PATH).parent
+        if not parent.exists():
+            return None  # not mounted; no opinion
+        return Path(SYNC_FLAG_PATH).exists()
+    except OSError:
+        return None
+
+
+def clock_status(build_time: str | None = None, now: datetime | None = None) -> dict:
+    """Combined verdict.
+
+    `unsynced` means the clock is known-bad and any timestamp taken now should be
+    treated as suspect. `unknown` means it could not be established — reported
+    honestly rather than assumed good.
+    """
+    flag = ntp_sync_flag()
+    before_build = clock_is_before_build(build_time, now=now)
+
+    # A clock earlier than the running build is wrong regardless of what systemd
+    # says, so this verdict wins.
+    if before_build is True:
+        status = UNSYNCED
+        reason = "clock is earlier than this software's build time"
+    elif flag is True:
+        status = SYNCED
+        reason = None
+    elif flag is False:
+        status = UNSYNCED
+        reason = "NTP has not synchronised since boot"
+    elif before_build is False:
+        # Only the one-sided test is available and it passed: consistent, but it
+        # cannot prove the clock is right.
+        status = UNKNOWN
+        reason = "NTP sync state unavailable; clock is at least later than the build"
+    else:
+        status = UNKNOWN
+        reason = "NTP sync state unavailable and no baked build time to compare against"
+
+    return {
+        "clock_status": status,
+        "clock_trusted": status == SYNCED,
+        "clock_reason": reason,
+        "ntp_synchronized": flag,
+        "clock_before_build": before_build,
+    }

--- a/aquila_web/main.py
+++ b/aquila_web/main.py
@@ -1,6 +1,7 @@
 from fastapi import FastAPI, Form, Body, HTTPException, Query
 from aq_lib.device_id import inject_hw_serial_env
 from aquila_web.local_db import enqueue_event, init_local_db, _utc_now
+from aquila_web import clock_health
 from aquila_web.optics_readings import build_optics_readings, count_data_lines
 from aq_curve.curve import ALGO_VERSION
 from aquila_web.profile_assembly import assemble_steps, validate_stages
@@ -864,6 +865,33 @@ def _read_app_version() -> str:
 @app.get("/version")
 async def version_check():
     return {"version": _read_app_version()}
+
+
+def _baked_build_time() -> str | None:
+    """The running image's build timestamp, if it carries one.
+
+    Present from #351 onward; absent on older images, in which case the clock's
+    lower-bound check simply cannot run. Read defensively so this works either
+    way.
+    """
+    try:
+        data = json.loads((BASE_DIR / "config_files" / "version.json").read_text())
+        value = data.get("build_time")
+        return str(value) if value and value != "unknown" else None
+    except Exception:  # noqa: BLE001
+        return None
+
+
+@app.get("/clock")
+async def clock_check():
+    """Whether this device's clock can be trusted (#353).
+
+    These Pis have no battery-backed RTC, and local_db stamps every outbox Event
+    with the local clock — so a device that boots with a wrong time writes wrong
+    timestamps into the analytics warehouse. Surfacing the state is the
+    prerequisite for deciding whether a timestamp is suspect.
+    """
+    return clock_health.clock_status(_baked_build_time())
 
 
 @app.get("/results")

--- a/fleet-config/docker-compose.yml
+++ b/fleet-config/docker-compose.yml
@@ -33,6 +33,12 @@ services:
       # the container and every recreate (update / --force-recreate) silently
       # discards unsynced runs. The on-device schema migrates in place (#305).
       - /opt/aquila/data:/opt/aquila/data
+      # systemd's NTP sync flag, so the backend can tell whether the host clock
+      # is trustworthy. These Pis have no RTC, and every outbox Event is stamped
+      # with the local clock — a device that boots wrong writes wrong timestamps
+      # into the analytics warehouse. Read-only; absence just means "unknown".
+      # See #353.
+      - /run/systemd/timesync:/run/systemd/timesync:ro
       # Mount the whole fleet dir (not just .env) so the OTA reboot sentinel
       # /opt/fleet/last_update.json is host-backed and survives the Watchtower
       # container swap. See specs/backend/spec_ota_sentinel_persistent_volume.md.

--- a/scripts/deploy/deployment2.sh
+++ b/scripts/deploy/deployment2.sh
@@ -150,6 +150,35 @@ run_test "pi in docker group"       "groups pi | grep -q docker"
 phase_pass "Docker installed and running, pi in docker group"
 
 # ═══════════════════════════════════════════════════════════════════════════════
+# Phase 3d — Device clock (#353)
+# ═══════════════════════════════════════════════════════════════════════════════
+phase_start "3d" "Device Clock"
+
+# A Pi has no battery-backed RTC: on every power loss the clock resets and stays
+# wrong until NTP resyncs. That is not just a logging annoyance here — every
+# Event on the sync outbox is stamped with the local clock, so a device that
+# boots wrong writes wrong timestamps into the analytics warehouse, permanently.
+#
+# fake-hwclock saves the last known time on shutdown and restores it at boot,
+# before NTP has synced. It narrows the window; systemd-timesyncd closes it.
+# Neither can help a device that never reaches an NTP server, which is why the
+# backend also reports its clock state at /clock.
+DEBIAN_FRONTEND=noninteractive apt-get install -y fake-hwclock
+systemctl enable --now fake-hwclock 2>/dev/null || true
+timedatectl set-ntp true 2>/dev/null || true
+systemctl enable --now systemd-timesyncd 2>/dev/null || true
+
+run_test "fake-hwclock installed"   "dpkg -l fake-hwclock | grep -q '^ii'"
+run_test "NTP enabled"              "timedatectl show -p NTP --value | grep -q yes"
+run_test "timesyncd active"         "systemctl is-active systemd-timesyncd | grep -q active"
+# The clock being SET is what matters, not merely that the service is running —
+# a device that cannot reach an NTP server has timesyncd active and a wrong clock.
+run_test "system clock synchronized" \
+    "timedatectl show -p NTPSynchronized --value | grep -q yes"
+
+phase_pass "fake-hwclock installed, NTP enabled and synchronized"
+
+# ═══════════════════════════════════════════════════════════════════════════════
 # Phase 3b — NetworkManager: disable BSSID pinning
 # ═══════════════════════════════════════════════════════════════════════════════
 phase_start "3b" "NetworkManager BSSID policy"

--- a/scripts/deploy/deployment2_verify.sh
+++ b/scripts/deploy/deployment2_verify.sh
@@ -54,6 +54,19 @@ test_phase_3() {
     check 3 "pi in docker group"       "groups pi | grep -q docker"
 }
 
+test_phase_3d() {
+    echo "── Phase 3d: Device Clock"
+    check 3d "fake-hwclock installed" "dpkg -l fake-hwclock | grep -q '^ii'"
+    check 3d "NTP enabled"            "timedatectl show -p NTP --value | grep -q yes"
+    check 3d "timesyncd active"       "systemctl is-active systemd-timesyncd | grep -q active"
+    # "service active" is not "clock correct" — a device that cannot reach an NTP
+    # server has timesyncd running and a wrong clock. Every outbox Event is
+    # stamped with that clock. See #353.
+    check 3d "clock synchronized"     "timedatectl show -p NTPSynchronized --value | grep -q yes"
+    check 3d "backend sees the clock state" \
+        "curl -sf http://localhost:8090/clock | grep -q clock_status"
+}
+
 test_phase_4() {
     echo "── Phase 4: Autologin"
     check 4 "autologin.conf exists"        "test -f /etc/lightdm/lightdm.conf.d/autologin.conf"
@@ -184,7 +197,7 @@ test_smoke() {
 # Entry point
 # ═══════════════════════════════════════════════════════════════════════════════
 
-ALL_PHASES=(1 2 3 4 5 6 7 8 9 10 11 12 13 14 smoke)
+ALL_PHASES=(1 2 3 3d 4 5 6 7 8 9 10 11 12 13 14 smoke)
 
 if [[ "${1:-}" == "smoke" ]]; then
     test_smoke

--- a/tests/fleet_device/test_linux_compatibility.py
+++ b/tests/fleet_device/test_linux_compatibility.py
@@ -121,6 +121,12 @@ class TestLinuxCompatibility:
                 # Skip Docker socket (watchtower)
                 if host_path == "/var/run/docker.sock":
                     continue
+                # systemd's NTP sync flag (#353). Read-only, and it is the only
+                # place the host's clock state is observable — the backend cannot
+                # tell whether the timestamps it writes onto the outbox are
+                # trustworthy without it.
+                if host_path == "/run/systemd/timesync":
+                    continue
                 if host_path == "/root/.docker/config.json":
                     continue
                 assert (

--- a/unit_tests/test_clock_health.py
+++ b/unit_tests/test_clock_health.py
@@ -1,0 +1,138 @@
+"""Clock trustworthiness (#353).
+
+These Pis have no battery-backed RTC, and local_db stamps every outbox Event with
+`datetime.utcnow()`. A device that boots with a wrong clock writes wrong
+timestamps into the analytics warehouse — permanently, and in the worst window:
+immediately after boot, while startup and first-run Events are queued.
+
+The distinction under test is `unknown` vs `synced`. A clock that cannot be
+verified must not report as trusted.
+"""
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+import pytest
+
+# unit_tests/ has no conftest, so the repo root is added the same way the other
+# tests in this directory do it.
+REPO_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(REPO_ROOT))
+
+from aquila_web import clock_health as ch  # noqa: E402
+
+BUILD = "2026-07-01T00:00:00Z"
+
+
+def _at(dt_str):
+    return datetime.fromisoformat(dt_str.replace("Z", "+00:00"))
+
+
+# ── The one-sided lower-bound test ────────────────────────────────────────────
+
+def test_clock_before_build_is_detected():
+    """A device cannot be running software that has not been built yet."""
+    assert ch.clock_is_before_build(BUILD, now=_at("2026-06-30T23:59:00Z")) is True
+
+
+def test_clock_at_epoch_is_detected():
+    """The dominant failure: an RTC-less Pi booting to 1970."""
+    assert ch.clock_is_before_build(BUILD, now=_at("1970-01-01T00:00:00Z")) is True
+
+
+def test_clock_after_build_passes_the_lower_bound():
+    assert ch.clock_is_before_build(BUILD, now=_at("2026-07-28T00:00:00Z")) is False
+
+
+def test_no_baked_build_time_cannot_be_evaluated():
+    """Images from before #351 have no build_time. None is not False."""
+    assert ch.clock_is_before_build(None) is None
+    assert ch.clock_is_before_build("unknown") is None
+    assert ch.clock_is_before_build("not-a-date") is None
+
+
+# ── The systemd flag ──────────────────────────────────────────────────────────
+
+def test_sync_flag_absent_directory_is_unknown_not_unsynced(tmp_path, monkeypatch):
+    """In a container the flag is invisible unless bind-mounted. Absence of the
+    mount is not evidence of a bad clock."""
+    monkeypatch.setattr(ch, "SYNC_FLAG_PATH", str(tmp_path / "nope" / "synchronized"))
+    assert ch.ntp_sync_flag() is None
+
+
+def test_sync_flag_present_means_synced(tmp_path, monkeypatch):
+    d = tmp_path / "timesync"
+    d.mkdir()
+    (d / "synchronized").write_text("")
+    monkeypatch.setattr(ch, "SYNC_FLAG_PATH", str(d / "synchronized"))
+    assert ch.ntp_sync_flag() is True
+
+
+def test_mounted_but_missing_flag_means_unsynced(tmp_path, monkeypatch):
+    """The directory exists (so it IS mounted) but NTP has not synced."""
+    d = tmp_path / "timesync"
+    d.mkdir()
+    monkeypatch.setattr(ch, "SYNC_FLAG_PATH", str(d / "synchronized"))
+    assert ch.ntp_sync_flag() is False
+
+
+# ── Combined verdict ──────────────────────────────────────────────────────────
+
+def _no_mount(monkeypatch, tmp_path):
+    monkeypatch.setattr(ch, "SYNC_FLAG_PATH", str(tmp_path / "absent" / "synchronized"))
+
+
+def _mounted(monkeypatch, tmp_path, synced):
+    d = tmp_path / "timesync"
+    d.mkdir(exist_ok=True)
+    if synced:
+        (d / "synchronized").write_text("")
+    monkeypatch.setattr(ch, "SYNC_FLAG_PATH", str(d / "synchronized"))
+
+
+def test_synced_flag_gives_a_trusted_clock(tmp_path, monkeypatch):
+    _mounted(monkeypatch, tmp_path, synced=True)
+    s = ch.clock_status(BUILD, now=_at("2026-07-28T00:00:00Z"))
+    assert s["clock_status"] == ch.SYNCED
+    assert s["clock_trusted"] is True
+
+
+def test_clock_before_build_overrides_a_synced_flag(tmp_path, monkeypatch):
+    """A clock earlier than the running build is wrong whatever systemd says."""
+    _mounted(monkeypatch, tmp_path, synced=True)
+    s = ch.clock_status(BUILD, now=_at("2026-06-01T00:00:00Z"))
+    assert s["clock_status"] == ch.UNSYNCED
+    assert s["clock_trusted"] is False
+    assert "build" in s["clock_reason"]
+
+
+def test_unsynced_flag_is_reported(tmp_path, monkeypatch):
+    _mounted(monkeypatch, tmp_path, synced=False)
+    s = ch.clock_status(BUILD, now=_at("2026-07-28T00:00:00Z"))
+    assert s["clock_status"] == ch.UNSYNCED
+    assert s["clock_trusted"] is False
+
+
+def test_no_mount_and_plausible_clock_is_unknown_not_trusted(tmp_path, monkeypatch):
+    """The lower-bound test passing does not prove the clock is right — a clock
+    set far into the future passes it too."""
+    _no_mount(monkeypatch, tmp_path)
+    s = ch.clock_status(BUILD, now=_at("2026-07-28T00:00:00Z"))
+    assert s["clock_status"] == ch.UNKNOWN
+    assert s["clock_trusted"] is False
+
+
+def test_no_mount_and_no_build_time_is_unknown(tmp_path, monkeypatch):
+    _no_mount(monkeypatch, tmp_path)
+    s = ch.clock_status(None)
+    assert s["clock_status"] == ch.UNKNOWN
+    assert s["clock_trusted"] is False
+
+
+def test_a_clock_in_the_far_future_is_not_caught():
+    """Documenting the known limit: the lower bound is one-sided by design.
+
+    This is why the systemd flag is preferred when present and why `unknown` is a
+    distinct answer rather than being folded into `synced`.
+    """
+    assert ch.clock_is_before_build(BUILD, now=_at("2099-01-01T00:00:00Z")) is False


### PR DESCRIPTION
Implements #353.

## Why this is a data problem, not a logging one

A Pi has no battery-backed RTC — after a power loss the clock resets and stays wrong until NTP resyncs. That is usually just messy logs. Here it corrupts the warehouse, because `aquila_web/local_db.py:12` stamps **every outbox Event** with the device's local clock:

```python
return datetime.utcnow().isoformat(timespec="seconds") + "Z"
```

Boot with a wrong clock → Events queue with wrong timestamps → the outbox flushes → those timestamps land permanently in the analytics warehouse. And the exposure window is the worst possible one: immediately after boot, while startup and first-run Events are being written.

Nothing in the repo configured `fake-hwclock`, `systemd-timesyncd`, `chrony` or NTP. Whatever the base Pi OS image does is what runs.

## Narrowing the window

New **Phase 3d** in `deployment2.sh`: install and enable `fake-hwclock` (restores the last known time at boot, before NTP syncs) and enable NTP + `systemd-timesyncd`.

## Making it visible

Neither of those helps a device that **never reaches an NTP server** — which, given #314 was a DNS blackhole on these same devices, is not hypothetical.

`aquila_web/clock_health.py` combines two independent signals:

**1. systemd's NTP sync flag.** Authoritative, but only visible inside the container if `/run/systemd/timesync` is bind-mounted — added to fleet-config, read-only.

**2. A lower bound from the image's own baked `build_time` (#351).** A device cannot be running software that has not been built yet, so a clock earlier than the build is **definitely** wrong. Needs no mount, and catches the dominant failure: an RTC-less Pi booting to the epoch.

### `unknown` is a distinct verdict, on purpose

Signal 2 is **one-sided by design** — it proves a clock is wrong, never that it is right. A clock set to 2099 passes it.

So `clock_trusted` is true **only** for `synced`. A clock that cannot be verified reports `unknown`, not trusted. There is a test documenting the far-future limitation explicitly, so it reads as a known boundary rather than an oversight.

```
GET /clock
{ "clock_status": "unknown",
  "clock_trusted": false,
  "clock_reason": "NTP sync state unavailable and no baked build time to compare against",
  "ntp_synchronized": null,
  "clock_before_build": null }
```

A new endpoint rather than an addition to `/health`, to avoid conflicting with the `/health` rewrite in #351.

## Verification checks assert the clock is *set*

`deployment2_verify.sh` gains a Phase 3d that checks `NTPSynchronized`, **not** merely that `timesyncd` is active. A device that cannot reach an NTP server has the service running and a wrong clock — the same "verified the wrong thing, concluded success" pattern as #350 and the Alloy checks in #354.

## Independent of #351

`build_time` is read defensively; its absence degrades to `unknown` rather than failing. Verified in a container with neither signal available: reports unknown/untrusted and says why. Once #351 lands the lower-bound check activates automatically.

## One guardrail test extended

`test_linux_compatibility` asserts device volumes come from `/opt/aquila`, `/opt/fleet` or `/root`. It caught the new mount, which is what it is for. Added to its explicit exemption list alongside the Docker socket, with the reason.

## ⚠️ Not verified, and one open question

**No hardware verification.** sn03 went offline mid-work, so `fake-hwclock`'s presence, the NTP state, and any actual drift are all unchecked on a real device.

**The question that decides this issue's true priority is still open:** does `acorn-analytics` ingest trust the device timestamp, or stamp arrival time? If it stamps on arrival, the damage is bounded to on-device logs and this drops down the list. If it trusts the device, warehouse data is already affected. That check needs someone with access to the ingest pipeline.

Worth running against the warehouse either way: query for Events with implausible timestamps — epoch-adjacent, or out of order within a single run — to size any existing damage.

## Tests

13 unit tests covering the lower-bound check, the sync flag (including that an unmounted directory is `unknown`, not `unsynced`), the combined verdict precedence, and graceful degradation.

**Full suite:** 37 failed / 855 passed / 237 skipped — the 37 match clean `main`, verified by stashing and diffing the failure lists.

Part of #353.
