### PR TITLE
feat(greengrass): recipe depends on TokenExchangeService

### DIFF
--- a/scripts/greengrass/recipe.py
+++ b/scripts/greengrass/recipe.py
@@ -46,9 +46,14 @@ def build_recipe(component_name, version, compose_artifact_uri, image_refs=None)
         "ComponentName": component_name,
         "ComponentVersion": version,
         # Greengrass pulls/pre-stages the ECR images (via the device's token
-        # exchange creds) before the compose stack runs.
+        # exchange creds) before the compose stack runs. TokenExchangeService is
+        # what mints those creds from the device cert — required for private ECR,
+        # and as a dependency it ships with every deployment (no per-ring add).
         "ComponentDependencies": {
             "aws.greengrass.DockerApplicationManager": {
+                "VersionRequirement": ">=2.0.0",
+            },
+            "aws.greengrass.TokenExchangeService": {
                 "VersionRequirement": ">=2.0.0",
             },
         },

--- a/tests/unit/test_greengrass_recipe.py
+++ b/tests/unit/test_greengrass_recipe.py
@@ -117,6 +117,13 @@ def test_recipe_depends_on_docker_application_manager():
     assert "aws.greengrass.DockerApplicationManager" in deps
 
 
+def test_recipe_depends_on_token_exchange_service():
+    deps = _recipe_with_images()["ComponentDependencies"]
+    # Private ECR pulls require the Token Exchange Service; as a recipe dependency
+    # every deployment includes it automatically (no manual add per ring).
+    assert "aws.greengrass.TokenExchangeService" in deps
+
+
 def test_recipe_declares_images_as_docker_artifacts():
     artifacts = _recipe_with_images()["Manifests"][0]["Artifacts"]
     uris = [a["URI"] for a in artifacts]


### PR DESCRIPTION
Bringing sn01 up, every Greengrass deployment failed until `aws.greengrass.TokenExchangeService` was added to the deployment by hand (private ECR pulls need it to mint creds from the device cert).

This declares it as a **recipe dependency** on `com.acorn.sentri`, so it ships with **every** deployment automatically — no per-ring manual add. Pairs with the existing `DockerApplicationManager` dependency.

Once merged + re-published, a plain `com.acorn.sentri:<ver>` deployment to any ring will self-include TES. 1 new unit test; recipe suite green (10).

🤖 Generated with [Claude Code](https://claude.com/claude-code)