### PR TITLE
fix(greengrass): restore PCR hardware access in the on-device compose

### DIFF
--- a/fleet-config/greengrass-compose.yaml
+++ b/fleet-config/greengrass-compose.yaml
@@ -12,6 +12,15 @@ services:
     ports:
       - "8090:8090"
     restart: unless-stopped
+    # PCR hardware access (Meerstetter serial, I2C, SPI, GPIO). Without these the
+    # app serves but can't drive the instrument — runs can't start.
+    privileged: true
+    devices:
+      - "/dev/ttyUSB0:/dev/ttyUSB0"
+      - "/dev/i2c-1:/dev/i2c-1"
+      - "/dev/spidev0.0:/dev/spidev0.0"
+      - "/dev/spidev0.1:/dev/spidev0.1"
+      - "/dev/gpiomem:/dev/gpiomem"
     volumes:
       - aquila-results:/opt/aquila/results
       - aquila-logs:/opt/aquila/logs
@@ -25,6 +34,13 @@ services:
     env_file: ${DEVICE_ENV_FILE:-/opt/aquila/config/device.env}
     container_name: aquila-app
     restart: unless-stopped
+    privileged: true
+    devices:
+      - "/dev/ttyUSB0:/dev/ttyUSB0"
+      - "/dev/i2c-1:/dev/i2c-1"
+      - "/dev/spidev0.0:/dev/spidev0.0"
+      - "/dev/spidev0.1:/dev/spidev0.1"
+      - "/dev/gpiomem:/dev/gpiomem"
     volumes:
       - aquila-results:/opt/aquila/results
       - aquila-logs:/opt/aquila/logs

--- a/tests/fleet_device/test_greengrass_component.py
+++ b/tests/fleet_device/test_greengrass_component.py
@@ -33,6 +33,18 @@ def test_runs_the_app_stack():
         assert name in services, f"greengrass compose missing service: {name}"
 
 
+def test_app_containers_have_pcr_hardware_access():
+    # Without privileged + the device mappings the app serves but can't drive the
+    # instrument (Meerstetter serial, I2C, SPI, GPIO) — "can't run anything".
+    services = _load_compose()["services"]
+    for name in ("backend", "app"):
+        svc = services[name]
+        assert svc.get("privileged") is True, f"{name} needs privileged for hardware"
+        mapped = " ".join(svc.get("devices", []))
+        for dev in ("/dev/ttyUSB0", "/dev/i2c-1", "/dev/spidev0.0", "/dev/gpiomem"):
+            assert dev in mapped, f"{name} missing device mapping {dev}"
+
+
 def test_has_no_watchtower():
     compose = _load_compose()
     # Greengrass owns updates now — no watchtower service, no enable labels.


### PR DESCRIPTION
## Symptom
On sn01 the app was healthy — `/health`, run UI, `/profiles`, `/version` (2.1.0.5) all `200` — but **runs wouldn't execute** ("can't run anything").

## Cause
My clean-room `greengrass-compose.yaml` **dropped the `privileged` + `devices` mappings** the original device compose had. The backend container was `Privileged=false`, `Devices=[]`, and couldn't see `/dev/i2c-1`, `/dev/spidev0.0/0.1`, `/dev/ttyUSB0`, `/dev/gpiomem` — so it can't drive the Meerstetter/motors/optics. `/button/run` returns `{"ok":true}` (accepted) but nothing happens.

## Fix
Restore `privileged: true` + the 5 hardware device mappings on **`backend`** and **`app`** (matches `fleet-config/docker-compose.yml`). Verified sn01's host has exactly those devices. Static test asserts they're present.

## To take effect on sn01
Merge → workflow publishes a new `0.1.x` with hardware access → deploy to `sandbox`. (No hand-publishing.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)