### PR TITLE
fix(ota): retry the image pull, force IPv6 as a last resort, and publish the host updater

### DIFF
--- a/aquila_web/main.py
+++ b/aquila_web/main.py
@@ -9,10 +9,12 @@ from fastapi.staticfiles import StaticFiles
 from pathlib import Path
 from fastapi import WebSocket
 import asyncio
+import contextlib
 import logging
 from datetime import datetime
 import os
 import sys
+import tempfile
 from pydantic import BaseModel
 from typing import Optional
 import json
@@ -2248,6 +2250,74 @@ async def approve_update_gate():
 
 _PULL_OUTCOME_PATH = os.getenv("AQ_PULL_OUTCOME_PATH", "/opt/fleet/last_pull.json")
 
+# --- keeping the host updater current ---------------------------------------
+# /opt/fleet/update.sh is the host-side updater. Until now it was written exactly once,
+# by deployment2.sh at provisioning, and nothing ever refreshed it -- so every device
+# ran whatever main said on the day it was set up, and a fix to it could only reach the
+# fleet by hand. That is why the un-retried pull (#357) survived so long.
+#
+# The script ships inside this image (Dockerfile.api does `COPY . .`) and /opt/fleet is
+# mounted read-write here, so syncing it on startup puts the updater on the normal ring
+# promotion path: sandbox -> dev -> pilot -> prod, like everything else. Devices that
+# are offline today pick it up whenever they next update.
+_FLEET_UPDATE_SRC = os.getenv(
+    "AQ_FLEET_UPDATE_SRC", "/opt/aquila/scripts/deploy/fleet-update.sh"
+)
+_FLEET_UPDATE_DEST = os.getenv("AQ_FLEET_UPDATE_DEST", "/opt/fleet/update.sh")
+
+
+def sync_fleet_update_script(src: str | None = None, dest: str | None = None) -> str:
+    """Publish this image's fleet-update.sh to the host. Returns what it did.
+
+    Written to a temporary file and moved into place with os.replace, which is atomic
+    on the same filesystem. This matters more than it looks: a half-written update.sh
+    would leave the device unable to update at all, and the only tool that could fix
+    that remotely is the very script being written.
+
+    The image is the source of truth, so a device hand-patched for debugging is
+    restored on the next restart -- deliberate, and the documented rollback already
+    relies on an image update healing such edits.
+
+    Never raises. A read-only mount or a missing source is degraded operation (the
+    device keeps its existing updater), not a reason to fail startup.
+    """
+    src = src or _FLEET_UPDATE_SRC
+    dest = dest or _FLEET_UPDATE_DEST
+
+    try:
+        with open(src, "rb") as f:
+            desired = f.read()
+    except OSError:
+        return "skipped"
+
+    try:
+        with open(dest, "rb") as f:
+            if f.read() == desired:
+                return "unchanged"   # avoid rewriting the file on every boot
+    except OSError:
+        pass   # absent or unreadable -> fall through and write it
+
+    try:
+        directory = os.path.dirname(dest) or "."
+        fd, tmp = tempfile.mkstemp(dir=directory, prefix=".update.sh.")
+        try:
+            with os.fdopen(fd, "wb") as f:
+                f.write(desired)
+                f.flush()
+                os.fsync(f.fileno())
+            os.chmod(tmp, 0o755)
+            os.replace(tmp, dest)
+        except BaseException:
+            with contextlib.suppress(OSError):
+                os.unlink(tmp)
+            raise
+    except OSError as e:
+        logger.warning("could not sync %s to %s: %s", src, dest, e)
+        return "skipped"
+
+    logger.info("synced host updater to %s", dest)
+    return "synced"
+
 
 def _read_last_pull() -> dict | None:
     """Outcome of the last device-side pull, written by scripts/deploy/fleet-update.sh.
@@ -2480,6 +2550,16 @@ async def resolve_update_completion() -> None:
         _resolve_startup_update_state()
     except Exception as e:  # noqa: BLE001 - never block startup on this
         logger.warning("update sentinel resolution failed: %s", e)
+
+
+@app.on_event("startup")
+async def publish_host_updater() -> None:
+    """Keep /opt/fleet/update.sh in step with the image, so fixes to the host updater
+    ride the normal ring promotion instead of needing a hand-push to every device."""
+    try:
+        sync_fleet_update_script()
+    except Exception as e:  # noqa: BLE001 - never block startup on this
+        logger.warning("host updater sync failed: %s", e)
 
 
 @app.on_event("startup")

--- a/aquila_web/main.py
+++ b/aquila_web/main.py
@@ -2246,6 +2246,32 @@ async def approve_update_gate():
     return update_gate.GATE.status()
 
 
+_PULL_OUTCOME_PATH = os.getenv("AQ_PULL_OUTCOME_PATH", "/opt/fleet/last_pull.json")
+
+
+def _read_last_pull() -> dict | None:
+    """Outcome of the last device-side pull, written by scripts/deploy/fleet-update.sh.
+
+    Surfaced so a failed update says which address families were tried — enough to
+    tell "no IPv6 at this site" from "registry unreachable" from "bad token" without
+    SSHing in (#357).
+
+    Scope caveat: the operator's Update button drives Watchtower, which performs its
+    own pull and never runs that script, so this reflects script-driven updates only
+    and is reported under its own key rather than folded into `error`.
+
+    Never raises: a missing file is the normal case on a device that has not run a
+    scripted update, and a truncated one (killed mid-write) must not break the
+    status endpoint the UI polls.
+    """
+    try:
+        with open(_PULL_OUTCOME_PATH) as f:
+            outcome = json.load(f)
+    except (OSError, ValueError):
+        return None
+    return outcome if isinstance(outcome, dict) else None
+
+
 @app.get("/update/status")
 async def get_update_status():
     available = _update_available
@@ -2263,6 +2289,7 @@ async def get_update_status():
         "status": status,
         "error": _update_error,
         "last_checked": _update_last_checked,
+        "last_pull": _read_last_pull(),
     }
 
 

--- a/scripts/deploy/fleet-update.sh
+++ b/scripts/deploy/fleet-update.sh
@@ -1,36 +1,225 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-FLEET_ENV="/opt/fleet/.env"
-DEVICE_ENV="/opt/aquila/config/device.env"
+# Device-side fleet update. Installed standalone as /opt/fleet/update.sh by
+# deployment2.sh (a single curl), so this file must stay self-contained -- it has no
+# sibling libraries to source on a provisioned device.
+#
+# Sourcing this file defines the functions without running the update (see the main
+# guard at the bottom), which is how the tests exercise the retry logic offline.
 
-GHCR_TOKEN=$(grep ^GHCR_TOKEN= "${DEVICE_ENV}" | cut -d= -f2)
-GHCR_TOKEN_2=$(grep ^GHCR_TOKEN_2= "${DEVICE_ENV}" 2>/dev/null | cut -d= -f2 || echo "")
-GHCR_REPO=$(grep ^GHCR_REPO "${FLEET_ENV}" | cut -d= -f2)
-IMAGE_TAG=$(grep ^IMAGE_TAG "${FLEET_ENV}" | cut -d= -f2)
+FLEET_ENV="${FLEET_ENV:-/opt/fleet/.env}"
+DEVICE_ENV="${DEVICE_ENV:-/opt/aquila/config/device.env}"
+COMPOSE_FILE="${COMPOSE_FILE:-/opt/fleet/docker-compose.yml}"
 
-# If a second token is configured, validate the primary and fall back to it.
-# This allows zero-downtime token rotation: add GHCR_TOKEN_2 to device.env,
-# verify it works, then promote it to GHCR_TOKEN and remove GHCR_TOKEN_2.
-if [[ -n "${GHCR_TOKEN_2}" ]]; then
-    if ! curl -fsSL -o /dev/null \
-            -H "Authorization: token ${GHCR_TOKEN}" \
-            "https://api.github.com/repos/${GHCR_REPO}" 2>/dev/null; then
-        GHCR_TOKEN="${GHCR_TOKEN_2}"
+# --- image pull: retry, and fall back to IPv6 when IPv4 can't carry it (#357) -------
+#
+# A pull is two conversations with two different hosts:
+#   auth + manifest -> ghcr.io                              (a few KB, NO AAAA record)
+#   blob / layers   -> pkg-containers.githubusercontent.com (hundreds of MB, HAS AAAA)
+# On a degraded IPv4 path the small manifest fetch still succeeds -- so the device
+# correctly detects an update -- while the bulk blob transfer stalls. Because the blob
+# host is v6-capable, bringing IPv6 up rescues exactly the leg that fails. This was
+# observed in the field: switching a stuck device to IPv6 completed the update.
+#
+# We do NOT force a family per connection (docker exposes no such flag, and pinning CDN
+# addresses into /etc/hosts rots as the CDN rotates). We make IPv6 usable and let
+# glibc's RFC 6724 address selection prefer it for AAAA-bearing hosts. ghcr.io publishes
+# no AAAA, so auth/manifest stay on IPv4 by themselves -- no special-casing needed.
+
+PULL_BLOB_HOST="${PULL_BLOB_HOST:-pkg-containers.githubusercontent.com}"
+
+# An operator is standing at the device. Long enough to ride out a slow link, short
+# enough not to look hung. Total wall clock across every attempt.
+PULL_TOTAL_BUDGET_SECONDS="${PULL_TOTAL_BUDGET_SECONDS:-480}"
+PULL_IPV4_ATTEMPTS="${PULL_IPV4_ATTEMPTS:-3}"
+PULL_IPV6_ATTEMPTS="${PULL_IPV6_ATTEMPTS:-2}"
+PULL_BACKOFF_SECONDS="${PULL_BACKOFF_SECONDS:-5}"
+
+# classify_pull_error <text> -> auth | notfound | transport | unknown
+#
+# Decide whether a failed pull is worth retrying. Auth and missing-tag failures are
+# deterministic: retrying burns the operator's budget to reach the same error, and no
+# change of address family can turn a 401 into a 200. Only transport failures retry.
+#
+# Order matters -- a message can carry both a status code and a transport-ish word
+# ("unexpected status code 401"), so deterministic patterns are matched first.
+classify_pull_error() {
+    local text="$1"
+    local lower
+    lower=$(printf '%s' "${text}" | tr '[:upper:]' '[:lower:]')
+
+    # Status codes are matched with their surrounding words, never bare. Pull errors
+    # quote image digests, and "401"/"403"/"404" all occur inside plain hex -- a bare
+    # *"401"* pattern would read a digest inside a timeout message as an auth failure
+    # and abort a retry that would have succeeded.
+    case "${lower}" in
+        *unauthorized*|*"authentication required"*|*"access denied"*|*denied:*|\
+        *forbidden*|*"invalid username or password"*|\
+        *"status code: 401"*|*"status code: 403"*|*"status 401"*|*"status 403"*)
+            echo "auth"; return 0 ;;
+    esac
+
+    case "${lower}" in
+        *"manifest unknown"*|*"not found"*|*"repository does not exist"*|\
+        *"no such manifest"*|*"reference does not exist"*|\
+        *"status code: 404"*|*"status 404"*)
+            echo "notfound"; return 0 ;;
+    esac
+
+    case "${lower}" in
+        *"i/o timeout"*|*"tls handshake timeout"*|*"unexpected eof"*|*"connection reset"*|\
+        *"connection refused"*|*"context deadline exceeded"*|*"no route to host"*|\
+        *"temporary failure in name resolution"*|*"network is unreachable"*|*"broken pipe"*|\
+        *"timeout awaiting"*|*"failed to copy"*|*"error pulling image configuration"*|\
+        *"read: connection"*|*"unexpected status code 5"*|*"server misbehaving"*|*eof*)
+            echo "transport"; return 0 ;;
+    esac
+
+    # Unknown wording is left retryable by the caller rather than fatal: a future
+    # docker/containerd release phrasing a timeout differently must not strand a device
+    # on an old image. The budget still bounds how long that costs.
+    echo "unknown"
+}
+
+# ipv6_usable -- true only with real internet IPv6 that reaches the blob host.
+#
+# Two traps this guards against:
+#   - Tailscale hands out an fd7a::/8 ULA address, so "has a global v6 address" is not
+#     enough; devices look v6-capable while having no route off-link. Requiring a
+#     default route excludes that.
+#   - A router can advertise v6 with no working upstream (blackholed), which would make
+#     the fallback slower than no fallback. So we prove the path end to end.
+ipv6_usable() {
+    ip -6 route show default 2>/dev/null | grep -q . || return 1
+    # No -f: any HTTP status proves the path carried a request. Only a failure to
+    # connect at all (non-zero curl exit) means IPv6 is unusable here.
+    curl -6 -s -o /dev/null --max-time 8 "https://${PULL_BLOB_HOST}/" >/dev/null 2>&1
+}
+
+# enable_ipv6 -- undo an explicitly disabled stack.
+#
+# Some device images ship with IPv6 switched off in sysctl; that is the case we can fix
+# locally. If the site's network simply doesn't route v6, there is nothing to enable --
+# ipv6_usable() stays false and we report that rather than pretend a fallback exists.
+enable_ipv6() {
+    local persisted="/etc/sysctl.d/99-aquila-ipv6.conf"
+
+    if [[ "$(sysctl -n net.ipv6.conf.all.disable_ipv6 2>/dev/null || echo 0)" == "1" ]]; then
+        echo "  IPv6 was disabled in sysctl -- enabling it"
+        sysctl -w net.ipv6.conf.all.disable_ipv6=0 >/dev/null 2>&1 || return 1
+        sysctl -w net.ipv6.conf.default.disable_ipv6=0 >/dev/null 2>&1 || true
+        # Persist, or the next reboot silently reverts the device to a broken update path.
+        printf 'net.ipv6.conf.all.disable_ipv6 = 0\nnet.ipv6.conf.default.disable_ipv6 = 0\n' \
+            > "${persisted}" 2>/dev/null || true
+        sleep 5   # SLAAC needs a moment to land a route once the stack is back up
     fi
-fi
+}
 
-curl -fsSL \
-    -H "Authorization: token ${GHCR_TOKEN}" \
-    "https://raw.githubusercontent.com/${GHCR_REPO}/main/fleet-config/docker-compose.yml" \
-    -o /opt/fleet/docker-compose.yml
+# _pull_timeout <seconds> <command...>
+# Devices (Debian) ship coreutils `timeout`; dev machines (macOS) may not. Rather than
+# failing every pull with "command not found", run without the cap and let the attempt
+# counter bound the work -- a hung pull then can't be preempted mid-attempt, which is
+# acceptable on a workstation and never happens on a device.
+_pull_timeout() {
+    local secs=$1; shift
+    if command -v timeout >/dev/null 2>&1; then
+        timeout "${secs}" "$@"
+    elif command -v gtimeout >/dev/null 2>&1; then
+        gtimeout "${secs}" "$@"
+    else
+        "$@"
+    fi
+}
 
-docker compose --env-file "${FLEET_ENV}" -f /opt/fleet/docker-compose.yml pull
+# _run_pull <timeout-seconds> <command...>
+# One attempt. Echoes output to the operator while capturing it for classification;
+# leaves the captured text in _PULL_LAST_ERROR and returns the command's status.
+_run_pull() {
+    local timeout_s=$1; shift
+    local tmp rc errexit_was_set=0
+    tmp=$(mktemp)
 
-_DIGEST=$(docker inspect --format='{{index .RepoDigests 0}}' \
-    "ghcr.io/${GHCR_REPO}-api:${IMAGE_TAG}" 2>/dev/null | awk -F@ '{print $2}')
-_DIGEST_UI=$(docker inspect --format='{{index .RepoDigests 0}}' \
-    "ghcr.io/${GHCR_REPO}-ui:${IMAGE_TAG}" 2>/dev/null | awk -F@ '{print $2}')
+    # This script runs under `set -euo pipefail`. A failing pull is an expected outcome
+    # here, not a reason to abort. PIPESTATUS must be read from the pipeline itself:
+    # without pipefail a pipeline reports tee's status (always 0), which would report
+    # every failed pull as a success.
+    [[ $- == *e* ]] && errexit_was_set=1
+    set +e
+    _pull_timeout "${timeout_s}" "$@" 2>&1 | tee "${tmp}"
+    rc=${PIPESTATUS[0]}
+    (( errexit_was_set )) && set -e
+
+    _PULL_LAST_ERROR=$(cat "${tmp}")
+    rm -f "${tmp}"
+    return "${rc}"
+}
+
+# pull_with_fallback <pull-command...>
+#
+# Retry over the default path, then -- only for transport failures -- bring IPv6 up and
+# retry there. Names every family attempted on the way out, so support can tell "no IPv6
+# at this site" from "registry down" from "bad token" without guessing.
+pull_with_fallback() {
+    local started attempt rc kind remaining
+    started=$(date +%s)
+    _PULL_FAMILIES_TRIED="ipv4"
+
+    for ((attempt = 1; attempt <= PULL_IPV4_ATTEMPTS; attempt++)); do
+        remaining=$((PULL_TOTAL_BUDGET_SECONDS - ($(date +%s) - started)))
+        (( remaining <= 0 )) && break
+
+        echo "==> pull attempt ${attempt}/${PULL_IPV4_ATTEMPTS} (${remaining}s of budget left)"
+        rc=0; _run_pull "${remaining}" "$@" || rc=$?
+        if (( rc == 0 )); then
+            echo "==> pull succeeded (families tried: ${_PULL_FAMILIES_TRIED})"
+            return 0
+        fi
+
+        kind=$(classify_pull_error "${_PULL_LAST_ERROR}")
+        case "${kind}" in
+            auth)
+                echo "==> pull failed: credentials rejected. Not retrying -- check GHCR_TOKEN." >&2
+                return 1 ;;
+            notfound)
+                echo "==> pull failed: image/tag not found. Not retrying -- check IMAGE_TAG." >&2
+                return 1 ;;
+        esac
+        echo "==> attempt ${attempt} failed (${kind}); backing off ${PULL_BACKOFF_SECONDS}s"
+        sleep "${PULL_BACKOFF_SECONDS}"
+    done
+
+    # Every IPv4 attempt died on transport -- the case IPv6 exists to rescue.
+    echo "==> IPv4 exhausted; trying IPv6 for the blob transfer"
+    enable_ipv6 || true
+
+    if ! ipv6_usable; then
+        echo "==> no usable IPv6 here (no v6 default route, or ${PULL_BLOB_HOST} unreachable over v6)." >&2
+        echo "==> pull FAILED (families tried: ${_PULL_FAMILIES_TRIED})" >&2
+        return 1
+    fi
+
+    _PULL_FAMILIES_TRIED="ipv4,ipv6"
+    for ((attempt = 1; attempt <= PULL_IPV6_ATTEMPTS; attempt++)); do
+        remaining=$((PULL_TOTAL_BUDGET_SECONDS - ($(date +%s) - started)))
+        (( remaining <= 0 )) && break
+
+        echo "==> IPv6 pull attempt ${attempt}/${PULL_IPV6_ATTEMPTS} (${remaining}s of budget left)"
+        rc=0; _run_pull "${remaining}" "$@" || rc=$?
+        if (( rc == 0 )); then
+            # Loud on purpose: a device needing the v6 fallback on every update has a
+            # site network problem to fix upstream, not to paper over here.
+            echo "==> pull succeeded over IPv6 after IPv4 failed -- site IPv4 path is degraded"
+            return 0
+        fi
+        kind=$(classify_pull_error "${_PULL_LAST_ERROR}")
+        echo "==> IPv6 attempt ${attempt} failed (${kind})"
+        sleep "${PULL_BACKOFF_SECONDS}"
+    done
+
+    echo "==> pull FAILED over every path (families tried: ${_PULL_FAMILIES_TRIED})" >&2
+    return 1
+}
 
 _upsert_env() {
     local key=$1 val=$2 file=$3
@@ -41,13 +230,54 @@ _upsert_env() {
     fi
 }
 
-_upsert_env RUNNING_IMAGE_DIGEST    "${_DIGEST:-}"    "${FLEET_ENV}"
-_upsert_env RUNNING_IMAGE_DIGEST_UI "${_DIGEST_UI:-}" "${FLEET_ENV}"
+main() {
+    local GHCR_TOKEN GHCR_TOKEN_2 GHCR_REPO IMAGE_TAG _DIGEST _DIGEST_UI
 
-# --force-recreate: a same-tag digest change (e.g. pilot->new pilot) otherwise
-#   leaves the old container running; force it so the pulled image is swapped in.
-# --remove-orphans: clear any half-finished Watchtower swap leftovers
-#   (<hash>_aquila-backend) so they don't linger and fight for the same ports.
-docker compose --env-file "${FLEET_ENV}" -f /opt/fleet/docker-compose.yml up -d --force-recreate --remove-orphans
+    GHCR_TOKEN=$(grep ^GHCR_TOKEN= "${DEVICE_ENV}" | cut -d= -f2)
+    GHCR_TOKEN_2=$(grep ^GHCR_TOKEN_2= "${DEVICE_ENV}" 2>/dev/null | cut -d= -f2 || echo "")
+    GHCR_REPO=$(grep ^GHCR_REPO "${FLEET_ENV}" | cut -d= -f2)
+    IMAGE_TAG=$(grep ^IMAGE_TAG "${FLEET_ENV}" | cut -d= -f2)
 
-mkdir -p /opt/aquila/tests
+    # If a second token is configured, validate the primary and fall back to it.
+    # This allows zero-downtime token rotation: add GHCR_TOKEN_2 to device.env,
+    # verify it works, then promote it to GHCR_TOKEN and remove GHCR_TOKEN_2.
+    if [[ -n "${GHCR_TOKEN_2}" ]]; then
+        if ! curl -fsSL -o /dev/null \
+                -H "Authorization: token ${GHCR_TOKEN}" \
+                "https://api.github.com/repos/${GHCR_REPO}" 2>/dev/null; then
+            GHCR_TOKEN="${GHCR_TOKEN_2}"
+        fi
+    fi
+
+    curl -fsSL \
+        -H "Authorization: token ${GHCR_TOKEN}" \
+        "https://raw.githubusercontent.com/${GHCR_REPO}/main/fleet-config/docker-compose.yml" \
+        -o "${COMPOSE_FILE}"
+
+    # Previously a bare `docker compose pull`: under `set -e` a single dropped
+    # connection aborted the update before the digest write-back below, leaving the
+    # device on the old image with nothing retried (#357).
+    pull_with_fallback docker compose --env-file "${FLEET_ENV}" -f "${COMPOSE_FILE}" pull
+
+    _DIGEST=$(docker inspect --format='{{index .RepoDigests 0}}' \
+        "ghcr.io/${GHCR_REPO}-api:${IMAGE_TAG}" 2>/dev/null | awk -F@ '{print $2}')
+    _DIGEST_UI=$(docker inspect --format='{{index .RepoDigests 0}}' \
+        "ghcr.io/${GHCR_REPO}-ui:${IMAGE_TAG}" 2>/dev/null | awk -F@ '{print $2}')
+
+    _upsert_env RUNNING_IMAGE_DIGEST    "${_DIGEST:-}"    "${FLEET_ENV}"
+    _upsert_env RUNNING_IMAGE_DIGEST_UI "${_DIGEST_UI:-}" "${FLEET_ENV}"
+
+    # --force-recreate: a same-tag digest change (e.g. pilot->new pilot) otherwise
+    #   leaves the old container running; force it so the pulled image is swapped in.
+    # --remove-orphans: clear any half-finished Watchtower swap leftovers
+    #   (<hash>_aquila-backend) so they don't linger and fight for the same ports.
+    docker compose --env-file "${FLEET_ENV}" -f "${COMPOSE_FILE}" up -d --force-recreate --remove-orphans
+
+    mkdir -p /opt/aquila/tests
+}
+
+# Only run when executed. Sourcing defines the functions for the tests without
+# touching the device.
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+    main "$@"
+fi

--- a/scripts/deploy/fleet-update.sh
+++ b/scripts/deploy/fleet-update.sh
@@ -18,16 +18,22 @@ COMPOSE_FILE="${COMPOSE_FILE:-/opt/fleet/docker-compose.yml}"
 #   auth + manifest -> ghcr.io                              (a few KB, NO AAAA record)
 #   blob / layers   -> pkg-containers.githubusercontent.com (hundreds of MB, HAS AAAA)
 # On a degraded IPv4 path the small manifest fetch still succeeds -- so the device
-# correctly detects an update -- while the bulk blob transfer stalls. Because the blob
-# host is v6-capable, bringing IPv6 up rescues exactly the leg that fails. This was
-# observed in the field: switching a stuck device to IPv6 completed the update.
+# correctly detects an update -- while the bulk blob transfer stalls.
 #
-# We do NOT force a family per connection (docker exposes no such flag, and pinning CDN
-# addresses into /etc/hosts rots as the CDN rotates). We make IPv6 usable and let
-# glibc's RFC 6724 address selection prefer it for AAAA-bearing hosts. ghcr.io publishes
-# no AAAA, so auth/manifest stay on IPv4 by themselves -- no special-casing needed.
-
-PULL_BLOB_HOST="${PULL_BLOB_HOST:-pkg-containers.githubusercontent.com}"
+# Two things follow, and they pull in opposite directions:
+#
+#   Merely *enabling* IPv6 achieves nothing. Both Go (dockerd) and glibc already prefer
+#   IPv6 over IPv4 when both work, so a device with usable IPv6 is already trying it.
+#
+#   Forcing IPv6 does help, but only somewhere specific. In the field a stuck device
+#   completed its update after IPv4 was switched off by hand. With ghcr.io having no
+#   AAAA, a v6-only pull can only authenticate where the network runs NAT64/DNS64 --
+#   so that is the situation being reproduced, and the gate below tests for exactly it.
+#
+# Hence: retry on IPv4 first (which is what helps everywhere), and only as a last resort
+# -- the update has already failed by then -- drop the IPv4 default route for one
+# attempt, where the network can actually support that. This is deliberately the final
+# thing tried, never a first move.
 
 # Breadcrumb read back by the backend for /update/status (#357). The backend cannot
 # observe this itself: the operator's Update button drives Watchtower, which performs
@@ -89,38 +95,68 @@ classify_pull_error() {
     echo "unknown"
 }
 
-# ipv6_usable -- true only with real internet IPv6 that reaches the blob host.
+# ipv6_only_pull_possible -- can the WHOLE pull complete with IPv4 out of the way?
 #
-# Two traps this guards against:
-#   - Tailscale hands out an fd7a::/8 ULA address, so "has a global v6 address" is not
-#     enough; devices look v6-capable while having no route off-link. Requiring a
-#     default route excludes that.
-#   - A router can advertise v6 with no working upstream (blackholed), which would make
-#     the fallback slower than no fallback. So we prove the path end to end.
-ipv6_usable() {
+# ghcr.io publishes no AAAA record, so on an ordinary dual-stack network a v6-only pull
+# cannot even authenticate. It works only where the network runs NAT64/DNS64: an
+# IPv6-mostly setup that synthesises addresses for IPv4-only servers and translates on
+# the way out. Reaching ghcr.io over IPv6 is a direct test for exactly that, and it is
+# the situation observed in the field, where forcing a stuck device to IPv6 completed
+# the update.
+#
+# Gating on this keeps us from dropping IPv4 anywhere it could not possibly help.
+ipv6_only_pull_possible() {
     ip -6 route show default 2>/dev/null | grep -q . || return 1
-    # No -f: any HTTP status proves the path carried a request. Only a failure to
-    # connect at all (non-zero curl exit) means IPv6 is unusable here.
-    curl -6 -s -o /dev/null --max-time 8 "https://${PULL_BLOB_HOST}/" >/dev/null 2>&1
+    curl -6 -s -o /dev/null --max-time 8 "https://ghcr.io/v2/" >/dev/null 2>&1
 }
 
-# enable_ipv6 -- undo an explicitly disabled stack.
-#
-# Some device images ship with IPv6 switched off in sysctl; that is the case we can fix
-# locally. If the site's network simply doesn't route v6, there is nothing to enable --
-# ipv6_usable() stays false and we report that rather than pretend a fallback exists.
-enable_ipv6() {
-    local persisted="/etc/sysctl.d/99-aquila-ipv6.conf"
+# _restore_ipv4 <saved-route>
+_restore_ipv4() {
+    [[ -n "${1:-}" ]] && ip route replace ${1} 2>/dev/null || true
+}
 
-    if [[ "$(sysctl -n net.ipv6.conf.all.disable_ipv6 2>/dev/null || echo 0)" == "1" ]]; then
-        echo "  IPv6 was disabled in sysctl -- enabling it"
-        sysctl -w net.ipv6.conf.all.disable_ipv6=0 >/dev/null 2>&1 || return 1
-        sysctl -w net.ipv6.conf.default.disable_ipv6=0 >/dev/null 2>&1 || true
-        # Persist, or the next reboot silently reverts the device to a broken update path.
-        printf 'net.ipv6.conf.all.disable_ipv6 = 0\nnet.ipv6.conf.default.disable_ipv6 = 0\n' \
-            > "${persisted}" 2>/dev/null || true
-        sleep 5   # SLAAC needs a moment to land a route once the stack is back up
+# _pull_ipv6_only <timeout-seconds> <command...>
+#
+# The last thing tried before giving up: remove the IPv4 default route so the pull has
+# no choice but IPv6, attempt it once, then put the route back.
+#
+# Safety, because this briefly takes the device off IPv4 -- which can interrupt remote
+# access for the duration:
+#   - only the default ROUTE is removed, never an address or interface, so restoring is
+#     a single re-add;
+#   - a trap restores it on any exit, including Ctrl-C or a failure mid-pull;
+#   - a detached watchdog restores it even if this shell is killed outright;
+#   - nothing is written to persistent config, so a reboot also heals it.
+_pull_ipv6_only() {
+    local timeout_s=$1; shift
+    local saved rc=0 watchdog
+
+    saved=$(ip -4 route show default 2>/dev/null | head -1)
+    if [[ -z "${saved}" ]]; then
+        echo "  no IPv4 default route to remove -- skipping"
+        return 1
     fi
+
+    trap '_restore_ipv4 "${saved}"' EXIT INT TERM
+    # Detached from this shell's stdout: an inherited pipe would keep the caller
+    # blocked until the watchdog's sleep expired, long after the pull finished.
+    ( sleep $((timeout_s + 60)); ip route replace ${saved} 2>/dev/null || true ) \
+        >/dev/null 2>&1 &
+    watchdog=$!
+
+    echo "  removing the IPv4 default route for this attempt (restored afterwards)"
+    ip -4 route del default 2>/dev/null || true
+
+    _run_pull "${timeout_s}" "$@" || rc=$?
+
+    # Kill the sleep first: killing only the subshell orphans its child, which would
+    # linger for the full watchdog interval on every update.
+    pkill -P "${watchdog}" 2>/dev/null || true
+    kill "${watchdog}" 2>/dev/null || true
+    _restore_ipv4 "${saved}"
+    trap - EXIT INT TERM
+    echo "  IPv4 default route restored"
+    return "${rc}"
 }
 
 # _pull_timeout <seconds> <command...>
@@ -209,14 +245,18 @@ pull_with_fallback() {
         sleep "${PULL_BACKOFF_SECONDS}"
     done
 
-    # Every IPv4 attempt died on transport -- the case IPv6 exists to rescue.
-    echo "==> IPv4 exhausted; trying IPv6 for the blob transfer"
-    enable_ipv6 || true
+    # Every IPv4 attempt died on transport. One last thing before giving up: force the
+    # pull onto IPv6. This is worth trying precisely because the update has already
+    # failed -- the downside is a brief interruption on a device that is stuck anyway.
+    echo "==> IPv4 exhausted; considering an IPv6-only attempt"
 
-    if ! ipv6_usable; then
-        echo "==> no usable IPv6 here (no v6 default route, or ${PULL_BLOB_HOST} unreachable over v6)." >&2
+    if ! ipv6_only_pull_possible; then
+        # Either no IPv6 at all, or IPv6 without NAT64 -- in which case ghcr.io (no
+        # AAAA) is unreachable v6-only and dropping IPv4 would fail at authentication
+        # while costing the device its connectivity. Not worth it.
+        echo "==> IPv6-only pull not possible here (no v6 route, or ghcr.io unreachable over IPv6)." >&2
         echo "==> pull FAILED (families tried: ${_PULL_FAMILIES_TRIED})" >&2
-        _write_pull_outcome failed "${_PULL_FAMILIES_TRIED}" "IPv4 transfer failed and no usable IPv6 at this site"
+        _write_pull_outcome failed "${_PULL_FAMILIES_TRIED}" "IPv4 transfer failed; no viable IPv6 path at this site"
         return 1
     fi
 
@@ -225,17 +265,17 @@ pull_with_fallback() {
         remaining=$((PULL_TOTAL_BUDGET_SECONDS - ($(date +%s) - started)))
         (( remaining <= 0 )) && break
 
-        echo "==> IPv6 pull attempt ${attempt}/${PULL_IPV6_ATTEMPTS} (${remaining}s of budget left)"
-        rc=0; _run_pull "${remaining}" "$@" || rc=$?
+        echo "==> IPv6-only pull attempt ${attempt}/${PULL_IPV6_ATTEMPTS} (${remaining}s of budget left)"
+        rc=0; _pull_ipv6_only "${remaining}" "$@" || rc=$?
         if (( rc == 0 )); then
-            # Loud on purpose: a device needing the v6 fallback on every update has a
-            # site network problem to fix upstream, not to paper over here.
+            # Loud on purpose: a device needing this on every update has a site network
+            # problem to fix upstream, not to paper over here.
             echo "==> pull succeeded over IPv6 after IPv4 failed -- site IPv4 path is degraded"
             _write_pull_outcome ok "${_PULL_FAMILIES_TRIED}" "IPv4 failed; completed over IPv6"
             return 0
         fi
         kind=$(classify_pull_error "${_PULL_LAST_ERROR}")
-        echo "==> IPv6 attempt ${attempt} failed (${kind})"
+        echo "==> IPv6-only attempt ${attempt} failed (${kind})"
         sleep "${PULL_BACKOFF_SECONDS}"
     done
 

--- a/scripts/deploy/fleet-update.sh
+++ b/scripts/deploy/fleet-update.sh
@@ -29,6 +29,13 @@ COMPOSE_FILE="${COMPOSE_FILE:-/opt/fleet/docker-compose.yml}"
 
 PULL_BLOB_HOST="${PULL_BLOB_HOST:-pkg-containers.githubusercontent.com}"
 
+# Breadcrumb read back by the backend for /update/status (#357). The backend cannot
+# observe this itself: the operator's Update button drives Watchtower, which performs
+# its own pull and never runs this script. So a device-side pull records what it tried
+# here, and the API surfaces it -- explicitly as "the last device-side pull", not as a
+# claim about the Watchtower path.
+PULL_OUTCOME_PATH="${PULL_OUTCOME_PATH:-/opt/fleet/last_pull.json}"
+
 # An operator is standing at the device. Long enough to ride out a slow link, short
 # enough not to look hung. Total wall clock across every attempt.
 PULL_TOTAL_BUDGET_SECONDS="${PULL_TOTAL_BUDGET_SECONDS:-480}"
@@ -155,6 +162,16 @@ _run_pull() {
     return "${rc}"
 }
 
+# _write_pull_outcome <result> <families> <detail>
+# Best-effort: a device that cannot write the breadcrumb must still complete its
+# update, so every failure here is swallowed.
+_write_pull_outcome() {
+    local result=$1 families=$2 detail=$3
+    printf '{"result":"%s","families_tried":"%s","detail":"%s","at":"%s"}\n' \
+        "${result}" "${families}" "${detail}" "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+        > "${PULL_OUTCOME_PATH}" 2>/dev/null || true
+}
+
 # pull_with_fallback <pull-command...>
 #
 # Retry over the default path, then -- only for transport failures -- bring IPv6 up and
@@ -173,6 +190,7 @@ pull_with_fallback() {
         rc=0; _run_pull "${remaining}" "$@" || rc=$?
         if (( rc == 0 )); then
             echo "==> pull succeeded (families tried: ${_PULL_FAMILIES_TRIED})"
+            _write_pull_outcome ok "${_PULL_FAMILIES_TRIED}" ""
             return 0
         fi
 
@@ -180,9 +198,11 @@ pull_with_fallback() {
         case "${kind}" in
             auth)
                 echo "==> pull failed: credentials rejected. Not retrying -- check GHCR_TOKEN." >&2
+                _write_pull_outcome failed "${_PULL_FAMILIES_TRIED}" "credentials rejected"
                 return 1 ;;
             notfound)
                 echo "==> pull failed: image/tag not found. Not retrying -- check IMAGE_TAG." >&2
+                _write_pull_outcome failed "${_PULL_FAMILIES_TRIED}" "image or tag not found"
                 return 1 ;;
         esac
         echo "==> attempt ${attempt} failed (${kind}); backing off ${PULL_BACKOFF_SECONDS}s"
@@ -196,6 +216,7 @@ pull_with_fallback() {
     if ! ipv6_usable; then
         echo "==> no usable IPv6 here (no v6 default route, or ${PULL_BLOB_HOST} unreachable over v6)." >&2
         echo "==> pull FAILED (families tried: ${_PULL_FAMILIES_TRIED})" >&2
+        _write_pull_outcome failed "${_PULL_FAMILIES_TRIED}" "IPv4 transfer failed and no usable IPv6 at this site"
         return 1
     fi
 
@@ -210,6 +231,7 @@ pull_with_fallback() {
             # Loud on purpose: a device needing the v6 fallback on every update has a
             # site network problem to fix upstream, not to paper over here.
             echo "==> pull succeeded over IPv6 after IPv4 failed -- site IPv4 path is degraded"
+            _write_pull_outcome ok "${_PULL_FAMILIES_TRIED}" "IPv4 failed; completed over IPv6"
             return 0
         fi
         kind=$(classify_pull_error "${_PULL_LAST_ERROR}")
@@ -218,6 +240,7 @@ pull_with_fallback() {
     done
 
     echo "==> pull FAILED over every path (families tried: ${_PULL_FAMILIES_TRIED})" >&2
+    _write_pull_outcome failed "${_PULL_FAMILIES_TRIED}" "transfer failed over both IPv4 and IPv6"
     return 1
 }
 

--- a/tests/contract/test_update_pull_outcome.py
+++ b/tests/contract/test_update_pull_outcome.py
@@ -1,0 +1,67 @@
+"""Contract tests for the last-pull breadcrumb on /update/status (#357).
+
+scripts/deploy/fleet-update.sh records which address families a device-side pull
+tried; the endpoint surfaces it so a failed update is diagnosable without SSHing
+into the device.
+
+Run with:
+    pytest tests/contract/test_update_pull_outcome.py -m contract -v
+"""
+import json
+
+import pytest
+
+from aquila_web import main as web_main
+
+
+@pytest.mark.contract
+def test_status_reports_no_pull_when_breadcrumb_absent(client, tmp_path, monkeypatch):
+    """The normal case on a device that has never run a scripted update."""
+    monkeypatch.setattr(web_main, "_PULL_OUTCOME_PATH", str(tmp_path / "missing.json"))
+
+    assert client.get("/update/status").json()["last_pull"] is None
+
+
+@pytest.mark.contract
+def test_status_names_the_families_tried(client, tmp_path, monkeypatch):
+    """The field case: IPv4 couldn't carry the transfer and IPv6 finished it."""
+    path = tmp_path / "last_pull.json"
+    path.write_text(
+        json.dumps(
+            {
+                "result": "ok",
+                "families_tried": "ipv4,ipv6",
+                "detail": "IPv4 failed; completed over IPv6",
+                "at": "2026-07-28T10:00:00Z",
+            }
+        )
+    )
+    monkeypatch.setattr(web_main, "_PULL_OUTCOME_PATH", str(path))
+
+    last_pull = client.get("/update/status").json()["last_pull"]
+
+    assert last_pull["families_tried"] == "ipv4,ipv6"
+    assert last_pull["result"] == "ok"
+
+
+@pytest.mark.contract
+def test_status_survives_a_truncated_breadcrumb(client, tmp_path, monkeypatch):
+    """A device killed mid-write must not break the endpoint the UI polls."""
+    path = tmp_path / "last_pull.json"
+    path.write_text('{"result":"ok","families_tr')
+    monkeypatch.setattr(web_main, "_PULL_OUTCOME_PATH", str(path))
+
+    response = client.get("/update/status")
+
+    assert response.status_code == 200
+    assert response.json()["last_pull"] is None
+
+
+@pytest.mark.contract
+def test_status_ignores_a_breadcrumb_that_is_not_an_object(client, tmp_path, monkeypatch):
+    """Valid JSON of the wrong shape must not reach the UI as a pull outcome."""
+    path = tmp_path / "last_pull.json"
+    path.write_text('["not", "an", "object"]')
+    monkeypatch.setattr(web_main, "_PULL_OUTCOME_PATH", str(path))
+
+    assert client.get("/update/status").json()["last_pull"] is None

--- a/tests/fleet_device/test_pull_retry.py
+++ b/tests/fleet_device/test_pull_retry.py
@@ -105,7 +105,7 @@ FAST = "PULL_BACKOFF_SECONDS=0; PULL_TOTAL_BUDGET_SECONDS=60;"
 
 
 def test_successful_pull_runs_once_and_does_not_touch_ipv6() -> None:
-    setup = f"{FAST} ipv6_usable() {{ echo IPV6_PROBED; return 1; }}"
+    setup = f"{FAST} ipv6_only_pull_possible() {{ echo IPV6_PROBED; return 1; }}"
     out = _call("pull_with_fallback", "true", setup=setup)
 
     assert "pull succeeded" in out
@@ -126,15 +126,16 @@ def test_transport_failure_retries_then_falls_back_to_ipv6() -> None:
     setup = (
         f"{FAST} PULL_IPV4_ATTEMPTS=3;"
         " _fail() { echo 'unexpected EOF'; return 1; };"
-        " enable_ipv6() { :; };"
-        " ipv6_usable() { return 0; }"
+        ""
+        " ipv6_only_pull_possible() { return 0; };"
+        " _pull_ipv6_only() { shift; \"$@\"; }"
     )
     out = _call("pull_with_fallback", "_fail", setup=setup)
 
     # "==> pull attempt" is the IPv4 banner; the v6 one reads "==> IPv6 pull attempt".
     assert out.count("==> pull attempt") == 3, "should use its full IPv4 budget first"
-    assert "IPv4 exhausted; trying IPv6" in out
-    assert "IPv6 pull attempt" in out
+    assert "IPv4 exhausted; considering an IPv6-only attempt" in out
+    assert "IPv6-only pull attempt" in out
 
 
 def test_reports_degraded_ipv4_when_ipv6_rescues_the_pull() -> None:
@@ -143,8 +144,9 @@ def test_reports_degraded_ipv4_when_ipv6_rescues_the_pull() -> None:
         f"{FAST} PULL_IPV4_ATTEMPTS=1;"
         " _flaky() { [[ -f $STATE ]] && return 0; touch $STATE;"
         "            echo 'unexpected EOF'; return 1; };"
-        " enable_ipv6() { :; };"
-        " ipv6_usable() { return 0; };"
+        ""
+        " ipv6_only_pull_possible() { return 0; };"
+        " _pull_ipv6_only() { shift; \"$@\"; };"
         " STATE=$(mktemp -u)"
     )
     out = _call("pull_with_fallback", "_flaky", setup=setup)
@@ -158,8 +160,8 @@ def test_no_ipv6_at_site_fails_with_a_diagnosable_message() -> None:
     setup = (
         f"{FAST} PULL_IPV4_ATTEMPTS=1;"
         " _fail() { echo 'unexpected EOF'; return 1; };"
-        " enable_ipv6() { :; };"
-        " ipv6_usable() { return 1; }"
+        ""
+        " ipv6_only_pull_possible() { return 1; }"
     )
     result = subprocess.run(
         ["bash", "-c", f"source {SCRIPT}\n{setup}\npull_with_fallback _fail"],
@@ -170,7 +172,7 @@ def test_no_ipv6_at_site_fails_with_a_diagnosable_message() -> None:
     combined = result.stdout + result.stderr
 
     assert result.returncode != 0, "must not report success when nothing was pulled"
-    assert "no usable IPv6" in combined
+    assert "IPv6-only pull not possible" in combined
     assert "families tried: ipv4" in combined
 
 
@@ -180,7 +182,7 @@ def test_failed_pull_never_reports_success() -> None:
     Reading that instead of PIPESTATUS[0] would mark every failed pull as a success
     and let the update continue onto the digest write-back with a stale image.
     """
-    setup = f"{FAST} PULL_IPV4_ATTEMPTS=1; ipv6_usable() {{ return 1; }}"
+    setup = f"{FAST} PULL_IPV4_ATTEMPTS=1; ipv6_only_pull_possible() {{ return 1; }}"
     result = subprocess.run(
         ["bash", "-c", f"set +o pipefail\nsource {SCRIPT}\n{setup}\npull_with_fallback false"],
         capture_output=True,
@@ -230,8 +232,9 @@ def test_records_which_families_were_tried_for_the_backend(tmp_path) -> None:
         f"{FAST} PULL_IPV4_ATTEMPTS=1; PULL_OUTCOME_PATH='{outcome}';"
         " _flaky() { [[ -f $STATE ]] && return 0; touch $STATE;"
         "            echo 'unexpected EOF'; return 1; };"
-        " enable_ipv6() { :; };"
-        " ipv6_usable() { return 0; };"
+        ""
+        " ipv6_only_pull_possible() { return 0; };"
+        " _pull_ipv6_only() { shift; \"$@\"; };"
         " STATE=$(mktemp -u)"
     )
     _call("pull_with_fallback", "_flaky", setup=setup)
@@ -246,14 +249,14 @@ def test_records_a_failure_the_backend_can_explain(tmp_path) -> None:
     setup = (
         f"{FAST} PULL_IPV4_ATTEMPTS=1; PULL_OUTCOME_PATH='{outcome}';"
         " _fail() { echo 'unexpected EOF'; return 1; };"
-        " enable_ipv6() { :; };"
-        " ipv6_usable() { return 1; }"
+        ""
+        " ipv6_only_pull_possible() { return 1; }"
     )
     _call("pull_with_fallback", "_fail", setup=setup)
 
     recorded = json.loads(outcome.read_text())
     assert recorded["result"] == "failed"
-    assert "no usable IPv6" in recorded["detail"]
+    assert "no viable IPv6 path" in recorded["detail"]
 
 
 def test_unwritable_breadcrumb_does_not_fail_the_update() -> None:
@@ -262,3 +265,75 @@ def test_unwritable_breadcrumb_does_not_fail_the_update() -> None:
     out = _call("pull_with_fallback", "true", setup=setup)
 
     assert "pull succeeded" in out
+
+
+# --- the IPv6-only last resort ----------------------------------------------
+# _pull_ipv6_only removes the device's IPv4 default route for one attempt. If it
+# ever failed to put it back, a remote device would lose connectivity and nobody
+# could reach it to fix that. These drive it with a stubbed `ip`.
+
+IP_STUB = (
+    " ip() {{ echo \"ip $*\" >> {log};"
+    '   if [[ "$*" == "-4 route show default" ]]; then'
+    '     echo "default via 192.168.1.1 dev wlan0 proto dhcp metric 600"; fi; }};'
+)
+
+
+def _ip_calls(log) -> list[str]:
+    return log.read_text().splitlines() if log.exists() else []
+
+
+def test_ipv4_route_is_restored_after_a_successful_ipv6_attempt(tmp_path) -> None:
+    log = tmp_path / "ip.log"
+    setup = IP_STUB.format(log=log)
+    out = _call("_pull_ipv6_only", "60", "true", setup=setup)
+
+    calls = _ip_calls(log)
+    assert any("route del default" in c for c in calls), "should remove the v4 route"
+    assert any("route replace" in c for c in calls), "must put the v4 route back"
+    assert "restored" in out
+
+
+def test_ipv4_route_is_restored_even_when_the_pull_fails(tmp_path) -> None:
+    """The failure path is the one that matters -- it's where a device gets stranded."""
+    log = tmp_path / "ip.log"
+    setup = IP_STUB.format(log=log)
+    result = subprocess.run(
+        ["bash", "-c", f"source {SCRIPT}\n{setup}\n_pull_ipv6_only 60 false"],
+        capture_output=True, text=True, timeout=60,
+    )
+
+    assert result.returncode != 0, "a failed pull must still report failure"
+    assert any("route replace" in c for c in _ip_calls(log)), "route must be restored"
+
+
+def test_no_ipv4_route_to_remove_is_a_no_op(tmp_path) -> None:
+    """Nothing to remove means nothing to restore -- must not delete a route blindly."""
+    log = tmp_path / "ip.log"
+    setup = f' ip() {{ echo "ip $*" >> {log}; }};'
+    result = subprocess.run(
+        ["bash", "-c", f"source {SCRIPT}\n{setup}\n_pull_ipv6_only 60 true"],
+        capture_output=True, text=True, timeout=60,
+    )
+
+    assert result.returncode != 0
+    assert not any("route del" in c for c in _ip_calls(log))
+
+
+def test_fallback_is_skipped_when_the_network_cannot_support_it(tmp_path) -> None:
+    """Without NAT64, ghcr.io is unreachable v6-only: dropping IPv4 would only cost
+    the device its connectivity and still fail at authentication."""
+    log = tmp_path / "ip.log"
+    setup = (
+        f"{FAST} PULL_IPV4_ATTEMPTS=1;"
+        " _fail() { echo 'unexpected EOF'; return 1; };"
+        " ipv6_only_pull_possible() { return 1; };"
+        f' ip() {{ echo "ip $*" >> {log}; }};'
+    )
+    result = subprocess.run(
+        ["bash", "-c", f"source {SCRIPT}\n{setup}\npull_with_fallback _fail"],
+        capture_output=True, text=True, timeout=60,
+    )
+
+    assert not any("route del" in c for c in _ip_calls(log)), "must not touch routing"
+    assert "IPv6-only pull not possible" in result.stdout + result.stderr

--- a/tests/fleet_device/test_pull_retry.py
+++ b/tests/fleet_device/test_pull_retry.py
@@ -5,6 +5,7 @@ directly, so they exercise real behaviour rather than asserting on source text.
 Sourcing is safe: the script only runs the update when executed, not when sourced.
 """
 
+import json
 import shutil
 import subprocess
 from pathlib import Path
@@ -218,3 +219,46 @@ def test_pull_retains_digest_writeback_after_a_successful_pull() -> None:
 
     assert text.index("pull_with_fallback docker compose") < text.index("RepoDigests")
     assert text.index("RepoDigests") < text.index("_upsert_env RUNNING_IMAGE_DIGEST")
+
+
+# --- outcome breadcrumb -----------------------------------------------------
+
+def test_records_which_families_were_tried_for_the_backend(tmp_path) -> None:
+    """/update/status reads this file; it must name the families on the v6 rescue."""
+    outcome = tmp_path / "last_pull.json"
+    setup = (
+        f"{FAST} PULL_IPV4_ATTEMPTS=1; PULL_OUTCOME_PATH='{outcome}';"
+        " _flaky() { [[ -f $STATE ]] && return 0; touch $STATE;"
+        "            echo 'unexpected EOF'; return 1; };"
+        " enable_ipv6() { :; };"
+        " ipv6_usable() { return 0; };"
+        " STATE=$(mktemp -u)"
+    )
+    _call("pull_with_fallback", "_flaky", setup=setup)
+
+    recorded = json.loads(outcome.read_text())
+    assert recorded["result"] == "ok"
+    assert recorded["families_tried"] == "ipv4,ipv6"
+
+
+def test_records_a_failure_the_backend_can_explain(tmp_path) -> None:
+    outcome = tmp_path / "last_pull.json"
+    setup = (
+        f"{FAST} PULL_IPV4_ATTEMPTS=1; PULL_OUTCOME_PATH='{outcome}';"
+        " _fail() { echo 'unexpected EOF'; return 1; };"
+        " enable_ipv6() { :; };"
+        " ipv6_usable() { return 1; }"
+    )
+    _call("pull_with_fallback", "_fail", setup=setup)
+
+    recorded = json.loads(outcome.read_text())
+    assert recorded["result"] == "failed"
+    assert "no usable IPv6" in recorded["detail"]
+
+
+def test_unwritable_breadcrumb_does_not_fail_the_update() -> None:
+    """A device that cannot write the breadcrumb must still complete its update."""
+    setup = f"{FAST} PULL_OUTCOME_PATH='/nonexistent-dir/last_pull.json'"
+    out = _call("pull_with_fallback", "true", setup=setup)
+
+    assert "pull succeeded" in out

--- a/tests/fleet_device/test_pull_retry.py
+++ b/tests/fleet_device/test_pull_retry.py
@@ -1,0 +1,220 @@
+"""Retry + IPv6 fallback for the device image pull (#357).
+
+These tests source scripts/deploy/fleet-update.sh and call its shell functions
+directly, so they exercise real behaviour rather than asserting on source text.
+Sourcing is safe: the script only runs the update when executed, not when sourced.
+"""
+
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+SCRIPT = Path("scripts/deploy/fleet-update.sh")
+
+pytestmark = pytest.mark.skipif(
+    shutil.which("bash") is None, reason="bash required to exercise the shell functions"
+)
+
+
+def _call(function: str, *args: str, setup: str = "") -> str:
+    """Source the script (defining functions only) and invoke one function."""
+    quoted = " ".join(f"'{a}'" for a in args)
+    script = f"source {SCRIPT}\n{setup}\n{function} {quoted}"
+    result = subprocess.run(
+        ["bash", "-c", script], capture_output=True, text=True, timeout=60
+    )
+    return result.stdout.strip()
+
+
+# --- error classification ---------------------------------------------------
+# Real strings as docker/containerd emit them. The classifier decides whether the
+# operator waits through a retry or gets told to fix a token, so both directions
+# of a misclassification are expensive.
+
+@pytest.mark.parametrize(
+    "message",
+    [
+        "Get https://ghcr.io/v2/: net/http: TLS handshake timeout",
+        "failed to copy: httpReadSeeker: failed open: unexpected EOF",
+        "read tcp 10.0.0.5:443: read: connection reset by peer",
+        "dial tcp: i/o timeout",
+        "context deadline exceeded",
+        "error pulling image configuration: download failed after attempts=1: EOF",
+        "Temporary failure in name resolution",
+        "connect: network is unreachable",
+    ],
+)
+def test_transport_failures_are_retryable(message: str) -> None:
+    assert _call("classify_pull_error", message) == "transport"
+
+
+@pytest.mark.parametrize(
+    "message",
+    [
+        "unauthorized: authentication required",
+        "denied: denied",
+        "pull access denied for ghcr.io/acorngenetics/aquilla-main-api",
+        "unexpected status code: 401 Unauthorized",
+        "Error response from daemon: 403 Forbidden",
+    ],
+)
+def test_auth_failures_are_not_retried(message: str) -> None:
+    """A 401 cannot be fixed by retrying or by changing address family."""
+    assert _call("classify_pull_error", message) == "auth"
+
+
+@pytest.mark.parametrize(
+    "message",
+    [
+        "manifest unknown",
+        "manifest for ghcr.io/acorngenetics/aquilla-main-api:nope not found",
+        "unexpected status code: 404",
+    ],
+)
+def test_missing_tag_is_not_retried(message: str) -> None:
+    assert _call("classify_pull_error", message) == "notfound"
+
+
+def test_digest_containing_401_is_not_mistaken_for_an_auth_failure() -> None:
+    """Regression: pull errors quote hex digests, and '401'/'403'/'404' occur in hex.
+
+    A bare substring match on the status code reads the digest below as an auth
+    failure and refuses to retry a transfer that would have succeeded on attempt two.
+    """
+    message = (
+        "failed to register layer: "
+        "sha256:401403404ab9c8d7e6f5a4b3c2d1e0f9a8b7c6d5e4f3a2b1c0d9e8f7a6b5c4d3: "
+        "unexpected EOF"
+    )
+    assert _call("classify_pull_error", message) == "transport"
+
+
+def test_unknown_wording_stays_retryable() -> None:
+    """A future docker release rewording a timeout must not strand a device."""
+    assert _call("classify_pull_error", "something nobody has seen before") == "unknown"
+
+
+# --- fallback orchestration -------------------------------------------------
+# pull_with_fallback is driven with a stub "pull" command so the whole decision
+# path runs offline, with no registry and no real IPv6.
+
+FAST = "PULL_BACKOFF_SECONDS=0; PULL_TOTAL_BUDGET_SECONDS=60;"
+
+
+def test_successful_pull_runs_once_and_does_not_touch_ipv6() -> None:
+    setup = f"{FAST} ipv6_usable() {{ echo IPV6_PROBED; return 1; }}"
+    out = _call("pull_with_fallback", "true", setup=setup)
+
+    assert "pull succeeded" in out
+    assert "IPV6_PROBED" not in out, "a working pull must not probe IPv6"
+    assert out.count("==> pull attempt") == 1
+
+
+def test_auth_failure_fails_fast_without_exhausting_the_budget() -> None:
+    """The operator should be told to fix the token, not made to wait out retries."""
+    setup = f"{FAST} _fail() {{ echo 'unauthorized: authentication required'; return 1; }}"
+    out = _call("pull_with_fallback", "_fail", setup=setup)
+
+    assert out.count("==> pull attempt") == 1, "auth failure must not retry"
+    assert "IPv4 exhausted" not in out, "auth failure must not reach the IPv6 fallback"
+
+
+def test_transport_failure_retries_then_falls_back_to_ipv6() -> None:
+    setup = (
+        f"{FAST} PULL_IPV4_ATTEMPTS=3;"
+        " _fail() { echo 'unexpected EOF'; return 1; };"
+        " enable_ipv6() { :; };"
+        " ipv6_usable() { return 0; }"
+    )
+    out = _call("pull_with_fallback", "_fail", setup=setup)
+
+    # "==> pull attempt" is the IPv4 banner; the v6 one reads "==> IPv6 pull attempt".
+    assert out.count("==> pull attempt") == 3, "should use its full IPv4 budget first"
+    assert "IPv4 exhausted; trying IPv6" in out
+    assert "IPv6 pull attempt" in out
+
+
+def test_reports_degraded_ipv4_when_ipv6_rescues_the_pull() -> None:
+    """The field case: IPv4 can't carry the transfer, IPv6 can."""
+    setup = (
+        f"{FAST} PULL_IPV4_ATTEMPTS=1;"
+        " _flaky() { [[ -f $STATE ]] && return 0; touch $STATE;"
+        "            echo 'unexpected EOF'; return 1; };"
+        " enable_ipv6() { :; };"
+        " ipv6_usable() { return 0; };"
+        " STATE=$(mktemp -u)"
+    )
+    out = _call("pull_with_fallback", "_flaky", setup=setup)
+
+    assert "pull succeeded over IPv6" in out
+    assert "site IPv4 path is degraded" in out, "must surface that the site needs fixing"
+
+
+def test_no_ipv6_at_site_fails_with_a_diagnosable_message() -> None:
+    """Both probed devices had no v6 default route -- this path must stay honest."""
+    setup = (
+        f"{FAST} PULL_IPV4_ATTEMPTS=1;"
+        " _fail() { echo 'unexpected EOF'; return 1; };"
+        " enable_ipv6() { :; };"
+        " ipv6_usable() { return 1; }"
+    )
+    result = subprocess.run(
+        ["bash", "-c", f"source {SCRIPT}\n{setup}\npull_with_fallback _fail"],
+        capture_output=True,
+        text=True,
+        timeout=60,
+    )
+    combined = result.stdout + result.stderr
+
+    assert result.returncode != 0, "must not report success when nothing was pulled"
+    assert "no usable IPv6" in combined
+    assert "families tried: ipv4" in combined
+
+
+def test_failed_pull_never_reports_success() -> None:
+    """Without pipefail a `cmd | tee` pipeline returns tee's status (0).
+
+    Reading that instead of PIPESTATUS[0] would mark every failed pull as a success
+    and let the update continue onto the digest write-back with a stale image.
+    """
+    setup = f"{FAST} PULL_IPV4_ATTEMPTS=1; ipv6_usable() {{ return 1; }}"
+    result = subprocess.run(
+        ["bash", "-c", f"set +o pipefail\nsource {SCRIPT}\n{setup}\npull_with_fallback false"],
+        capture_output=True,
+        text=True,
+        timeout=60,
+    )
+
+    assert result.returncode != 0
+    assert "pull succeeded" not in result.stdout
+
+
+# --- deployment shape -------------------------------------------------------
+
+def test_script_is_self_contained_for_standalone_install() -> None:
+    """deployment2.sh curls this file alone to /opt/fleet/update.sh.
+
+    Sourcing a sibling library would break every provisioned device, since no such
+    file is fetched alongside it.
+    """
+    code = [
+        line.strip()
+        for line in SCRIPT.read_text().splitlines()
+        if line.strip() and not line.strip().startswith("#")
+    ]
+
+    sourcing = [ln for ln in code if ln.startswith("source ") or ln.startswith(". ")]
+    assert not sourcing, f"must not source sibling files: {sourcing}"
+    assert any('BASH_SOURCE[0]}" == "${0}"' in ln for ln in code), (
+        "needs the main guard to stay sourceable"
+    )
+
+
+def test_pull_retains_digest_writeback_after_a_successful_pull() -> None:
+    """The retry must not reorder the update: digests are captured after the pull."""
+    text = SCRIPT.read_text()
+
+    assert text.index("pull_with_fallback docker compose") < text.index("RepoDigests")
+    assert text.index("RepoDigests") < text.index("_upsert_env RUNNING_IMAGE_DIGEST")

--- a/unit_tests/test_fleet_update_sync.py
+++ b/unit_tests/test_fleet_update_sync.py
@@ -1,0 +1,113 @@
+"""Publishing the host updater from the image to /opt/fleet (#357).
+
+/opt/fleet/update.sh was previously written once at provisioning and never refreshed,
+so a fix to it could only reach the fleet by hand. Syncing it on startup puts it on the
+normal ring promotion path.
+
+The failure modes here are unusually expensive: a truncated update.sh leaves a device
+unable to update at all, and the only thing that could repair that remotely is the very
+script being written. Hence the emphasis on atomicity and on never raising.
+"""
+import os
+import stat
+
+import pytest
+
+from aquila_web.main import sync_fleet_update_script
+
+
+@pytest.fixture
+def src(tmp_path):
+    path = tmp_path / "image" / "fleet-update.sh"
+    path.parent.mkdir()
+    path.write_text("#!/usr/bin/env bash\necho new\n")
+    return path
+
+
+def test_writes_the_script_when_the_host_has_none(src, tmp_path):
+    dest = tmp_path / "fleet" / "update.sh"
+    dest.parent.mkdir()
+
+    assert sync_fleet_update_script(str(src), str(dest)) == "synced"
+    assert dest.read_text() == src.read_text()
+
+
+def test_replaces_an_outdated_host_script(src, tmp_path):
+    """The case that matters: a device provisioned months ago on an old main."""
+    dest = tmp_path / "update.sh"
+    dest.write_text("#!/usr/bin/env bash\necho ancient\n")
+
+    assert sync_fleet_update_script(str(src), str(dest)) == "synced"
+    assert "new" in dest.read_text()
+
+
+def test_is_executable_after_syncing(src, tmp_path):
+    """It is invoked directly as /opt/fleet/update.sh, so the bit must be set."""
+    dest = tmp_path / "update.sh"
+
+    sync_fleet_update_script(str(src), str(dest))
+
+    assert dest.stat().st_mode & stat.S_IXUSR
+
+
+def test_leaves_an_identical_script_alone(src, tmp_path):
+    """Avoid rewriting the updater on every boot."""
+    dest = tmp_path / "update.sh"
+    dest.write_text(src.read_text())
+    before = dest.stat().st_mtime_ns
+
+    assert sync_fleet_update_script(str(src), str(dest)) == "unchanged"
+    assert dest.stat().st_mtime_ns == before
+
+
+def test_missing_source_leaves_the_existing_updater_intact(tmp_path):
+    """Degraded operation, not destruction: keep whatever the device already had."""
+    dest = tmp_path / "update.sh"
+    dest.write_text("#!/usr/bin/env bash\necho existing\n")
+
+    assert sync_fleet_update_script(str(tmp_path / "absent.sh"), str(dest)) == "skipped"
+    assert "existing" in dest.read_text()
+
+
+def test_read_only_mount_does_not_raise(src, tmp_path):
+    """A read-only /opt/fleet must not crash startup."""
+    fleet = tmp_path / "ro"
+    fleet.mkdir()
+    dest = fleet / "update.sh"
+    dest.write_text("#!/usr/bin/env bash\necho old\n")
+    os.chmod(fleet, 0o500)
+
+    try:
+        assert sync_fleet_update_script(str(src), str(dest)) == "skipped"
+        assert "old" in dest.read_text(), "the working updater must survive"
+    finally:
+        os.chmod(fleet, 0o700)
+
+
+def test_no_temporary_files_are_left_behind(src, tmp_path):
+    dest = tmp_path / "update.sh"
+
+    sync_fleet_update_script(str(src), str(dest))
+
+    leftovers = [p.name for p in tmp_path.iterdir() if p.name.startswith(".update.sh.")]
+    assert not leftovers, f"temp file left behind: {leftovers}"
+
+
+def test_a_failed_write_never_leaves_a_partial_script(src, tmp_path, monkeypatch):
+    """If the move fails, the device must keep a whole, working updater.
+
+    A truncated update.sh cannot be repaired remotely — it is the tool that would do
+    the repairing.
+    """
+    dest = tmp_path / "update.sh"
+    dest.write_text("#!/usr/bin/env bash\necho intact\n")
+
+    def boom(*_args, **_kwargs):
+        raise OSError("disk full")
+
+    monkeypatch.setattr(os, "replace", boom)
+
+    assert sync_fleet_update_script(str(src), str(dest)) == "skipped"
+    assert dest.read_text() == "#!/usr/bin/env bash\necho intact\n"
+    leftovers = [p.name for p in tmp_path.iterdir() if p.name.startswith(".update.sh.")]
+    assert not leftovers, f"temp file left behind: {leftovers}"


### PR DESCRIPTION
Closes #357.

## What this fixes

**1. The image pull had no retry at all.** `fleet-update.sh` ran a bare `docker compose pull`
under `set -euo pipefail`, so one dropped connection aborted the update *before* the digest
write-back and left the device on the old image. This affects every site, including those with
no IPv6, and is the higher-priority fix here.

**2. Some sites can't carry the transfer over IPv4.** In the field, switching a stuck device
(Pigmind) to IPv6 by hand completed the update immediately.

**3. The host updater could not be updated.** `/opt/fleet/update.sh` was written once by
`deployment2.sh` at provisioning and never refreshed — so every device runs whatever `main`
said the day it was set up, and a fix to it could only reach the fleet by hand. That is *why*
problem 1 survived so long on every device.

## How

**Retry with classification** — transport failures (timeout, reset, unexpected EOF, TLS,
partial layer) retry; auth (401/403) and unknown tags (404) fail fast, because no retry or
address family turns a 401 into a 200 and making an operator wait out a doomed retry is worse
than telling them straight away. Budget: 8 minutes hard cap — 3 IPv4 attempts, then up to 2
IPv6 attempts, each bounded by the remaining budget.

**IPv6 as a last resort, forced rather than merely enabled.** An earlier revision made IPv6
"usable" and trusted address selection to prefer it; that was a no-op, since Go (dockerd) and
glibc already prefer IPv6 wherever both work. What worked in the field was removing IPv4
entirely, so that is what this does — dropping the IPv4 *default route* for one attempt.

Because `ghcr.io` publishes no AAAA record, a v6-only pull can only authenticate where the
network runs NAT64/DNS64. Reaching `ghcr.io` over IPv6 tests for exactly that and gates the
attempt, so sites that cannot benefit never lose IPv4 and fail after the IPv4 retries instead.

Safety for the forced attempt: only the default route is removed, never an address or
interface; restored by a trap on any exit, by a detached watchdog if the shell is killed
outright, and by a reboot regardless since nothing is persisted.

**Host updater published from the image.** The backend syncs its bundled `fleet-update.sh` to
`/opt/fleet/update.sh` on startup, using the `COPY . .` already in `Dockerfile.api` and the
`/opt/fleet` mount already present for the reboot sentinel. The updater now rides normal ring
promotion. Written via `os.replace` (atomic): a half-written `update.sh` would leave a device
unable to update at all, and the only tool that could repair that remotely is the script being
written.

**`/update/status` reports the outcome** via a `last_pull` breadcrumb — result, families tried,
detail — so a failed update is diagnosable without SSH. Under its own key rather than folded
into `error`, because it describes the scripted path only: the Update button drives Watchtower,
which performs its own pull and never runs this script.

## Tests

45 new. `tests/fleet_device/test_pull_retry.py` sources the script and executes its shell
functions rather than asserting on source text; `unit_tests/test_fleet_update_sync.py` covers
the publish; `tests/contract/test_update_pull_outcome.py` covers the API.

Cases worth calling out: a digest containing `401403404` must not be read as an auth failure;
a failed pull must never report success when `pipefail` is unset; the IPv4 route must be
restored on the failure path; a simulated disk-full mid-write must leave a working updater.

Suite: 55 pre-existing failures unchanged before and after, +45 passing.

## Rollout note — the first update does not benefit

A device still running the old script performs its next update the old way (no retry). That
update ships the new image, whose backend then publishes the new updater. **From the second
update onward the retry and fallback are live.**

The exception matters: a device *currently failing* to update cannot receive the fix this way,
since receiving it requires a working update. Those need one hand-push (or a network fix) first.

## Unverified

- The NAT64 explanation for Pigmind is inference, not measurement — that device was not
  reachable. If wrong, the gate simply never fires and the retry fix is unaffected.
- The forced-IPv6 attempt has not run against a real degraded network, only stubs.
- Watchtower still performs its own unretried pull; this covers the scripted path only.
