### PR TITLE
fix(greengrass): deployment3 onboarding fixes (endpoints, perms, Phase 10/11)

### DIFF
--- a/scripts/deploy/deployment3_greengrass.sh
+++ b/scripts/deploy/deployment3_greengrass.sh
@@ -661,6 +661,10 @@ AWS_REGION="${AWS_REGION:-us-east-2}"
 GG_ROLE_ALIAS="${GG_ROLE_ALIAS:-acorn-sentri-tes}"   # Token Exchange role alias (ECR pulls)
 GG_THING_GROUP="${GG_THING_GROUP:-holding}"          # JITP lands new Sentris here
 GG_ROOT="/greengrass/v2"
+# Account IoT endpoints (from `aws iot describe-endpoint`). The Pi has no AWS creds
+# to look these up, so they are baked in here (env-overridable for other accounts).
+GG_IOT_DATA_ENDPOINT="${GG_IOT_DATA_ENDPOINT:-a2xt0nylntrpe0-ats.iot.us-east-2.amazonaws.com}"
+GG_IOT_CRED_ENDPOINT="${GG_IOT_CRED_ENDPOINT:-c1mnxdemzipv8n.credentials.iot.us-east-2.amazonaws.com}"
 
 # The nucleus is a Java app; install a headless JRE + unzip for the installer.
 DEBIAN_FRONTEND=noninteractive apt-get install -y default-jre-headless unzip
@@ -689,6 +693,8 @@ services:
     configuration:
       awsRegion: "${AWS_REGION}"
       iotRoleAlias: "${GG_ROLE_ALIAS}"
+      iotDataEndpoint: "${GG_IOT_DATA_ENDPOINT}"
+      iotCredEndpoint: "${GG_IOT_CRED_ENDPOINT}"
 EOF
 
 java -Droot="${GG_ROOT}" -Dlog.store=FILE \

--- a/scripts/deploy/deployment3_greengrass.sh
+++ b/scripts/deploy/deployment3_greengrass.sh
@@ -806,13 +806,12 @@ phase_start 10 "App Stack Ownership (Greengrass)"
 
 # Under Greengrass the com.acorn.sentri component runs `docker compose up` from
 # its recipe, so the host must NOT also run the stack — a second owner would race
-# the component (double up/down, port clashes). Remove any legacy host compose
-# service left by deployment2 so greengrass.service is the sole stack owner.
-if systemctl list-unit-files | grep -q '^aquila-stack.service'; then
-    systemctl disable --now aquila-stack.service || true
-    rm -f /etc/systemd/system/aquila-stack.service
-    systemctl daemon-reload
-fi
+# the component (double up/down, port clashes). Unconditionally remove any legacy
+# host compose service left by deployment2 so greengrass.service is the sole owner.
+# (disable is best-effort; the rm is what the check below verifies.)
+systemctl disable --now aquila-stack.service 2>/dev/null || true
+rm -f /etc/systemd/system/aquila-stack.service
+systemctl daemon-reload
 
 run_test "no host compose service" "! test -f /etc/systemd/system/aquila-stack.service"
 

--- a/tests/fleet_device/test_deployment3_greengrass_script.py
+++ b/tests/fleet_device/test_deployment3_greengrass_script.py
@@ -35,6 +35,13 @@ def test_configures_role_alias_region_and_holding_ring():
     assert "holding" in SCRIPT            # JITP lands the Thing here
 
 
+def test_configures_iot_endpoints():
+    # Manual provisioning must be told the account's IoT data + credential
+    # endpoints — the Pi has no AWS creds to look them up itself.
+    assert "iotDataEndpoint" in SCRIPT
+    assert "iotCredEndpoint" in SCRIPT
+
+
 def test_watchtower_ota_path_removed():
     # No Watchtower updater, no manual GHCR compose pull for delivery.
     assert "fleet-update.sh" not in SCRIPT


### PR DESCRIPTION
The set of `deployment3_greengrass.sh` fixes found bringing the first real device (sn01) up under Greengrass. **Targets `feat/greengrass-migration`.**

- **IoT endpoints** — manual provisioning needs `iotDataEndpoint`/`iotCredEndpoint` (the Pi has no AWS creds to look them up); baked in, env-overridable. Without them the nucleus can't connect.
- **Phase 10** — unconditionally remove the legacy `aquila-stack.service` (the guarded `list-unit-files` check missed a stale file → Phase 10 failed on sn01).
- **ggc_user access** — the component runs as `ggc_user`, which needs the Docker socket + readable `device.env` or it goes `BROKEN`. Add `usermod -aG docker ggc_user` + `device.env → ggc_group 640`.
- **Meerstetter tuning removed** — it needs the running app container (owned by the Greengrass component), so it can't run at provisioning time. The Phase 11 app-up check is now informational (the app starts when a ring deployment lands).

All verified live on sn01 — it now runs the app under Greengrass, `/health` OK. deployment3 tests: 10; deployment2 untouched (11); `bash -n` clean.