### PR TITLE
feat(greengrass): operator update-gate + shadow agent (Part of am#382)

### DIFF
--- a/aquila_web/greengrass_ipc.py
+++ b/aquila_web/greengrass_ipc.py
@@ -1,0 +1,88 @@
+"""On-device Greengrass Core IPC adapter for the update agent (am#382, Phase 2).
+
+Thin wrapper over ``awsiot.greengrasscoreipc`` — imported lazily so this module
+loads fine off-device (CI, local dev, tests). The testable orchestration lives in
+update_agent.py / update_gate.py; this is the adapter that only means anything on
+a real Sentri under Greengrass, and is verified there (not in unit tests).
+
+Wiring on the device:
+    start_update_agent(gate, running_shas, assay_running)
+brings up the IPC client, subscribes to component updates (deferring per the gate),
+and publishes the Device Shadow on an interval.
+"""
+import json
+import os
+import threading
+import time
+
+
+class GreengrassIpc:
+    """Real Greengrass Core IPC — defer component updates + publish the shadow."""
+
+    def __init__(self, thing_name=None):
+        import awsiot.greengrasscoreipc.clientv2 as clientv2
+
+        self._client = clientv2.GreengrassCoreIPCClientV2()
+        self._thing_name = thing_name or os.environ["AWS_IOT_THING_NAME"]
+
+    def defer_component_update(self, deployment_id, recheck_after_ms=30000):
+        # Hold the switch; Greengrass re-offers after recheck_after_ms so the gate
+        # is polled again (operator may approve / the assay may finish by then).
+        self._client.defer_component_update(
+            deployment_id=deployment_id, recheck_after_ms=recheck_after_ms
+        )
+
+    def update_thing_shadow(self, payload):
+        # Classic (unnamed) shadow, so Fleet Indexing (REGISTRY_AND_SHADOW) indexes
+        # it without a named-shadow filter change.
+        self._client.update_thing_shadow(
+            thing_name=self._thing_name,
+            shadow_name="",
+            payload=json.dumps({"state": {"reported": payload}}).encode(),
+        )
+
+    def subscribe_to_component_updates(self, on_pre_update):
+        # PreComponentUpdateEvent carries the deploymentId; the handler decides
+        # whether to defer. Returns after establishing the stream.
+        self._client.subscribe_to_component_updates(
+            on_stream_event=lambda ev: (
+                on_pre_update(ev.pre_update_event.deployment_id)
+                if getattr(ev, "pre_update_event", None)
+                else None
+            )
+        )
+
+
+def start_update_agent(gate, running_shas, assay_running, publish_interval_s=60):
+    """Bring up the on-device agent: defer-gate on updates + periodic shadow publish.
+
+    Best-effort — if Greengrass IPC isn't available (off-device), it logs and
+    returns without starting, so it never breaks a non-Greengrass boot.
+    """
+    from aquila_web.update_agent import UpdateAgent
+
+    try:
+        ipc = GreengrassIpc()
+    except Exception as e:  # noqa: BLE001 - off-device / IPC unavailable is fine
+        import logging
+
+        logging.getLogger(__name__).info("Greengrass IPC unavailable, agent not started: %s", e)
+        return None
+
+    agent = UpdateAgent(ipc, gate, running_shas, assay_running)
+    # Defer/apply each offered update via the gate.
+    ipc.subscribe_to_component_updates(
+        lambda deployment_id: agent.handle_update_offer(deployment_id, deployment_id)
+    )
+
+    # Report health (running SHAs + Container Health) on an interval.
+    def _publish_loop():
+        while True:
+            try:
+                agent.publish_health()
+            except Exception:  # noqa: BLE001 - a transient IPC error must not kill the loop
+                pass
+            time.sleep(publish_interval_s)
+
+    threading.Thread(target=_publish_loop, daemon=True).start()
+    return agent

--- a/aquila_web/main.py
+++ b/aquila_web/main.py
@@ -2169,6 +2169,22 @@ async def _do_check_update() -> None:
         _update_error = str(e)
 
 
+from aquila_web import update_gate
+
+
+@app.get("/update/gate")
+async def get_update_gate():
+    """The operator apply-gate state (Greengrass pre-download-then-deferred-switch)."""
+    return update_gate.GATE.status()
+
+
+@app.post("/update/approve")
+async def approve_update_gate():
+    """The 'Update' button: release the deferred switch for the pending version."""
+    update_gate.GATE.approve()
+    return update_gate.GATE.status()
+
+
 @app.get("/update/status")
 async def get_update_status():
     available = _update_available
@@ -2386,3 +2402,17 @@ async def start_background_update_poller() -> None:
 @app.on_event("startup")
 async def start_background_sync_poller() -> None:
     asyncio.create_task(_background_sync_poller())
+
+
+@app.on_event("startup")
+async def start_greengrass_update_agent() -> None:
+    """Bring up the operator update-gate agent (am#382): defer offered updates
+    until the operator approves + no assay runs, and publish the Device Shadow.
+    No-ops off-device (Greengrass IPC unavailable) so local/dev boots are unaffected."""
+    from aquila_web.greengrass_ipc import start_update_agent
+
+    start_update_agent(
+        update_gate.GATE,
+        running_shas=_running_container_shas,
+        assay_running=lambda: current_item.screen == "running",
+    )

--- a/aquila_web/update_agent.py
+++ b/aquila_web/update_agent.py
@@ -1,0 +1,31 @@
+"""Greengrass update agent (am#382, Phase 2).
+
+Wires the tested decisions (UpdateGate + version_health) to Greengrass Core IPC:
+- defers an offered component update until the operator approves AND no assay runs
+- publishes the Device Shadow (running SHAs + matched-pair Container Health)
+
+The IPC client is injected — the real greengrasscoreipc adapter is used on-device;
+tests pass a fake. This module holds no IPC specifics, only the orchestration.
+"""
+from aquila_web.version_health import build_shadow_report
+
+
+class UpdateAgent:
+    def __init__(self, ipc, gate, running_shas, assay_running):
+        self._ipc = ipc
+        self._gate = gate
+        self._running_shas = running_shas
+        self._assay_running = assay_running
+
+    def handle_update_offer(self, deployment_id, version):
+        """Greengrass offers `version` — hold it until idle AND operator-approved."""
+        self._gate.mark_pending(version)
+        if not self._gate.should_apply(self._assay_running()):
+            self._ipc.defer_component_update(deployment_id)
+            return "deferred"
+        return "applied"
+
+    def publish_health(self):
+        """Report the running build SHAs + Container Health to the Device Shadow."""
+        api_sha, ui_sha = self._running_shas()
+        self._ipc.update_thing_shadow(build_shadow_report(api_sha, ui_sha))

--- a/aquila_web/update_gate.py
+++ b/aquila_web/update_gate.py
@@ -1,0 +1,52 @@
+"""On-device operator update-gate (am#382).
+
+Holds the operator-approval state for the pre-download-then-deferred-switch
+model: Greengrass offers an update, the device holds the switch until the
+operator approves, and the switch only applies when idle. Pure in-process state
+built on the tested version_health decisions — the Phase-2 Greengrass IPC agent
+reads it to decide whether to DeferComponentUpdate.
+"""
+from aquila_web.version_health import should_defer_update, update_banner
+
+
+class UpdateGate:
+    def __init__(self):
+        self._pending_version = None
+        self._approved = False
+        self._last_update_failed = False
+
+    def mark_pending(self, version):
+        """Greengrass has offered `version`. A *new* version needs fresh approval;
+        a re-offer of the same version (each defer recheck) keeps the approval."""
+        if version != self._pending_version:
+            self._approved = False
+        self._pending_version = version
+
+    def mark_update_failed(self):
+        """Record that the last update did not take (running the previous version)."""
+        self._last_update_failed = True
+
+    def approve(self):
+        """The operator tapped Update — release the deferred switch."""
+        self._approved = True
+
+    def should_apply(self, assay_running):
+        """Apply the pre-staged switch only when idle AND operator-approved."""
+        if self._pending_version is None:
+            return False
+        return not should_defer_update(assay_running, self._approved)
+
+    def status(self):
+        """Operator-facing gate state (served to the UI)."""
+        return {
+            "pending": self._pending_version is not None,
+            "target_version": self._pending_version,
+            "approved": self._approved,
+            "banner": update_banner(self._last_update_failed),
+        }
+
+
+# Process-wide gate shared by the FastAPI endpoints and the Phase-2 Greengrass IPC
+# agent (which runs in the same process). Reference as `update_gate.GATE` so it
+# stays swappable in tests.
+GATE = UpdateGate()

--- a/tests/contract/test_update_gate_endpoints.py
+++ b/tests/contract/test_update_gate_endpoints.py
@@ -1,0 +1,33 @@
+"""
+Contract test: the operator update-gate endpoints (am#382).
+
+GET /update/gate reports the pre-staged-update state; POST /update/approve is the
+"Update" button that releases the deferred switch. Uses the shared UpdateGate the
+Phase-2 Greengrass IPC agent also reads.
+"""
+import pytest
+
+from aquila_web import update_gate
+
+pytestmark = pytest.mark.contract
+
+
+@pytest.fixture(autouse=True)
+def _fresh_gate():
+    update_gate.GATE = update_gate.UpdateGate()
+    yield
+    update_gate.GATE = update_gate.UpdateGate()
+
+
+def test_approve_button_records_operator_approval(client):
+    # Greengrass offers an update (what the IPC agent will do on the device).
+    update_gate.GATE.mark_pending("0.1.20")
+
+    assert client.get("/update/gate").json()["approved"] is False
+
+    client.post("/update/approve")  # operator taps "Update"
+
+    body = client.get("/update/gate").json()
+    assert body["approved"] is True
+    assert body["pending"] is True
+    assert body["target_version"] == "0.1.20"

--- a/tests/unit/test_update_agent.py
+++ b/tests/unit/test_update_agent.py
@@ -1,0 +1,86 @@
+"""
+Unit tests for the Greengrass update agent (am#382, Phase 2).
+
+The agent wires the tested decisions (UpdateGate + version_health) to Greengrass
+Core IPC. The IPC client is injected so the agent's behaviour is testable with a
+fake — the real greengrasscoreipc client is a thin adapter used only on-device.
+
+Run with:
+    pytest tests/unit/test_update_agent.py -v
+"""
+import pytest
+
+pytestmark = pytest.mark.unit
+
+from aquila_web.update_agent import UpdateAgent
+from aquila_web.update_gate import UpdateGate
+
+
+class FakeIpc:
+    def __init__(self):
+        self.deferred = []
+        self.shadows = []
+
+    def defer_component_update(self, deployment_id, recheck_after_ms=None):
+        self.deferred.append(deployment_id)
+
+    def update_thing_shadow(self, payload):
+        self.shadows.append(payload)
+
+
+def test_defers_an_update_the_operator_has_not_approved():
+    ipc = FakeIpc()
+    agent = UpdateAgent(
+        ipc,
+        gate=UpdateGate(),
+        running_shas=lambda: ("abc", "abc"),
+        assay_running=lambda: False,
+    )
+
+    action = agent.handle_update_offer("deploy-1", "0.1.20")
+
+    assert action == "deferred"
+    assert ipc.deferred == ["deploy-1"]
+
+
+def test_applies_on_re_offer_once_the_operator_approves():
+    ipc = FakeIpc()
+    gate = UpdateGate()
+    agent = UpdateAgent(
+        ipc, gate, running_shas=lambda: ("a", "a"), assay_running=lambda: False
+    )
+
+    agent.handle_update_offer("deploy-1", "0.1.20")  # 1st offer → deferred (unapproved)
+    gate.approve()  # operator taps "Update"
+    action = agent.handle_update_offer("deploy-1", "0.1.20")  # Greengrass re-offers
+
+    assert action == "applied"
+    assert ipc.deferred == ["deploy-1"]  # only the first was deferred
+
+
+def test_defers_during_an_assay_even_when_approved():
+    ipc = FakeIpc()
+    gate = UpdateGate()
+    agent = UpdateAgent(
+        ipc, gate, running_shas=lambda: ("a", "a"), assay_running=lambda: True
+    )
+    gate.mark_pending("0.1.20")
+    gate.approve()
+
+    action = agent.handle_update_offer("deploy-1", "0.1.20")
+
+    assert action == "deferred"  # never interrupt a run
+
+
+def test_publish_health_reports_matched_pair_to_the_shadow():
+    ipc = FakeIpc()
+    agent = UpdateAgent(
+        ipc, UpdateGate(), running_shas=lambda: ("sha1", "sha1"), assay_running=lambda: False
+    )
+
+    agent.publish_health()
+
+    assert len(ipc.shadows) == 1
+    report = ipc.shadows[0]
+    assert report["images"] == {"api": "sha1", "ui": "sha1"}
+    assert report["container_health"] == "matched"

--- a/tests/unit/test_update_gate.py
+++ b/tests/unit/test_update_gate.py
@@ -1,0 +1,88 @@
+"""
+Unit tests for the operator update-gate (am#382).
+
+The gate holds the on-device operator-approval state for the pre-download-then-
+deferred-switch model: Greengrass offers an update (mark_pending), the device
+holds the switch until the operator approves (approve), and only then — and only
+when no assay is running — does the switch apply. Pure in-process state built on
+the tested version_health decisions.
+
+Run with:
+    pytest tests/unit/test_update_gate.py -v
+"""
+import pytest
+
+pytestmark = pytest.mark.unit
+
+from aquila_web.update_gate import UpdateGate
+
+
+def test_approved_pending_update_applies_when_idle():
+    gate = UpdateGate()
+    gate.mark_pending("0.1.20")
+    gate.approve()
+
+    # Idle + approved + a pending update → apply the pre-staged switch.
+    assert gate.should_apply(assay_running=False) is True
+
+
+def test_never_applies_during_an_assay_even_if_approved():
+    gate = UpdateGate()
+    gate.mark_pending("0.1.20")
+    gate.approve()
+
+    assert gate.should_apply(assay_running=True) is False
+
+
+def test_does_not_apply_until_the_operator_approves():
+    gate = UpdateGate()
+    gate.mark_pending("0.1.20")
+
+    assert gate.should_apply(assay_running=False) is False
+
+
+def test_a_newer_pending_update_requires_fresh_approval():
+    gate = UpdateGate()
+    gate.mark_pending("0.1.20")
+    gate.approve()
+
+    gate.mark_pending("0.1.21")  # a newer version supersedes — re-approve required
+    assert gate.should_apply(assay_running=False) is False
+
+
+def test_re_offering_the_same_version_keeps_approval():
+    gate = UpdateGate()
+    gate.mark_pending("0.1.20")
+    gate.approve()
+
+    # Greengrass re-offers the same version after each defer — must not reset approval.
+    gate.mark_pending("0.1.20")
+    assert gate.should_apply(assay_running=False) is True
+
+
+def test_nothing_to_apply_when_no_update_pending():
+    assert UpdateGate().should_apply(assay_running=False) is False
+
+
+def test_status_reports_pending_and_approval():
+    gate = UpdateGate()
+    assert gate.status()["pending"] is False
+
+    gate.mark_pending("0.1.20")
+    s = gate.status()
+    assert s["pending"] is True
+    assert s["target_version"] == "0.1.20"
+    assert s["approved"] is False
+
+    gate.approve()
+    assert gate.status()["approved"] is True
+
+
+def test_status_carries_a_non_blocking_banner_after_a_failed_update():
+    gate = UpdateGate()
+    assert gate.status()["banner"] is None
+
+    gate.mark_update_failed()
+    banner = gate.status()["banner"]
+    assert banner is not None
+    assert banner["blocking"] is False  # informational — the operator can still run


### PR DESCRIPTION
**Part of** AcornGenetics/aquilla-main#382 (not Closes — UI + on-device verification remain). Builds the device agent that #360 specified but #373 didn't implement.

## What's here (tested)
- **`UpdateGate`** — operator-approval state machine for pre-download-then-deferred-switch: `mark_pending`/`approve`, applies only when **idle AND approved**, a **re-offer of the same version keeps approval** (Greengrass re-offers after each defer), banner after a failed update. Built on the tested `version_health` decisions.
- **`UpdateAgent`** — defers an offered component update until the gate allows; publishes the Device Shadow (SHAs + matched-pair Container Health). **IPC client injected** → orchestration unit-tested with a fake.
- **Endpoints** — `GET /update/gate`, `POST /update/approve` (the **Update button**'s backend).
- **`greengrass_ipc.py`** — the real Core IPC adapter (lazy `awsiot.greengrasscoreipc` import) + `start_update_agent` wired into app startup. **No-ops off-device**, so local/CI/dev boots are unaffected (verified).

## Tests — 13 new
gate 8 · agent 4 · endpoint contract 1. Full operator-gate + related suites green (45).

## Remaining for #382 (on-device / frontend, needs a Sentri)
- ShadowManager component + sync config so the shadow publish reaches the cloud (the defer/gate path needs no recipe change; component-update IPC requires no authorization policy).
- The UI **Update** button + non-blocking banner (frontend, on top of these endpoints).
- Live verification on sn01.

## AWS
No new AWS account changes — the device policy already has shadow perms; component-update IPC needs none.

🤖 Generated with [Claude Code](https://claude.com/claude-code)