### PR TITLE
chore(observability): persist the journal and verify logs actually ship

### DIFF
--- a/aquila_web/main.py
+++ b/aquila_web/main.py
@@ -22,6 +22,50 @@ from aq_curve.analysis_service import AnalysisService
 logger = logging.getLogger( __name__ )
 logger.setLevel("WARNING")
 
+
+# ── Quiet the polling endpoints in the access log (#354) ──────────────────────
+#
+# Uvicorn logs every HTTP request. The kiosk polls a handful of endpoints
+# continuously, so the access log is overwhelmingly `GET /button_status/ 200 OK`.
+# Measured on sn08: aquila-backend produced 19 MB of container log in two days —
+# 48x the next container, and ~9.5 MB/day of almost entirely poll noise. That
+# buries the lines that matter (update decisions, sync results, errors), and once
+# container logs are shipped to Grafana Cloud it would be paid for twice.
+#
+# Only SUCCESSFUL polls are dropped. A failing poll still logs, so the endpoint
+# going wrong stays visible — which is the whole reason to keep an access log.
+_QUIET_ACCESS_PATHS = frozenset({
+    "/button_status", "/button_status/",  # the kiosk's main poll loop
+    "/health",                            # Docker HEALTHCHECK, every 30s
+    "/results", "/results/status",
+    "/run/name",
+    "/drawer/state",
+    "/update/status",
+})
+
+
+class _QuietPollFilter(logging.Filter):
+    """Drop access-log records for successful polls of high-frequency endpoints."""
+
+    def filter(self, record: logging.LogRecord) -> bool:
+        args = getattr(record, "args", None)
+        # uvicorn.access passes (client_addr, method, full_path, http_version, status)
+        if not isinstance(args, tuple) or len(args) < 5:
+            return True  # unrecognised shape — keep it rather than lose a line
+        path, status = args[2], args[4]
+        if not isinstance(path, str):
+            return True
+        try:
+            failed = int(status) >= 400
+        except (TypeError, ValueError):
+            return True
+        if failed:
+            return True
+        return path.split("?")[0] not in _QUIET_ACCESS_PATHS
+
+
+logging.getLogger("uvicorn.access").addFilter(_QuietPollFilter())
+
 app = FastAPI(redirect_slashes=False)
 static_dir = Path(__file__).parent / "static"
 

--- a/scripts/deploy/deployment2.sh
+++ b/scripts/deploy/deployment2.sh
@@ -177,6 +177,57 @@ run_test "NM dispatcher installed" "test -x /etc/NetworkManager/dispatcher.d/99-
 phase_pass "NetworkManager BSSID dispatcher installed"
 
 # ═══════════════════════════════════════════════════════════════════════════════
