### PR TITLE
fix(greengrass): arm64-only publish + separate CI version lane

### DIFF
--- a/.github/workflows/publish-component.yml
+++ b/.github/workflows/publish-component.yml
@@ -42,15 +42,17 @@ jobs:
       - name: Set up Buildx
         uses: docker/setup-buildx-action@v3
 
-      # Multi-arch: the Sentri is arm64, CI/dev is amd64. push returns the
-      # manifest-list digest we pin on (the device resolves its own arch from it).
+      # arm64 only — the whole fleet is arm64 Raspberry Pis; the published images
+      # are consumed only by Greengrass, never run on amd64. (Local dev builds
+      # from source for its own arch, so this doesn't affect it.) push returns the
+      # image digest we pin on.
       - name: Build + push api image
         id: api
         uses: docker/build-push-action@v6
         with:
           context: .
           file: docker/Dockerfile.api
-          platforms: linux/amd64,linux/arm64
+          platforms: linux/arm64
           push: true
           tags: ${{ env.ECR_REGISTRY }}/aquilla-main-api:${{ github.sha }}
       - name: Build + push ui image
@@ -59,14 +61,17 @@ jobs:
         with:
           context: .
           file: docker/Dockerfile.ui
-          platforms: linux/amd64,linux/arm64
+          platforms: linux/arm64
           push: true
           tags: ${{ env.ECR_REGISTRY }}/aquilla-main-ui:${{ github.sha }}
 
       - name: Version + artifact URI
         id: meta
         run: |
-          VERSION="0.0.${{ github.run_number }}"
+          # CI publishes in the 0.1.x lane so ad-hoc/hotfix versions (0.0.x, made
+          # by hand outside CI) can never collide with CI's run-number scheme —
+          # the ConflictException that failed run #11 (0.0.11 already existed).
+          VERSION="0.1.${{ github.run_number }}"
           ARTIFACT_URI="s3://${{ vars.ARTIFACTS_BUCKET }}/${COMPONENT_NAME}/${VERSION}/compose.yaml"
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
           echo "artifact_uri=$ARTIFACT_URI" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
## Why the publish failed
`ConflictException: Component [com.acorn.sentri : 0.0.11] already exists`. The workflow names versions `0.0.<github.run_number>`; run #11 tried `0.0.11`, which **already existed** because I published `0.0.11` **by hand** (a recipe-only hotfix to recover sn01). CI's auto-numbering collided with an out-of-band version.

## Changes
1. **Version lane** — CI now publishes `0.1.<run_number>` (was `0.0.<run_number>`). Ad-hoc/hotfix versions stay in `0.0.x`; CI owns `0.1.x`; they can't collide. `0.1.x` > all existing `0.0.x`, so Greengrass still sees CI versions as newest.
2. **arm64-only** — dropped `linux/amd64` from both builds. The fleet is 100% arm64 Pis and the published images are consumed only by Greengrass; local dev builds from source for its own arch, so this doesn't touch it. Smaller/faster build. (QEMU stays — GitHub runners are amd64, so cross-building arm64 still needs it.)

## After merge
Merge auto-triggers a publish → the next version is `0.1.<run_number>` (arm64). Deploy that to `sandbox` (revise the existing deployment). Pairs with #380 (the 25s health-gate buffer).

🤖 Generated with [Claude Code](https://claude.com/claude-code)