### PR TITLE
feat(greengrass): component publisher — recipe, compose pinning, workflow

### DIFF
--- a/scripts/greengrass/recipe.py
+++ b/scripts/greengrass/recipe.py
@@ -1,0 +1,45 @@
+"""Build the AWS IoT Greengrass component recipe for the on-device app stack.
+
+Pure functions only — the CI workflow feeds in the image digests and the S3 URI
+of the compose artifact, and gets back the recipe dict to hand to
+`greengrassv2 create-component-version`. No AWS calls live here.
+"""
+import copy
+
+# The recipe schema version Greengrass v2 expects.
+RECIPE_FORMAT_VERSION = "2020-01-25"
+
+
+def pin_compose(compose, api_ref, ui_ref):
+    """Rewrite the on-device compose to run the exact built images by digest.
+
+    The authored compose uses floating GHCR tags and `build:` sections. On the
+    device we never build — Greengrass deploys prebuilt images, pinned by ECR
+    digest so a deployment is byte-for-byte the artifact CI published.
+    """
+    pinned = copy.deepcopy(compose)
+    for service, ref in (("backend", api_ref), ("ui", ui_ref)):
+        pinned["services"][service]["image"] = ref
+        pinned["services"][service].pop("build", None)
+    return pinned
+
+
+def build_recipe(component_name, version, compose_artifact_uri):
+    """Return the Greengrass recipe for a published component version."""
+    compose_file = compose_artifact_uri.rsplit("/", 1)[-1]
+    compose_path = "{artifacts:path}/" + compose_file
+    return {
+        "RecipeFormatVersion": RECIPE_FORMAT_VERSION,
+        "ComponentName": component_name,
+        "ComponentVersion": version,
+        "Manifests": [
+            {
+                "Platform": {"os": "linux"},
+                "Artifacts": [{"URI": compose_artifact_uri}],
+                "Lifecycle": {
+                    "Run": "docker compose -f %s up -d" % compose_path,
+                    "Shutdown": "docker compose -f %s down" % compose_path,
+                },
+            }
+        ],
+    }