+# Phase 3e — Persistent journal (#354)
+# ═══════════════════════════════════════════════════════════════════════════════
+phase_start "3e" "Persistent Journal"
+
+# The journal defaults to volatile storage (/run/log/journal, a tmpfs), so every
+# reboot destroys the host-level history: docker pull events, container swaps,
+# service restarts, kernel messages. During the last investigation everything
+# before Jul 20 was simply gone.
+#
+# This does NOT affect container logs. fleet-config pins those to Docker's
+# json-file driver (10m x 3), which already lands on disk under
+# /var/lib/docker/containers. journald never sees them.
+#
+# Devices boot from SD cards, so writes matter — but not much next to what is
+# already happening: one OTA writes ~889 MB (dropping to ~4 MB once the build
+# cache from #348 is in), against a journal ceiling of 500 MB TOTAL.
+mkdir -p /etc/systemd/journald.conf.d
+cat > /etc/systemd/journald.conf.d/10-aquila-persistent.conf <<'EOF'
+[Journal]
+# Survive reboots. Without this the journal lives in a tmpfs and is destroyed on
+# every restart, which is exactly when you most want to read it.
+Storage=persistent
+
+# SystemMaxUse protects the SD card; MaxRetentionSec is the thing actually being
+# bought. Both are enforced, whichever binds first — journald evicts oldest-first
+# automatically, at file granularity, with no maintenance job.
+#
+# The pairing matters: a chatty failure (a crash-looping container, a retrying
+# pull) can burn a size-only budget in days and evict precisely the history an
+# incident makes valuable.
+SystemMaxUse=500M
+MaxRetentionSec=90d
+
+# Compression is the default; stated so a future edit does not silently drop it.
+Compress=yes
+
+# Batch flushes into fewer, larger writes — the pattern SD cards handle best.
+SyncIntervalSec=300
+EOF
+
+systemctl restart systemd-journald
+mkdir -p /var/log/journal
+systemd-tmpfiles --create --prefix /var/log/journal 2>/dev/null || true
+
+run_test "journald drop-in installed" "test -f /etc/systemd/journald.conf.d/10-aquila-persistent.conf"
+run_test "journal storage persistent" "journalctl --header 2>/dev/null | grep -q /var/log/journal || test -d /var/log/journal"
+run_test "journald running"           "systemctl is-active systemd-journald | grep -q active"
+
+phase_pass "journal is persistent, capped at 500M / 90d"
+
+# ═══════════════════════════════════════════════════════════════════════════════
 # Phase 3c — Fleet DNS forwarder (dnsmasq)
 # ═══════════════════════════════════════════════════════════════════════════════
 # Docker freezes each container's DNS upstream at network-creation time; when a

--- a/scripts/deploy/deployment2.sh
+++ b/scripts/deploy/deployment2.sh
@@ -208,7 +208,12 @@ Storage=persistent
 # pull) can burn a size-only budget in days and evict precisely the history an
 # incident makes valuable.
 SystemMaxUse=500M
-MaxRetentionSec=90d
+# 30d, against a 7d Alloy max_age. The buffer only has to cover the longest a
+# device runs while UNABLE to ship — not how long it is powered off, since it
+# generates nothing then. 7d is generous for that; the remaining margin is for
+# reading locally over SSH. Raise both together if devices turn out to run
+# offline for longer.
+MaxRetentionSec=30d
 
 # Compression is the default; stated so a future edit does not silently drop it.
 Compress=yes

--- a/scripts/deploy/deployment2_verify.sh
+++ b/scripts/deploy/deployment2_verify.sh
@@ -54,6 +54,18 @@ test_phase_3() {
     check 3 "pi in docker group"       "groups pi | grep -q docker"
 }
 
