### PR TITLE
feat(greengrass): matched-pair Container Health + operator gate (am#360)

### DIFF
--- a/aquila_web/main.py
+++ b/aquila_web/main.py
@@ -1251,12 +1251,32 @@ async def button_open():
     logger.info("Drawer reset pressed")
     return{"ok":True}
 
+from aquila_web.version_health import runs_allowed
+
+
+def _running_container_shas():
+    """(api_build_sha, ui_build_sha) of the running containers, or None if unknown.
+
+    Sourced from the baked build identity (am#365); unknown during migration, in
+    which case the run gate cannot enforce and allows the run.
+    """
+    return (os.getenv("RUNNING_BUILD_SHA"), os.getenv("RUNNING_BUILD_SHA_UI"))
+
+
 @app.post("/button/run")
 async def button_run():
     global run_requested, stop_requested
     run_requested = True
     stop_requested = False
     logger.info("Run button pressed")
+    # Matched-pair gate (am#360): never run a split-brain api/ui (the sn04 case).
+    if not runs_allowed(*_running_container_shas()):
+        run_requested = False
+        return {
+            "ok": False,
+            "message": "Update incomplete — the api and ui versions do not match. "
+            "Runs are blocked until the versions match.",
+        }
     if not selected_profile:
         run_requested = False
         return {"ok": False, "message": "Select a profile before running"}

--- a/aquila_web/version_health.py
+++ b/aquila_web/version_health.py
@@ -1,0 +1,62 @@
+"""Matched-pair Container Health + operator-gate logic for the Greengrass agent.
+
+Pure functions only (no Greengrass IPC, no FastAPI) so the run-gate, the shadow
+reporter, and the operator banner all share one source of truth. A Sentri's api
+and ui containers must run the SAME build; a mismatch is the sn04 failure mode
+and blocks runs (ADR-022 invariant A).
+"""
+
+
+def is_matched_pair(api_sha, ui_sha):
+    """True only when the api and ui containers run the same, known build.
+
+    Unknown identity (missing/empty SHA) fails safe as *not* matched, so a
+    container that has not reported blocks runs rather than passing silently.
+    """
+    return bool(api_sha) and api_sha == ui_sha
+
+
+def runs_allowed(api_sha, ui_sha):
+    """Whether an assay run may start, given the running container SHAs.
+
+    Blocks only a *known* mismatch (both SHAs present and different) — the sn04
+    case. Unknown identity (a SHA missing) cannot be enforced and must not brick
+    the instrument, so it is allowed. Distinct from is_matched_pair, which treats
+    unknown as "not matched" for honest Container-Health reporting.
+    """
+    if not api_sha or not ui_sha:
+        return True
+    return api_sha == ui_sha
+
+
+def build_shadow_report(api_sha, ui_sha):
+    """The Device-Shadow reported state: the running build SHAs + Container Health."""
+    return {
+        "images": {"api": api_sha, "ui": ui_sha},
+        "container_health": "matched" if is_matched_pair(api_sha, ui_sha) else "mismatched",
+    }
+
+
+def update_banner(last_update_failed):
+    """Operator notice when an update failed and the device kept the old version.
+
+    Non-blocking: a failed update rolls back to a working build, so the operator
+    keeps running — this only informs them a newer version did not take.
+    """
+    if not last_update_failed:
+        return None
+    return {
+        "level": "warning",
+        "blocking": False,
+        "message": "Last update failed — running the previous version.",
+    }
+
+
+def should_defer_update(assay_running, operator_approved):
+    """Whether to DeferComponentUpdate instead of switching now.
+
+    The image is pre-staged; the switch is held (deferred) until the device is
+    idle AND the operator has approved. So "Update" is instant when tapped, and a
+    running assay is never interrupted.
+    """
+    return assay_running or not operator_approved

--- a/tests/contract/test_run_version_gate.py
+++ b/tests/contract/test_run_version_gate.py
@@ -1,0 +1,32 @@
+"""
+Contract test: the run gate blocks an assay when the api/ui containers run
+different builds (am#360 — the sn04 matched-pair invariant), and does not block
+when they match.
+
+Uses the FastAPI TestClient; the running container SHAs are injected via
+_running_container_shas so the test controls the version state without hardware.
+"""
+import pytest
+
+from aquila_web import main as web_main
+
+pytestmark = pytest.mark.contract
+
+
+def test_run_blocked_on_version_mismatch(client, monkeypatch):
+    monkeypatch.setattr(web_main, "_running_container_shas", lambda: ("api-OLD", "ui-NEW"))
+
+    body = client.post("/button/run").json()
+
+    assert body["ok"] is False
+    assert "match" in body["message"].lower()  # blocked for the version reason
+
+
+def test_run_not_blocked_for_version_when_matched(client, monkeypatch):
+    monkeypatch.setattr(web_main, "_running_container_shas", lambda: ("same-sha", "same-sha"))
+
+    body = client.post("/button/run").json()
+
+    # A matched pair is never blocked for a version reason (it may still fail an
+    # unrelated precondition like "select a profile").
+    assert "do not match" not in body.get("message", "").lower()

--- a/tests/unit/test_version_health.py
+++ b/tests/unit/test_version_health.py
@@ -1,0 +1,96 @@
+"""
+Unit tests for the matched-pair Container Health logic (am#360).
+
+A Sentri runs an api container and a ui container. They must come from the SAME
+build — a mismatch (api updated, ui stale, or vice-versa) is the sn04 failure
+mode and must block runs. These are pure functions over the two running build
+SHAs, so they carry no Greengrass/IPC dependency.
+
+Run with:
+    pytest tests/unit/test_version_health.py -v
+"""
+import pytest
+
+pytestmark = pytest.mark.unit
+
+from aquila_web.version_health import (
+    build_shadow_report,
+    is_matched_pair,
+    runs_allowed,
+    should_defer_update,
+    update_banner,
+)
+
+
+@pytest.mark.parametrize(
+    "api_sha, ui_sha, expected",
+    [
+        ("abc123", "abc123", True),   # same build → matched
+        ("abc123", "def456", False),  # different builds → mismatch (sn04)
+    ],
+)
+def test_is_matched_pair(api_sha, ui_sha, expected):
+    assert is_matched_pair(api_sha, ui_sha) is expected
+
+
+@pytest.mark.parametrize(
+    "api_sha, ui_sha",
+    [
+        (None, None),      # neither reported → unknown, must block
+        ("abc123", None),  # ui not reported yet
+        (None, "abc123"),  # api not reported yet
+        ("", ""),          # empty is not a real build id
+    ],
+)
+def test_missing_sha_is_not_a_matched_pair(api_sha, ui_sha):
+    # Unknown identity must never read as "matched" — fail safe, block runs.
+    assert is_matched_pair(api_sha, ui_sha) is False
+
+
+def test_shadow_report_carries_shas_and_matched_health():
+    report = build_shadow_report("abc123", "abc123")
+    assert report["images"] == {"api": "abc123", "ui": "abc123"}
+    assert report["container_health"] == "matched"
+
+
+def test_shadow_report_flags_mismatch():
+    report = build_shadow_report("abc123", "def456")
+    assert report["container_health"] == "mismatched"
+
+
+def test_failed_update_shows_non_blocking_banner():
+    banner = update_banner(last_update_failed=True)
+    assert banner is not None
+    assert banner["blocking"] is False  # informational — the operator can still run
+    assert "previous version" in banner["message"].lower()
+
+
+def test_no_banner_when_update_healthy():
+    assert update_banner(last_update_failed=False) is None
+
+
+@pytest.mark.parametrize(
+    "assay_running, operator_approved, expected_defer",
+    [
+        (True, True, True),    # never switch mid-run, even if approved
+        (True, False, True),   # running + not approved → defer
+        (False, False, True),  # idle but waiting on the operator gate → defer
+        (False, True, False),  # idle AND approved → apply the pre-staged switch
+    ],
+)
+def test_should_defer_update(assay_running, operator_approved, expected_defer):
+    assert should_defer_update(assay_running, operator_approved) is expected_defer
+
+
+@pytest.mark.parametrize(
+    "api_sha, ui_sha, allowed",
+    [
+        ("abc123", "abc123", True),   # matched → allow (incl. a matched older build)
+        ("abc123", "def456", False),  # KNOWN mismatch → block (sn04)
+        (None, "abc123", True),       # unknown identity → allow, never brick
+        ("abc123", None, True),
+        (None, None, True),
+    ],
+)
+def test_runs_allowed(api_sha, ui_sha, allowed):
+    assert runs_allowed(api_sha, ui_sha) is allowed


### PR DESCRIPTION
Closes AcornGenetics/aquilla-main#360. The device-side safety logic for the two-gate update model. **Targets `feat/greengrass-migration`.**

## What (all pure + testable — `aquila_web/version_health.py`)
- **`is_matched_pair(api, ui)`** — the sn04 invariant: matched only when both SHAs are present and equal; unknown fails safe to *not matched* (honest Container-Health reporting). Table-tested.
- **`runs_allowed(api, ui)`** — the run gate: blocks a **known** mismatch, but **allows unknown** identity so a migrating device is never bricked. Wired into **`POST /button/run`**.
- **`build_shadow_report(api, ui)`** — Device-Shadow reported state (both SHAs + `container_health: matched|mismatched`).
- **`update_banner(failed)`** — non-blocking "running the previous version" operator notice.
- **`should_defer_update(assay_running, operator_approved)`** — `DeferComponentUpdate` decision: hold the pre-staged switch until idle **and** operator-approved (so "Update" is instant and never interrupts a run).

## Tests (21)
19 unit (matched-pair + missing-SHA table, shadow report, banner, defer table, runs_allowed table) + 2 contract (run **blocked** on mismatch via `/button/run`, **allowed** when matched).

## Not in this PR (on-device glue, per plan)
The Greengrass IPC adapter — actually publishing the shadow and subscribing to component updates to call `DeferComponentUpdate` — lands with provisioning (am#361), where Greengrass runs on a real Sentri. This PR is the tested decision logic it will call. `_running_container_shas()` reads baked build identity (am#365); unknown today → gate allows.

Note: ~19 pre-existing failures on this branch (optics plotting, profile filtering) are unrelated — they fail identically without this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)