--- a/tests/unit/test_greengrass_recipe.py
+++ b/tests/unit/test_greengrass_recipe.py
@@ -1,0 +1,88 @@
+"""
+Unit tests for the Greengrass component recipe builder.
+
+The recipe is the manifest AWS IoT Greengrass stores for each published
+component version: it names the component, pins its version, and points at the
+docker-compose artifact (in S3) the device runs. These are pure functions — no
+AWS, no network — so they exercise the real artifact-shaping logic directly.
+
+Behaviors tested:
+  1. build_recipe stamps the component name and version into a valid recipe
+  2. build_recipe pins the compose artifact and runs it via a Lifecycle
+  3. pin_compose rewrites the app images to the ECR digest refs
+  4. pin_compose strips build sections (the device pulls, never builds)
+"""
+import pytest
+
+pytestmark = pytest.mark.unit
+
+from scripts.greengrass.recipe import build_recipe, pin_compose
+
+
+def _device_compose():
+    """The on-device compose as authored: floating GHCR tags + build sections."""
+    return {
+        "services": {
+            "backend": {
+                "build": {"context": ".", "dockerfile": "docker/Dockerfile.api"},
+                "image": "ghcr.io/acorngenetics/aquilla-main-api:latest",
+            },
+            "ui": {
+                "build": {"context": ".", "dockerfile": "docker/Dockerfile.ui"},
+                "image": "ghcr.io/acorngenetics/aquilla-main-ui:latest",
+            },
+        }
+    }
+
+
+API_DIGEST = "867958227555.dkr.ecr.us-east-2.amazonaws.com/aquilla-main-api@sha256:aaa"
+UI_DIGEST = "867958227555.dkr.ecr.us-east-2.amazonaws.com/aquilla-main-ui@sha256:bbb"
+
+
+def test_build_recipe_sets_name_and_version():
+    recipe = build_recipe(
+        component_name="com.acorn.sentri",
+        version="1.2.3",
+        compose_artifact_uri="s3://acorn-artifacts/com.acorn.sentri/1.2.3/compose.yaml",
+    )
+
+    assert recipe["RecipeFormatVersion"] == "2020-01-25"
+    assert recipe["ComponentName"] == "com.acorn.sentri"
+    assert recipe["ComponentVersion"] == "1.2.3"
+
+
+def test_recipe_manifest_pins_compose_artifact_and_runs_it():
+    uri = "s3://acorn-artifacts/com.acorn.sentri/1.2.3/compose.yaml"
+    recipe = build_recipe("com.acorn.sentri", "1.2.3", uri)
+
+    manifest = recipe["Manifests"][0]
+    artifact_uris = [artifact["URI"] for artifact in manifest["Artifacts"]]
+    assert uri in artifact_uris
+
+    # The device brings the stack up from the downloaded compose artifact.
+    run = manifest["Lifecycle"]["Run"]
+    assert "docker compose" in run
+    assert "up" in run
+
+
+def test_pin_compose_sets_images_to_digest_refs():
+    pinned = pin_compose(_device_compose(), API_DIGEST, UI_DIGEST)
+
+    assert pinned["services"]["backend"]["image"] == API_DIGEST
+    assert pinned["services"]["ui"]["image"] == UI_DIGEST
+
+
+def test_pin_compose_strips_build_sections():
+    pinned = pin_compose(_device_compose(), API_DIGEST, UI_DIGEST)
+
+    assert "build" not in pinned["services"]["backend"]
+    assert "build" not in pinned["services"]["ui"]
+
+
+def test_pin_compose_does_not_mutate_the_input():
+    original = _device_compose()
+    pin_compose(original, API_DIGEST, UI_DIGEST)
+
+    # The authored compose is reused across builds — pinning must not clobber it.
+    assert original["services"]["backend"]["image"].startswith("ghcr.io/")
+    assert "build" in original["services"]["backend"]


### PR DESCRIPTION
AcornGenetics/aquilla-main#358 — the full aquilla-main side of the component publisher. **Targets `feat/greengrass-migration`, not `main`.**

## What
**Pure functions** (`scripts/greengrass/recipe.py`, unit-tested):
- `build_recipe(name, version, compose_artifact_uri)` → Greengrass v2 recipe naming the component (`com.acorn.sentri`), pinning the version, running the stack from the compose artifact via a `docker compose up`/`down` Lifecycle.
- `pin_compose(compose, api_ref, ui_ref)` → rewrites `backend`/`ui` to the **exact ECR digests** and strips `build:` (device pulls prebuilt). Non-mutating.

**CLI glue** (`scripts/greengrass/publish.py`) — thin argument/IO wrapper over those functions; smoke-verified against the real `compose.yaml`.

**Workflow** (`.github/workflows/publish-component.yml`) — on the migration branch: build api+ui (bake git SHA) → push to ECR → pin compose → upload to S3 → `greengrassv2 create-component-version`. Auth via **OIDC** (assumes `aquilla-main-component-publish`). **No ring promotion.**

## Tests
5 unit tests (`pytest -m unit`): name+version · manifest pins+runs artifact · images→digests · build stripped · input not mutated. Full `tests/unit` still collects (432).

## Depends on / pairs with
- **acorn-fleet PR #17** — creates the `aquilla-main-component-publish` OIDC role (ECR push + `CreateComponentVersion` + S3).

## GitHub setup to run it (per repo)
- `publish` **Environment** in aquilla-main
- Variables: `AWS_ACCOUNT_ID`, `ARTIFACTS_BUCKET` (the DeviceAccess artifacts bucket name)

## Known follow-up (am#359, not here)
The recipe is a first working shape. Running private-ECR images cleanly under Greengrass (DockerApplicationManager + TokenExchangeService deps / docker artifacts) is am#359's concern.

🤖 Generated with [Claude Code](https://claude.com/claude-code)