### PR TITLE
feat(greengrass): component recipe runs the app under Greengrass (am#359)

### DIFF
--- a/.github/workflows/publish-component.yml
+++ b/.github/workflows/publish-component.yml
@@ -68,7 +68,7 @@ jobs:
       - name: Generate pinned compose + recipe
         run: |
           python -m scripts.greengrass.publish \
-            --compose compose.yaml \
+            --compose fleet-config/greengrass-compose.yaml \
             --api-ref "${ECR_REGISTRY}/aquilla-main-api@${{ steps.api.outputs.digest }}" \
             --ui-ref  "${ECR_REGISTRY}/aquilla-main-ui@${{ steps.ui.outputs.digest }}" \
             --component-name "$COMPONENT_NAME" \

--- a/fleet-config/greengrass-compose.yaml
+++ b/fleet-config/greengrass-compose.yaml
@@ -1,0 +1,50 @@
+# On-device app stack for the Greengrass component (com.acorn.sentri).
+#
+# A clean-room version of docker-compose.yml: same app stack, but the CI
+# publish workflow pins the images to ECR digests, Greengrass (not watchtower)
+# owns updates, and state lives on named volumes. Do NOT reintroduce watchtower
+# or the #314 host-DNS forwarding here — Greengrass manages the network.
+services:
+  backend:
+    image: aquilla-main-api
+    env_file: ${DEVICE_ENV_FILE:-/opt/aquila/config/device.env}
+    container_name: aquila-backend
+    ports:
+      - "8090:8090"
+    restart: unless-stopped
+    volumes:
+      - aquila-results:/opt/aquila/results
+      - aquila-logs:/opt/aquila/logs
+      - aquila-profiles:/opt/aquila/profiles
+      - aquila-config:/opt/aquila/config
+      # The sync outbox (completed runs not yet pushed) — must survive recreate.
+      - aquila-data:/opt/aquila/data
+
+  app:
+    image: aquilla-main-api
+    env_file: ${DEVICE_ENV_FILE:-/opt/aquila/config/device.env}
+    container_name: aquila-app
+    restart: unless-stopped
+    volumes:
+      - aquila-results:/opt/aquila/results
+      - aquila-logs:/opt/aquila/logs
+      - aquila-profiles:/opt/aquila/profiles
+      - aquila-config:/opt/aquila/config
+      - aquila-data:/opt/aquila/data
+
+  ui:
+    image: aquilla-main-ui
+    env_file: ${DEVICE_ENV_FILE:-/opt/aquila/config/device.env}
+    container_name: aquila-ui
+    ports:
+      - "8080:8080"
+    restart: unless-stopped
+
+# Persistent state lives in named volumes managed by the Docker engine — survives
+# container recreate on every Greengrass deployment, no host /opt binds needed.
+volumes:
+  aquila-results:
+  aquila-logs:
+  aquila-profiles:
+  aquila-config:
+  aquila-data:

--- a/scripts/greengrass/publish.py
+++ b/scripts/greengrass/publish.py
@@ -32,7 +32,12 @@ def main(argv=None):
     pinned = pin_compose(compose, args.api_ref, args.ui_ref)
     Path(args.out_compose).write_text(yaml.safe_dump(pinned, sort_keys=False))
 
-    recipe = build_recipe(args.component_name, args.version, args.artifact_uri)
+    recipe = build_recipe(
+        args.component_name,
+        args.version,
+        args.artifact_uri,
+        image_refs=[args.api_ref, args.ui_ref],
+    )
     Path(args.out_recipe).write_text(json.dumps(recipe, indent=2))
 
 

--- a/scripts/greengrass/recipe.py
+++ b/scripts/greengrass/recipe.py
@@ -18,28 +18,57 @@ def pin_compose(compose, api_ref, ui_ref):
     digest so a deployment is byte-for-byte the artifact CI published.
     """
     pinned = copy.deepcopy(compose)
-    for service, ref in (("backend", api_ref), ("ui", ui_ref)):
-        pinned["services"][service]["image"] = ref
-        pinned["services"][service].pop("build", None)
+    # backend and app run the api image; ui runs the ui image. Only touch the
+    # services a given compose actually defines.
+    refs = {"backend": api_ref, "app": api_ref, "ui": ui_ref}
+    for service, ref in refs.items():
+        if service in pinned["services"]:
+            pinned["services"][service]["image"] = ref
+            pinned["services"][service].pop("build", None)
     return pinned
 
 
-def build_recipe(component_name, version, compose_artifact_uri):
-    """Return the Greengrass recipe for a published component version."""
+def build_recipe(component_name, version, compose_artifact_uri, image_refs=None):
+    """Return the Greengrass recipe for a published component version.
+
+    ``image_refs`` are the ECR digest refs of the app images; when given, the
+    recipe depends on DockerApplicationManager so Greengrass pre-stages them.
+    """
     compose_file = compose_artifact_uri.rsplit("/", 1)[-1]
     compose_path = "{artifacts:path}/" + compose_file
-    return {
+    # The compose file plus one docker: artifact per app image so
+    # DockerApplicationManager pre-pulls them from ECR before the stack runs.
+    artifacts = [{"URI": compose_artifact_uri}]
+    for ref in image_refs or []:
+        artifacts.append({"URI": "docker:" + ref})
+    recipe = {
         "RecipeFormatVersion": RECIPE_FORMAT_VERSION,
         "ComponentName": component_name,
         "ComponentVersion": version,
+        # Greengrass pulls/pre-stages the ECR images (via the device's token
+        # exchange creds) before the compose stack runs.
+        "ComponentDependencies": {
+            "aws.greengrass.DockerApplicationManager": {
+                "VersionRequirement": ">=2.0.0",
+            },
+        },
         "Manifests": [
             {
                 "Platform": {"os": "linux"},
-                "Artifacts": [{"URI": compose_artifact_uri}],
+                "Artifacts": artifacts,
                 "Lifecycle": {
-                    "Run": "docker compose -f %s up -d" % compose_path,
+                    # Bring the stack up, then foreground a /health monitor: while
+                    # the app is healthy the component stays RUNNING; when /health
+                    # fails the loop exits non-zero and Greengrass marks the
+                    # component broken (feeds rollback in af#4).
+                    "Run": (
+                        "docker compose -f %s up -d && "
+                        "while curl -fsS http://localhost:8090/health >/dev/null; "
+                        "do sleep 30; done; exit 1" % compose_path
+                    ),
                     "Shutdown": "docker compose -f %s down" % compose_path,
                 },
             }
         ],
     }
+    return recipe

--- a/tests/fleet_device/test_greengrass_component.py
+++ b/tests/fleet_device/test_greengrass_component.py
@@ -1,0 +1,72 @@
+"""
+Static structure checks for the Greengrass on-device component.
+
+Like test_compose_config.py, these parse YAML/JSON without Docker or AWS — they
+assert the *shape* of the artifacts a Greengrass deployment runs, so a
+misconfiguration is caught before it reaches a device.
+
+The Greengrass compose is a clean-room version of the fleet compose: it runs the
+same app stack but drops watchtower and the #314 DNS hacks, and persists state on
+named volumes instead of host binds.
+
+Run with:
+    pytest tests/fleet_device/test_greengrass_component.py -v
+"""
+from pathlib import Path
+
+import pytest
+import yaml
+
+pytestmark = pytest.mark.unit
+
+GREENGRASS_COMPOSE = Path("fleet-config/greengrass-compose.yaml")
+
+
+def _load_compose() -> dict:
+    assert GREENGRASS_COMPOSE.exists(), f"{GREENGRASS_COMPOSE} not found"
+    return yaml.safe_load(GREENGRASS_COMPOSE.read_text())
+
+
+def test_runs_the_app_stack():
+    services = _load_compose().get("services", {})
+    for name in ("backend", "app", "ui"):
+        assert name in services, f"greengrass compose missing service: {name}"
+
+
+def test_has_no_watchtower():
+    compose = _load_compose()
+    # Greengrass owns updates now — no watchtower service, no enable labels.
+    assert "watchtower" not in compose.get("services", {})
+    blob = yaml.safe_dump(compose)
+    assert "watchtower" not in blob.lower(), "watchtower reference must be gone"
+
+
+def test_has_no_dns_hacks():
+    compose = _load_compose()
+    services = compose.get("services", {})
+    for name, svc in services.items():
+        assert "dns" not in svc, f"{name} still pins dns (the #314 host-DNS hack)"
+    # No hardcoded bridge IPs anywhere (the #314 forwarder gateway).
+    blob = yaml.safe_dump(compose)
+    assert "172.18.0.1" not in blob, "hardcoded bridge IP (#314 DNS hack) must be gone"
+
+
+def _sources(mounts):
+    out = []
+    for m in mounts or []:
+        out.append(m.split(":", 1)[0] if isinstance(m, str) else m.get("source", ""))
+    return out
+
+
+def test_persists_state_on_named_volumes():
+    compose = _load_compose()
+    named = compose.get("volumes") or {}
+    assert named, "no top-level named volumes defined"
+
+    backend = compose["services"]["backend"]
+    sources = _sources(backend.get("volumes"))
+    assert sources, "backend persists nothing"
+    # Named volumes, not host binds — Greengrass state must not depend on /opt paths.
+    for src in sources:
+        assert not src.startswith("/"), f"backend uses a host bind ({src}); use a named volume"
+        assert src in named, f"backend mounts '{src}' but it is not a declared named volume"

--- a/tests/unit/test_greengrass_recipe.py
+++ b/tests/unit/test_greengrass_recipe.py
@@ -11,6 +11,10 @@ Behaviors tested:
   2. build_recipe pins the compose artifact and runs it via a Lifecycle
   3. pin_compose rewrites the app images to the ECR digest refs
   4. pin_compose strips build sections (the device pulls, never builds)
+  5. build_recipe depends on DockerApplicationManager to pre-stage the images
+  6. build_recipe declares the app images as docker artifacts (pre-staged)
+  7. build_recipe reports the app /health as the component health
+  8. pin_compose also pins the app service (shares the api image)
 """
 import pytest
 
@@ -79,6 +83,16 @@ def test_pin_compose_strips_build_sections():
     assert "build" not in pinned["services"]["ui"]
 
 
+def test_pin_compose_also_pins_the_app_service():
+    compose = _device_compose()
+    compose["services"]["app"] = {"image": "ghcr.io/acorngenetics/aquilla-main-api:latest"}
+
+    pinned = pin_compose(compose, API_DIGEST, UI_DIGEST)
+
+    # app shares the api image, so it pins to the same digest as backend.
+    assert pinned["services"]["app"]["image"] == API_DIGEST
+
+
 def test_pin_compose_does_not_mutate_the_input():
     original = _device_compose()
     pin_compose(original, API_DIGEST, UI_DIGEST)
@@ -86,3 +100,32 @@ def test_pin_compose_does_not_mutate_the_input():
     # The authored compose is reused across builds — pinning must not clobber it.
     assert original["services"]["backend"]["image"].startswith("ghcr.io/")
     assert "build" in original["services"]["backend"]
+
+
+def _recipe_with_images():
+    return build_recipe(
+        "com.acorn.sentri",
+        "1.2.3",
+        "s3://acorn-artifacts/com.acorn.sentri/1.2.3/compose.yaml",
+        image_refs=[API_DIGEST, UI_DIGEST],
+    )
+
+
+def test_recipe_depends_on_docker_application_manager():
+    deps = _recipe_with_images()["ComponentDependencies"]
+    # Greengrass pre-stages the ECR images via DockerApplicationManager.
+    assert "aws.greengrass.DockerApplicationManager" in deps
+
+
+def test_recipe_declares_images_as_docker_artifacts():
+    artifacts = _recipe_with_images()["Manifests"][0]["Artifacts"]
+    uris = [a["URI"] for a in artifacts]
+    # docker: URIs tell DockerApplicationManager which images to pre-stage.
+    assert f"docker:{API_DIGEST}" in uris
+    assert f"docker:{UI_DIGEST}" in uris
+
+
+def test_recipe_reports_health_from_slash_health():
+    run = _recipe_with_images()["Manifests"][0]["Lifecycle"]["Run"]
+    # Component liveness is gated on the app's /health endpoint.
+    assert "/health" in run


### PR DESCRIPTION
Closes AcornGenetics/aquilla-main#359. Makes the published component (am#358) actually **runnable** under Greengrass. **Targets `feat/greengrass-migration`.**

## What
- **`fleet-config/greengrass-compose.yaml`** (new) — clean-room of the fleet compose: `backend`/`app`/`ui`, **named volumes** for persistence, **no watchtower**, **no #314 DNS hacks**. Kiosk (ADR-005) untouched.
- **`recipe.build_recipe`** — now depends on **`aws.greengrass.DockerApplicationManager`** (pre-stages the ECR images), declares each app image as a **`docker:` artifact**, and gates the Run lifecycle on the app **`/health`** (component goes broken when `/health` fails → the signal af#4 rolls back on).
- **`pin_compose`** — also pins the `app` service (shares the api image); tolerant of composes that omit a service.
- **workflow** — pins `greengrass-compose.yaml` and passes the image refs into the recipe.

## Tests (13, static — no Docker/AWS, prior art `tests/fleet_device`)
compose: runs backend/app/ui · no watchtower · no DNS hacks · named-volume persistence.
recipe: DockerApplicationManager dep · images as docker artifacts · `/health` health gate · app-service pinning.
Full `tests/fleet_device` + recipe suites green (29). End-to-end glue smoke-verified against the real compose.

## Out of scope (later issues)
matched-pair Container Health + operator gate (am#360), on-device watchtower disable/provisioning (am#361), IoT cert rotation (am#363).

🤖 Generated with [Claude Code](https://claude.com/claude-code)