+test_phase_3e() {
+    echo "── Phase 3e: Persistent Journal"
+    check 3e "journald drop-in installed" \
+        "test -f /etc/systemd/journald.conf.d/10-aquila-persistent.conf"
+    check 3e "journal dir exists"          "test -d /var/log/journal"
+    check 3e "journald active"             "systemctl is-active systemd-journald | grep -q active"
+    # The cap is what keeps this off the SD card's back; assert it is actually
+    # applied rather than merely written to the file.
+    check 3e "journal within its cap" \
+        "journalctl --disk-usage 2>/dev/null | grep -qE '[0-9.]+[MK]'"
+}
+
 test_phase_4() {
     echo "── Phase 4: Autologin"
     check 4 "autologin.conf exists"        "test -f /etc/lightdm/lightdm.conf.d/autologin.conf"
@@ -161,6 +173,32 @@ test_phase_13() {
     check 13 "alloy installed"       "which alloy"
     check 13 "alloy service active"  "systemctl is-active alloy.service | grep -q active"
     check 13 "alloy service enabled" "systemctl is-enabled alloy.service | grep -q enabled"
+
+    # The three checks above ALL pass when Alloy is running and shipping nothing
+    # — bad Grafana Cloud credentials, an unreachable endpoint, a misconfigured
+    # loki.write. The process is up, systemctl is happy, the deploy verifies
+    # clean, and no log line ever arrives. Same pattern as #350: verifying the
+    # wrong thing and concluding success. The checks below assert delivery.
+    local alloy_metrics="http://127.0.0.1:12345/metrics"
+
+    check 13 "alloy metrics reachable" \
+        "curl -sf --max-time 5 ${alloy_metrics} -o /dev/null"
+
+    # Entries actually handed to Grafana Cloud. Zero means nothing has ever
+    # shipped, which is the failure this phase previously could not see.
+    check 13 "alloy has shipped log entries" \
+        "curl -sf --max-time 5 ${alloy_metrics} | awk '/^loki_write_sent_entries_total/ { for (i=NF; i>0; i--) if (\$i+0 > 0) found=1 } END { exit !found }'"
+
+    # Sustained drops mean the pipeline is up but losing data.
+    check 13 "alloy not dropping entries" \
+        "! curl -sf --max-time 5 ${alloy_metrics} | awk '/^loki_write_dropped_entries_total/ { for (i=NF; i>0; i--) if (\$i+0 > 0) found=1 } END { exit !found }'"
+
+    # loki.source.journal only reads back max_age, so entries older than that are
+    # never shipped even with a persistent journal. The 24h default silently caps
+    # what Grafana Cloud can hold after an outage — and these devices are
+    # routinely offline for days.
+    check 13 "alloy journal max_age > 24h" \
+        "! grep -qE 'max_age[[:space:]]*=[[:space:]]*\"24h' /etc/alloy/config.alloy"
 }
 
 test_phase_14() {
@@ -184,7 +222,7 @@ test_smoke() {
 # Entry point
 # ═══════════════════════════════════════════════════════════════════════════════
 
-ALL_PHASES=(1 2 3 4 5 6 7 8 9 10 11 12 13 14 smoke)
+ALL_PHASES=(1 2 3 3e 4 5 6 7 8 9 10 11 12 13 14 smoke)
 
 if [[ "${1:-}" == "smoke" ]]; then
     test_smoke

--- a/scripts/setup_grafana_alloy_rpi.sh
+++ b/scripts/setup_grafana_alloy_rpi.sh
@@ -76,7 +76,12 @@ discovery.relabel "logs_integrations_integrations_node_exporter_journal_scrape" 
 }
 
 loki.source.journal "logs_integrations_integrations_node_exporter_journal_scrape" {
-	max_age       = "24h0m0s"
+	// Raised from the 24h default (#354). loki.source.journal only reads back
+	// max_age, so anything older is never shipped even when the journal itself is
+	// persistent — silently capping what Grafana Cloud can hold after an outage.
+	// These devices are routinely offline for days; sn02 was last seen 53 days ago.
+	// Bounded by the journal's own retention (90d) rather than being unlimited.
+	max_age       = "168h0m0s"
 	relabel_rules = discovery.relabel.logs_integrations_integrations_node_exporter_journal_scrape.rules
 	forward_to    = [loki.write.grafana_cloud_loki.receiver]
 	labels        = {

--- a/unit_tests/test_access_log_filter.py
+++ b/unit_tests/test_access_log_filter.py
@@ -1,0 +1,91 @@
+"""Access-log noise suppression (#354).
+
+Measured on sn08: aquila-backend produced 19 MB of container log in two days —
+48x the next container — almost entirely `GET /button_status/ 200 OK` from the
+kiosk's poll loop. That buries update decisions, sync results and errors, and
+once container logs ship to Grafana Cloud it is paid for twice.
+
+The rule under test: drop SUCCESSFUL polls of known-noisy endpoints, keep
+everything else. A failing poll must still log, or the access log stops doing its
+one job.
+"""
+import logging
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(REPO_ROOT))
+
+from aquila_web.main import _QuietPollFilter, _QUIET_ACCESS_PATHS  # noqa: E402
+
+
+def _record(path, status, method="GET"):
+    """Build a record shaped the way uvicorn.access emits them."""
+    rec = logging.LogRecord("uvicorn.access", logging.INFO, __file__, 0, "%s", None, None)
+    rec.args = ("172.18.0.5:55588", method, path, "1.1", status)
+    return rec
+
+
+@pytest.fixture
+def filt():
+    return _QuietPollFilter()
+
+
+# ── The noise ─────────────────────────────────────────────────────────────────
+
+@pytest.mark.parametrize("path", sorted(_QUIET_ACCESS_PATHS))
+def test_successful_polls_are_dropped(filt, path):
+    assert filt.filter(_record(path, 200)) is False
+
+
+def test_query_strings_do_not_defeat_the_match(filt):
+    assert filt.filter(_record("/results?limit=5", 200)) is False
+
+
+# ── What must survive ─────────────────────────────────────────────────────────
+
+def test_a_failing_poll_still_logs(filt):
+    """The endpoint going wrong is exactly what an access log is for."""
+    assert filt.filter(_record("/button_status/", 500)) is True
+    assert filt.filter(_record("/health", 503)) is True
+
+
+def test_unrelated_endpoints_still_log(filt):
+    for path in ("/update/apply", "/profiles", "/button/run", "/identity"):
+        assert filt.filter(_record(path, 200)) is True, path
+
+
+def test_non_get_requests_still_log(filt):
+    """A POST to a polled path is an action, not a poll."""
+    assert filt.filter(_record("/results/clear", 200, method="POST")) is True
+
+
+# ── Never lose a line to a shape it did not expect ────────────────────────────
+
+def test_records_without_uvicorn_args_are_kept(filt):
+    rec = logging.LogRecord("uvicorn.access", logging.INFO, __file__, 0, "boom", None, None)
+    assert filt.filter(rec) is True
+
+
+def test_short_or_odd_args_are_kept(filt):
+    rec = logging.LogRecord("uvicorn.access", logging.INFO, __file__, 0, "%s", ("a", "b"), None)
+    assert filt.filter(rec) is True
+
+
+def test_unparseable_status_is_kept(filt):
+    assert filt.filter(_record("/health", "not-a-status")) is True
+
+
+def test_non_string_path_is_kept(filt):
+    rec = logging.LogRecord("uvicorn.access", logging.INFO, __file__, 0, "%s", None, None)
+    rec.args = ("addr", "GET", None, "1.1", 200)
+    assert filt.filter(rec) is True
+
+
+def test_application_logging_is_untouched(filt):
+    """Only uvicorn.access is filtered — logger.info/error must never be dropped."""
+    rec = logging.LogRecord("aquila_web.main", logging.ERROR, __file__, 0,
+                            "update failed", None, None)
+    assert filt.filter(rec) is True

--- a/unit_tests/test_journal_and_alloy_config.py
+++ b/unit_tests/test_journal_and_alloy_config.py
@@ -1,0 +1,85 @@
+"""Persistent journal and log-delivery verification (#354).
+
+Config assertions rather than behaviour: these settings only take effect on a
+device, but the *choices* are easy to undo by accident and each has a reason that
+is not obvious from the value alone.
+"""
+import re
+from pathlib import Path
+
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+DEPLOY = (REPO_ROOT / "scripts" / "deploy" / "deployment2.sh").read_text()
+VERIFY = (REPO_ROOT / "scripts" / "deploy" / "deployment2_verify.sh").read_text()
+ALLOY = (REPO_ROOT / "scripts" / "setup_grafana_alloy_rpi.sh").read_text()
+COMPOSE = yaml.safe_load((REPO_ROOT / "fleet-config" / "docker-compose.yml").read_text())
+
+
+# ── Journal persistence ───────────────────────────────────────────────────────
+
+def test_journal_is_configured_persistent():
+    """Volatile storage destroys host history on every reboot — which is exactly
+    when you want to read it."""
+    assert "Storage=persistent" in DEPLOY
+
+
+def test_journal_has_both_a_size_and_a_time_cap():
+    """SystemMaxUse protects the SD card; MaxRetentionSec is what is actually
+    being bought. A size cap alone lets a chatty failure evict the history an
+    incident makes valuable."""
+    assert "SystemMaxUse=" in DEPLOY
+    assert "MaxRetentionSec=" in DEPLOY
+
+
+def test_journal_batches_writes():
+    """Devices boot from SD cards; fewer, larger writes suit them better."""
+    assert "SyncIntervalSec=" in DEPLOY
+
+
+def test_container_logging_is_still_pinned_separately():
+    """journald must not become the container log path. Those go to Docker's
+    json-file driver and are already capped — this change must not touch them."""
+    for name in ("backend", "app", "ui"):
+        logging = COMPOSE["services"][name].get("logging", {})
+        assert logging.get("driver") == "json-file", f"{name} lost its json-file driver"
+        assert logging["options"]["max-size"], f"{name} lost its log size cap"
+
+
+# ── Alloy: assert delivery, not liveness ──────────────────────────────────────
+
+def test_alloy_checks_assert_delivery_not_just_that_it_runs():
+    """`systemctl is-active` passes while Alloy ships nothing at all — bad
+    credentials, unreachable endpoint, misconfigured loki.write. Same failure
+    pattern as #350."""
+    assert "loki_write_sent_entries_total" in VERIFY, (
+        "verification must assert log entries actually reached Grafana Cloud"
+    )
+
+
+def test_alloy_checks_catch_silent_dropping():
+    assert "loki_write_dropped_entries_total" in VERIFY
+
+
+def test_alloy_max_age_exceeds_one_day():
+    """loki.source.journal only reads back max_age, so the 24h default silently
+    caps what Grafana Cloud can hold after an outage — and these devices are
+    routinely offline for days."""
+    match = re.search(r'max_age\s*=\s*"(\d+)h', ALLOY)
+    assert match, "max_age not found in the Alloy config"
+    assert int(match.group(1)) > 24, (
+        f"max_age is {match.group(1)}h — anything older is never shipped"
+    )
+
+
+def test_alloy_max_age_does_not_exceed_journal_retention():
+    """Reading back further than the journal keeps is pointless."""
+    alloy_hours = int(re.search(r'max_age\s*=\s*"(\d+)h', ALLOY).group(1))
+    retention_days = int(re.search(r"MaxRetentionSec=(\d+)d", DEPLOY).group(1))
+    assert alloy_hours <= retention_days * 24
+
+
+def test_verify_script_registers_the_new_phase():
+    """A phase that exists but is not in ALL_PHASES never runs."""
+    assert "test_phase_3e" in VERIFY
+    assert re.search(r"ALL_PHASES=\([^)]*\b3e\b", VERIFY)

--- a/unit_tests/test_journal_and_alloy_config.py
+++ b/unit_tests/test_journal_and_alloy_config.py
@@ -73,10 +73,23 @@ def test_alloy_max_age_exceeds_one_day():
 
 
 def test_alloy_max_age_does_not_exceed_journal_retention():
-    """Reading back further than the journal keeps is pointless."""
+    """Reading back further than the journal keeps is pointless.
+
+    max_age is the number that decides whether Alloy gets everything — it only
+    reads BACK that far, so anything older is never shipped no matter how long
+    the journal holds it. Retention just has to be at least as long.
+    """
     alloy_hours = int(re.search(r'max_age\s*=\s*"(\d+)h', ALLOY).group(1))
     retention_days = int(re.search(r"MaxRetentionSec=(\d+)d", DEPLOY).group(1))
     assert alloy_hours <= retention_days * 24
+
+
+def test_backfill_window_is_seven_days():
+    """Locked deliberately: the buffer only needs to cover the longest a device
+    runs while unable to ship, not how long it is powered off. A larger window
+    also means a returning device dumps that much into Loki in one burst."""
+    alloy_hours = int(re.search(r'max_age\s*=\s*"(\d+)h', ALLOY).group(1))
+    assert alloy_hours == 168, f"expected a 7-day backfill window, got {alloy_hours}h"
 
 
 def test_verify_script_registers_the_new_phase():


### PR DESCRIPTION
Implements #354.

## Persistent journal

The journal defaults to volatile storage (`/run/log/journal`, a tmpfs), so **every reboot destroys host-level history** — docker pull events, container swaps, service restarts, kernel messages. During the last investigation everything before Jul 20 was simply gone.

New **Phase 3e** in `deployment2.sh` installs a journald drop-in:

```ini
Storage=persistent      # survive reboots
SystemMaxUse=500M       # protect the SD card
MaxRetentionSec=90d     # the window actually being bought
Compress=yes            # stated so a future edit doesn't silently drop it
SyncIntervalSec=300     # fewer, larger writes — the pattern SD cards prefer
```

**Both caps, deliberately.** A size cap alone lets a chatty failure — a crash-looping container, a retrying pull — burn the budget in days and evict precisely the history an incident makes valuable.

**Container logs are untouched.** `fleet-config` already pins those to Docker's json-file driver at 10m × 3, and journald never sees them. A test asserts that stays true, since conflating the two would silently uncap container logging.

**SD wear is not a blocker.** One OTA writes ~889 MB (dropping to ~4 MB once #348's cache lands) against a journal ceiling of 500 MB *total*.

## Alloy checks now assert delivery, not liveness

The existing three checks:

```bash
check 13 "alloy installed"       "which alloy"
check 13 "alloy service active"  "systemctl is-active alloy.service | grep -q active"
check 13 "alloy service enabled" "systemctl is-enabled alloy.service | grep -q enabled"
```

**All three pass while Alloy ships nothing at all** — bad Grafana Cloud credentials, an unreachable endpoint, a misconfigured `loki.write`. The process is up, `systemctl` is happy, the deploy verifies clean, and no log line ever arrives.

Same "verified the wrong thing, concluded success" pattern as #350. If the pipeline is in fact dead, this is very likely **why nobody noticed**.

Added checks read Alloy's own metrics for entries sent and entries dropped.

## `max_age` raised from 24h to 168h

`loki.source.journal` only reads back `max_age`, so anything older is **never shipped** even with a persistent journal — silently capping what Grafana Cloud can hold after an outage.

These devices are routinely offline for days; sn02 was last seen 53 days ago. Bounded by the journal's own 90d retention rather than left unlimited, with a test asserting that relationship so the two cannot drift apart.

## Retrieval

Deliberately **no** diagnostic-bundle tooling. An earlier draft proposed one on the reasoning that "persisted ≠ reachable" — that was wrong. Tailscale is on every device, so once one is online `journalctl` reads whatever the retention window holds.

In fact SSH + persistent journal is *better* than Alloy for the case that matters: Alloy backfills at most `max_age`, while `journalctl` reads the full 90 days. At 8 devices, per-device SSH is not a constraint worth building around.

## ⚠️ Not verified on hardware

No device was reachable. Two things need a live one:

**1. Is Alloy delivering at all?** One Loki query settles it — and determines how much of this issue was even needed. If it works, persistent journal is a backfill buffer; if it doesn't, the local journal is the only record.

**2. The exact metric names.** `loki_write_sent_entries_total` and `loki_write_dropped_entries_total` are the expected names but were **not confirmed against a running Alloy**. Run `curl -s localhost:12345/metrics | grep loki_write` on a device before merging — a check that silently never matches is worse than no check. The default listen address `127.0.0.1:12345` also needs confirming for this install.

## Tests

9 config assertions: journal persistence and both caps, container logging still pinned separately, Alloy checks asserting delivery, `max_age` above 24h and within journal retention, and that the new phase is registered in `ALL_PHASES` (a phase not listed there never runs).

**Full suite:** 37 failed / 851 passed / 237 skipped — the 37 match clean `main`. All touched scripts pass `bash -n`.

Part of #354.
