### PR TITLE
feat(greengrass): component-publish workflow + CLI glue (slice C)

### DIFF
--- a/.github/workflows/publish-component.yml
+++ b/.github/workflows/publish-component.yml
@@ -1,0 +1,84 @@
+name: publish-component
+
+# Builds the api+ui images, pushes them to ECR BY DIGEST, and publishes a new
+# Greengrass component version whose recipe pins those digests + a compose
+# artifact in S3. It does NOT promote to any ring — that is a separate,
+# human-gated step in acorn-fleet. Auth is GitHub OIDC; no static AWS keys.
+on:
+  push:
+    branches: [feat/greengrass-migration]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  id-token: write # mint the OIDC token to assume the publish role
+
+env:
+  AWS_REGION: us-east-2
+  COMPONENT_NAME: com.acorn.sentri
+  ECR_REGISTRY: ${{ vars.AWS_ACCOUNT_ID }}.dkr.ecr.us-east-2.amazonaws.com
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    environment: publish # pins the OIDC sub to repo:...:environment:publish
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - run: pip install pyyaml
+
+      - name: Assume the publish role via OIDC
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: arn:aws:iam::${{ vars.AWS_ACCOUNT_ID }}:role/aquilla-main-component-publish
+          aws-region: ${{ env.AWS_REGION }}
+      - name: Log in to ECR
+        uses: aws-actions/amazon-ecr-login@v2
+      - name: Set up Buildx
+        uses: docker/setup-buildx-action@v3
+
+      # Bake the git SHA as a tag; push returns the immutable digest we pin on.
+      - name: Build + push api image
+        id: api
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: docker/Dockerfile.api
+          push: true
+          tags: ${{ env.ECR_REGISTRY }}/aquilla-main-api:${{ github.sha }}
+      - name: Build + push ui image
+        id: ui
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: docker/Dockerfile.ui
+          push: true
+          tags: ${{ env.ECR_REGISTRY }}/aquilla-main-ui:${{ github.sha }}
+
+      - name: Version + artifact URI
+        id: meta
+        run: |
+          VERSION="0.0.${{ github.run_number }}"
+          ARTIFACT_URI="s3://${{ vars.ARTIFACTS_BUCKET }}/${COMPONENT_NAME}/${VERSION}/compose.yaml"
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "artifact_uri=$ARTIFACT_URI" >> "$GITHUB_OUTPUT"
+
+      - name: Generate pinned compose + recipe
+        run: |
+          python -m scripts.greengrass.publish \
+            --compose compose.yaml \
+            --api-ref "${ECR_REGISTRY}/aquilla-main-api@${{ steps.api.outputs.digest }}" \
+            --ui-ref  "${ECR_REGISTRY}/aquilla-main-ui@${{ steps.ui.outputs.digest }}" \
+            --component-name "$COMPONENT_NAME" \
+            --version "${{ steps.meta.outputs.version }}" \
+            --artifact-uri "${{ steps.meta.outputs.artifact_uri }}" \
+            --out-compose pinned-compose.yaml \
+            --out-recipe recipe.json
+
+      # Upload BEFORE publishing so the recipe's artifact is fetchable at deploy.
+      - name: Upload compose artifact
+        run: aws s3 cp pinned-compose.yaml "${{ steps.meta.outputs.artifact_uri }}"
+      - name: Publish Greengrass component version
+        run: aws greengrassv2 create-component-version --inline-recipe fileb://recipe.json --region "$AWS_REGION"

--- a/scripts/greengrass/publish.py
+++ b/scripts/greengrass/publish.py
@@ -1,0 +1,40 @@
+"""CLI glue for the component-publish workflow.
+
+Reads the authored compose, pins it to the freshly-built image digests, and
+emits the Greengrass recipe pointing at the compose artifact in S3. All the
+artifact-shaping logic is the tested pure functions in ``recipe.py`` — this only
+does argument plumbing and file IO, so the workflow can call one command.
+
+Run from the repo root:  python -m scripts.greengrass.publish --help
+"""
+import argparse
+import json
+from pathlib import Path
+
+import yaml
+
+from scripts.greengrass.recipe import build_recipe, pin_compose
+
+
+def main(argv=None):
+    p = argparse.ArgumentParser(description="Emit pinned compose + Greengrass recipe.")
+    p.add_argument("--compose", required=True, help="source compose.yaml")
+    p.add_argument("--api-ref", required=True, help="ECR digest ref for the api image")
+    p.add_argument("--ui-ref", required=True, help="ECR digest ref for the ui image")
+    p.add_argument("--component-name", required=True)
+    p.add_argument("--version", required=True)
+    p.add_argument("--artifact-uri", required=True, help="s3:// URI of the compose artifact")
+    p.add_argument("--out-compose", required=True, help="write the pinned compose here")
+    p.add_argument("--out-recipe", required=True, help="write the recipe JSON here")
+    args = p.parse_args(argv)
+
+    compose = yaml.safe_load(Path(args.compose).read_text())
+    pinned = pin_compose(compose, args.api_ref, args.ui_ref)
+    Path(args.out_compose).write_text(yaml.safe_dump(pinned, sort_keys=False))
+
+    recipe = build_recipe(args.component_name, args.version, args.artifact_uri)
+    Path(args.out_recipe).write_text(json.dumps(recipe, indent=2))
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Completes AcornGenetics/aquilla-main#358. The recipe module (slice A) already merged in #370; this adds the two pieces that were committed **after** #370 merged and never landed:

- **`scripts/greengrass/publish.py`** — thin CLI glue over the tested `pin_compose`/`build_recipe` (smoke-verified against the real `compose.yaml`).
- **`.github/workflows/publish-component.yml`** — on the migration branch: build api+ui (bake git SHA) → push to ECR → pin compose → upload to S3 → `greengrassv2 create-component-version`. OIDC auth (assumes `aquilla-main-component-publish`), **no ring promotion**.

Pairs with acorn-fleet **#17** (the publish OIDC role). GitHub setup to run: `publish` Environment + `AWS_ACCOUNT_ID` / `ARTIFACTS_BUCKET` vars.

🤖 Generated with [Claude Code](https://claude.com/claude-code)