### PR TITLE
Reconnect Greengrass after a device-cert rotation (am#363)

### DIFF
--- a/aq_lib/renew.py
+++ b/aq_lib/renew.py
@@ -19,6 +19,15 @@ CERT_FILENAME = "device.crt"
 KEY_FILENAME = "device.key"
 ENV_FILENAME = "device.env"
 
+# Dropped in config_dir on a successful rotation. Greengrass loads device.crt once
+# at startup and holds a long-lived MQTT connection, so it won't pick up a renewed
+# cert until greengrass.service restarts. The renewal runs in a container and can't
+# touch the host's systemd, so it leaves this marker in the (bind-mounted) config
+# dir; a host-side hook (aquila-cert-renew.service ExecStartPost) sees it, restarts
+# Greengrass, and clears it. Written ONLY when the cert actually rotated — a no-op
+# or failed run leaves no marker, so a healthy connection is never bounced.
+ROTATION_MARKER = ".cert-rotated"
+
 # The prod acorn-ca renew front. device.env may override via AQ_RENEW_ENDPOINT.
 DEFAULT_RENEW_ENDPOINT = "https://renew.cloud.acorngenetics.com/renew"
 
@@ -92,6 +101,7 @@ def renew_device_cert(
     new_cert_pem = response.json()["certificate"]
 
     _install_pair(cert_path, new_cert_pem, key_path, new_key_pem)
+    _signal_greengrass_reconnect(config_dir)
     return new_cert_pem
 
 
@@ -115,6 +125,15 @@ def _install_pair(cert_path, cert_pem, key_path, key_pem):
     """
     _write_0600(key_path, key_pem if isinstance(key_pem, bytes) else key_pem.encode())
     _write_0600(cert_path, cert_pem if isinstance(cert_pem, bytes) else cert_pem.encode())
+
+
+def _signal_greengrass_reconnect(config_dir):
+    """Drop the reconnect marker so the host bounces Greengrass onto the new cert.
+
+    Called only after a rotation actually installed a new pair. See ``ROTATION_MARKER``.
+    """
+    with open(os.path.join(config_dir, ROTATION_MARKER), "w") as f:
+        f.write("cert rotated; restart greengrass to reconnect with the new cert\n")
 
 
 def _read_env(config_dir):

--- a/scripts/deploy/deployment3_greengrass.sh
+++ b/scripts/deploy/deployment3_greengrass.sh
@@ -849,6 +849,14 @@ ExecStart=/usr/bin/docker run --rm \\
     -v /opt/aquila/config:/config \\
     ghcr.io/${GHCR_REPO}-api:${IMAGE_TAG} \\
     python -m aq_lib.renew /config
+# Greengrass loads device.crt once at startup and holds a long-lived MQTT
+# connection, so it won't pick up a renewed cert on its own (#363). The renewal
+# runs in the container above and can't touch host systemd; on a rotation it drops
+# /opt/aquila/config/.cert-rotated. Only when that marker is present do we restart
+# Greengrass so it reconnects with the new cert, then clear it. A no-op renewal
+# leaves no marker => Greengrass's healthy connection is never bounced. If the
+# restart fails the marker stays and the next daily tick retries it.
+ExecStartPost=/bin/sh -c 'test -f /opt/aquila/config/.cert-rotated && { systemctl restart greengrass && rm -f /opt/aquila/config/.cert-rotated; } || true'
 EOF
 
 # Daily, but with a large randomized delay so a batch of devices enrolled the same
@@ -871,6 +879,7 @@ systemctl daemon-reload
 systemctl enable --now aquila-cert-renew.timer
 
 run_test "renew service file exists" "test -f /etc/systemd/system/aquila-cert-renew.service"
+run_test "renew reconnects greengrass"  "grep -q 'restart greengrass' /etc/systemd/system/aquila-cert-renew.service"
 run_test "renew timer file exists"   "test -f /etc/systemd/system/aquila-cert-renew.timer"
 run_test "renew timer enabled"       "systemctl is-enabled aquila-cert-renew.timer | grep -q enabled"
 run_test "renew timer active"        "systemctl is-active aquila-cert-renew.timer | grep -q active"

--- a/unit_tests/test_renew.py
+++ b/unit_tests/test_renew.py
@@ -16,7 +16,13 @@ from cryptography.hazmat.primitives import hashes, serialization
 from cryptography.hazmat.primitives.asymmetric import ec
 from cryptography.x509.oid import NameOID
 
-from aq_lib.renew import RenewalError, renew_device_cert, renewal_due, run_renewal
+from aq_lib.renew import (
+    ROTATION_MARKER,
+    RenewalError,
+    renew_device_cert,
+    renewal_due,
+    run_renewal,
+)
 
 DEVICE_ID = "10000000a6b7d43e"
 RENEW_ENDPOINT = "https://renew.example/renew"
@@ -259,6 +265,69 @@ class TestRenewDeviceCert:
         )
         (cn,) = csr.subject.get_attributes_for_oid(NameOID.COMMON_NAME)
         assert cn.value == DEVICE_ID
+
+
+class TestGreengrassReconnectMarker:
+    """After a rotation, the container must signal the host to reconnect Greengrass.
+
+    Greengrass reads device.crt once at startup and holds a long-lived MQTT
+    connection, so it won't pick up a rotated cert until greengrass.service
+    restarts. The renewal runs in a container and can't touch the host's systemd,
+    so on a successful rotation it drops a marker in the (bind-mounted) config dir;
+    a host-side hook sees it and bounces Greengrass. No rotation => no marker, so a
+    healthy connection is never bounced needlessly.
+    """
+
+    def test_rotation_drops_the_reconnect_marker(self, tmp_path):
+        now = dt.datetime(2026, 7, 11, tzinfo=dt.timezone.utc)
+        config = tmp_path / "config"
+        write_config(config, due_cert(now))
+        post = issuing_post(now)
+
+        renew_device_cert(
+            RENEW_ENDPOINT, config_dir=str(config), device_id=DEVICE_ID,
+            now=now, http_post=post,
+        )
+
+        assert (config / ROTATION_MARKER).exists()
+
+    def test_not_due_leaves_no_marker(self, tmp_path):
+        # Nothing rotated, so Greengrass's healthy long-lived connection must not be
+        # bounced. A daily no-op tick must never leave a marker.
+        now = dt.datetime(2026, 7, 2, tzinfo=dt.timezone.utc)
+        config = tmp_path / "config"
+        fresh = make_cert_pem(
+            not_before=now - dt.timedelta(days=1),
+            not_after=now + dt.timedelta(days=13),
+        )
+        write_config(config, fresh)
+
+        result = renew_device_cert(
+            RENEW_ENDPOINT, config_dir=str(config), device_id=DEVICE_ID,
+            now=now, http_post=lambda *a, **k: pytest.fail("must not contact /renew"),
+        )
+
+        assert result is None
+        assert not (config / ROTATION_MARKER).exists()
+
+    def test_failed_renewal_leaves_no_marker(self, tmp_path):
+        # Due, but /renew refused: the installed cert is unchanged, so there is
+        # nothing new to reconnect with. A marker here would bounce Greengrass back
+        # onto the same old cert — pointless and disruptive.
+        now = dt.datetime(2026, 7, 11, tzinfo=dt.timezone.utc)
+        config = tmp_path / "config"
+        write_config(config, due_cert(now))
+
+        def refusing_post(url, data=None, cert=None):
+            return FakeResponse(403, {"error": "Device ID is revoked"})
+
+        with pytest.raises(RenewalError):
+            renew_device_cert(
+                RENEW_ENDPOINT, config_dir=str(config), device_id=DEVICE_ID,
+                now=now, http_post=refusing_post,
+            )
+
+        assert not (config / ROTATION_MARKER).exists()
 
 
 class TestRunRenewal:


### PR DESCRIPTION
## What this does

When the short-lived acorn-ca device cert renews, Greengrass now gets reconnected onto the new cert. Previously only analytics mTLS picked up a rotated cert (it's request-scoped); Greengrass holds a **long-lived MQTT connection** and reads `device.crt` only once at startup — so a renewed cert was invisible to it, and ~14 days later the cert it was *still* using would expire and the device would silently drop off the fleet.

## How

The renewal runs in a container and can't touch the host's systemd, so the fix is split across the container/host boundary:

- **Container (Python, unit-tested):** on a **successful rotation**, drop a `.cert-rotated` marker in the bind-mounted config dir. A **no-op** (not due) or a **failed** renewal (non-200 / TLS reject) leaves **no marker** — a healthy connection is never bounced, and we never restart onto an unchanged cert.
- **Host (`deployment3_greengrass.sh`):** an `ExecStartPost` on `aquila-cert-renew.service` checks for the marker; if present it `systemctl restart greengrass` and clears it. If the restart fails the marker stays and the next daily tick retries.

Note: Greengrass is already provisioned to read the same `/opt/aquila/config/device.crt` the renewal rotates, so the cert file *is* the IoT connection cert — no separate cert copy needed, only the reconnect.

## Tests

`unit_tests/test_renew.py` (through the public `renew_device_cert` interface, tmp dir + fake `/renew`):
- rotation → marker written
- not-due no-op → no marker
- failed renewal → no marker

All 117 unit tests pass. `deployment3_greengrass.sh` gains a `run_test` asserting the reconnect hook is wired (verified on-device with the rest of that script).

## Still pending (issue stays open)

- [ ] Verified on the pilot device: a rotation restarts Greengrass and it reconnects cleanly with no dropped control-plane connection.

Part of #363.