### PR TITLE
Baked build identity → real Device Shadow SHAs (Part of am#382)

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -24,6 +24,12 @@ jobs:
       - name: Set lowercase repo
         run: echo "REPO_LOWER=$(echo "$GITHUB_REPOSITORY" | tr '[:upper:]' '[:lower:]')" >> $GITHUB_ENV
 
+      # Computed in a step rather than read from github.event.head_commit, which
+      # is absent on workflow_dispatch. Baked into both images so a device can
+      # report its own provenance — see #351.
+      - name: Stamp build time
+        run: echo "BUILD_TIME=$(date -u +%Y-%m-%dT%H:%M:%SZ)" >> $GITHUB_ENV
+
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
 
@@ -44,6 +50,9 @@ jobs:
           file: docker/Dockerfile.api
           platforms: linux/amd64,linux/arm64
           push: true
+          build-args: |
+            GIT_SHA=${{ github.sha }}
+            BUILD_TIME=${{ env.BUILD_TIME }}
           tags: |
             ghcr.io/${{ env.REPO_LOWER }}-api:latest
             ghcr.io/${{ env.REPO_LOWER }}-api:${{ github.sha }}
@@ -56,6 +65,9 @@ jobs:
           file: docker/Dockerfile.ui
           platforms: linux/amd64,linux/arm64
           push: true
+          build-args: |
+            GIT_SHA=${{ github.sha }}
+            BUILD_TIME=${{ env.BUILD_TIME }}
           tags: |
             ghcr.io/${{ env.REPO_LOWER }}-ui:latest
             ghcr.io/${{ env.REPO_LOWER }}-ui:${{ github.sha }}

--- a/.github/workflows/publish-component.yml
+++ b/.github/workflows/publish-component.yml
@@ -42,6 +42,13 @@ jobs:
       - name: Set up Buildx
         uses: docker/setup-buildx-action@v3
 
+      # Stamp the build identity (#351) into both images so /health, /version.json,
+      # and the Device Shadow report the real running build. github.sha is the
+      # commit; BUILD_TIME is computed here (github.event.head_commit is absent on
+      # workflow_dispatch).
+      - name: Compute build time
+        run: echo "BUILD_TIME=$(date -u +%Y-%m-%dT%H:%M:%SZ)" >> "$GITHUB_ENV"
+
       # arm64 only — the whole fleet is arm64 Raspberry Pis; the published images
       # are consumed only by Greengrass, never run on amd64. (Local dev builds
       # from source for its own arch, so this doesn't affect it.) push returns the
@@ -54,6 +61,9 @@ jobs:
           file: docker/Dockerfile.api
           platforms: linux/arm64
           push: true
+          build-args: |
+            GIT_SHA=${{ github.sha }}
+            BUILD_TIME=${{ env.BUILD_TIME }}
           tags: ${{ env.ECR_REGISTRY }}/aquilla-main-api:${{ github.sha }}
       - name: Build + push ui image
         id: ui
@@ -63,6 +73,9 @@ jobs:
           file: docker/Dockerfile.ui
           platforms: linux/arm64
           push: true
+          build-args: |
+            GIT_SHA=${{ github.sha }}
+            BUILD_TIME=${{ env.BUILD_TIME }}
           tags: ${{ env.ECR_REGISTRY }}/aquilla-main-ui:${{ github.sha }}
 
       - name: Version + artifact URI

--- a/aquila_web/main.py
+++ b/aquila_web/main.py
@@ -845,9 +845,44 @@ async def timer(payload: TimerControl):
         raise HTTPException(status_code=400, detail="Invalid action")
 
 
+def _read_build_identity() -> dict:
+    """This image's own baked provenance (#351).
+
+    Written into config_files/version.json at build time by docker/Dockerfile.api.
+    config_files/ is not a mounted volume, so nothing can overwrite it at runtime
+    — unlike RUNNING_IMAGE_DIGEST, which is an env var supplied by whoever started
+    the container and is written by /update/apply BEFORE the swap, recording
+    intent rather than outcome.
+
+    Tolerates the keys being absent: images built before #351 have only
+    app_version, and a device running one must not crash on startup.
+    """
+    identity = {"app_version": "unknown", "git_sha": "unknown", "build_time": "unknown"}
+    try:
+        data = json.loads((BASE_DIR / "config_files" / "version.json").read_text())
+        for key in identity:
+            if data.get(key):
+                identity[key] = str(data[key])
+    except Exception:  # noqa: BLE001 - identity must never break startup
+        logger.warning("could not read build identity from version.json")
+    return identity
+
+
+# Resolved once: the values are baked into the image and cannot change while the
+# container runs, and /health is polled every 30s by the Docker healthcheck.
+_BUILD_IDENTITY = _read_build_identity()
+
+
 @app.get("/health")
 async def health_check():
-    return {"status": "ok"}
+    return {
+        "status": "ok",
+        **_BUILD_IDENTITY,
+        # Deliberately reported alongside the baked values rather than instead of
+        # them: their disagreement is the signal that a device is not running what
+        # the fleet config claims. See #352.
+        "running_image_digest": os.getenv("RUNNING_IMAGE_DIGEST") or "unknown",
+    }
 
 
 def _read_app_version() -> str:

--- a/aquila_web/main.py
+++ b/aquila_web/main.py
@@ -1289,13 +1289,39 @@ async def button_open():
 from aquila_web.version_health import runs_allowed
 
 
-def _running_container_shas():
-    """(api_build_sha, ui_build_sha) of the running containers, or None if unknown.
+# The UI container serves its own baked git_sha at /version.json (nginx, #351).
+# Overridable for local dev; on-device the app reaches the UI by compose service name.
+_UI_VERSION_URL = os.getenv("AQ_UI_VERSION_URL", "http://ui:8080/version.json")
 
-    Sourced from the baked build identity (am#365); unknown during migration, in
-    which case the run gate cannot enforce and allows the run.
+
+def _read_ui_git_sha():
+    """The UI container's baked git_sha, from its nginx-served /version.json (#351).
+
+    Best-effort with a short timeout: the UI being briefly unreachable must never
+    block a run or crash the shadow reporter, so unknown degrades to None (reported
+    as an unmatched pair, never a fabricated match).
     """
-    return (os.getenv("RUNNING_BUILD_SHA"), os.getenv("RUNNING_BUILD_SHA_UI"))
+    try:
+        resp = httpx.get(_UI_VERSION_URL, timeout=2.0)
+        sha = resp.json().get("git_sha")
+        return sha if sha and sha != "unknown" else None
+    except Exception:  # noqa: BLE001 - identity lookup must never break a run/report
+        return None
+
+
+def _running_container_shas():
+    """(api_build_sha, ui_build_sha) of the running containers, or None when unknown.
+
+    api: this container's own baked git_sha (config_files/version.json, #351).
+    ui:  the UI container's baked git_sha, fetched from its /version.json.
+    A SHA is None when unknown (pre-#351 image / UI unreachable): the run gate
+    treats that as "cannot enforce -> allow", and Container Health reports it as
+    not-a-matched-pair rather than inventing a match.
+    """
+    api_sha = _BUILD_IDENTITY.get("git_sha")
+    if not api_sha or api_sha == "unknown":
+        api_sha = None
+    return (api_sha, _read_ui_git_sha())
 
 
 @app.post("/button/run")

--- a/docker/Dockerfile.api
+++ b/docker/Dockerfile.api
@@ -17,6 +17,24 @@ COPY profiles/bundled/ /opt/aquila/profiles_bundled/
 COPY docker/entrypoint.sh /opt/aquila/entrypoint.sh
 RUN chmod +x /opt/aquila/entrypoint.sh
 
+# Bake build provenance into the image (#351).
+#
+# An injected env var like RUNNING_IMAGE_DIGEST is a claim made by whoever
+# started the container — /update/apply writes it BEFORE the swap, so it records
+# intent, not outcome. A value baked into the image bytes cannot misreport what
+# is running. config_files/ is not a mounted volume, so nothing can overwrite
+# this at runtime.
+#
+# Declared here, after the dependency layers, so a new SHA invalidates only this
+# tiny layer and the build cache from #348 still applies.
+ARG GIT_SHA=unknown
+ARG BUILD_TIME=unknown
+LABEL org.opencontainers.image.revision=$GIT_SHA
+LABEL org.opencontainers.image.created=$BUILD_TIME
+# Extends the version.json introduced in #340 rather than replacing it —
+# _read_app_version() reads data["app_version"] and is unaffected by extra keys.
+RUN python -c "import json,os,pathlib;p=pathlib.Path('config_files/version.json');d=json.loads(p.read_text());d['git_sha']=os.environ.get('GIT_SHA','unknown');d['build_time']=os.environ.get('BUILD_TIME','unknown');p.write_text(json.dumps(d,indent=4)+'\n')"
+
 ENV DATA_DIR=/opt/aquila \
     PROFILE_DIR=/opt/aquila/profiles \
     RESULTS_PATH=/opt/aquila/results/results.json

--- a/docker/Dockerfile.ui
+++ b/docker/Dockerfile.ui
@@ -3,5 +3,17 @@ FROM nginx:1.27-alpine
 COPY docker/nginx.conf /etc/nginx/conf.d/default.conf
 COPY aquila_web/static/ /usr/share/nginx/html/
 
+# Bake build provenance (#351). This image is nginx serving static files — there
+# is no application to answer a request — so the identity is a static file that
+# nginx serves directly. See the `location = /version.json` block in nginx.conf:
+# without it this path falls through to the catch-all proxy and is answered by
+# the API container, which would silently compare that image against itself.
+ARG GIT_SHA=unknown
+ARG BUILD_TIME=unknown
+LABEL org.opencontainers.image.revision=$GIT_SHA
+LABEL org.opencontainers.image.created=$BUILD_TIME
+RUN printf '{"git_sha":"%s","build_time":"%s"}\n' "$GIT_SHA" "$BUILD_TIME" \
+    > /usr/share/nginx/html/version.json
+
 HEALTHCHECK --interval=30s --timeout=5s --start-period=10s --retries=3 \
     CMD wget -qO- http://127.0.0.1/ > /dev/null

--- a/docker/nginx.conf
+++ b/docker/nginx.conf
@@ -25,6 +25,14 @@ server {
         try_files $uri =404;
     }
 
+    # The UI image's own baked identity (#351). This MUST be served locally: the
+    # catch-all `location /` below proxies to aquila-backend, so without this the
+    # request is answered by the API container and the UI would appear to match
+    # itself no matter how far the two images had drifted apart.
+    location = /version.json {
+        try_files $uri =404;
+    }
+
     location /kiosk-control/ {
         limit_except POST { deny all; }
         resolver 127.0.0.11 valid=10s ipv6=off;

--- a/tests/contract/test_build_identity.py
+++ b/tests/contract/test_build_identity.py
@@ -109,3 +109,46 @@ def test_ci_passes_the_build_args_to_both_images():
     assert "BUILD_TIME=$(date -u" in wf, (
         "computed in a step — github.event.head_commit is absent on workflow_dispatch"
     )
+
+
+# ── The Greengrass shadow reporter reads the baked identity (am#365 -> am#382) ──
+# _running_container_shas() feeds both the run gate and the Device-Shadow
+# Container-Health report. It must source the API SHA from this image's own baked
+# git_sha and the UI SHA from the UI container's /version.json — never invent a
+# match, and never let an unreachable UI break a run.
+
+class _FakeResp:
+    def __init__(self, body):
+        self._body = body
+
+    def json(self):
+        return self._body
+
+
+def test_running_shas_reads_baked_api_and_ui_git_sha(monkeypatch):
+    monkeypatch.setattr(main, "_BUILD_IDENTITY",
+                        {"app_version": "2.1.0.6", "git_sha": "apisha", "build_time": "t"})
+    monkeypatch.setattr(main.httpx, "get",
+                        lambda url, timeout=None: _FakeResp({"git_sha": "uisha"}))
+    assert main._running_container_shas() == ("apisha", "uisha")
+
+
+def test_running_shas_ui_unreachable_degrades_to_none(monkeypatch):
+    # UI briefly down: report (api, None) — an unmatched pair, not a crash and not
+    # a false match. The run gate treats None as "cannot enforce -> allow".
+    monkeypatch.setattr(main, "_BUILD_IDENTITY", {"git_sha": "apisha"})
+
+    def boom(*a, **k):
+        raise RuntimeError("connection refused")
+
+    monkeypatch.setattr(main.httpx, "get", boom)
+    assert main._running_container_shas() == ("apisha", None)
+
+
+def test_running_shas_unknown_api_is_none(monkeypatch):
+    # An image built before #351 bakes no git_sha ("unknown"); surface it as None
+    # so Container Health reports honestly rather than matching on the string.
+    monkeypatch.setattr(main, "_BUILD_IDENTITY", {"git_sha": "unknown"})
+    monkeypatch.setattr(main.httpx, "get",
+                        lambda url, timeout=None: _FakeResp({"git_sha": "uisha"}))
+    assert main._running_container_shas() == (None, "uisha")

--- a/tests/contract/test_build_identity.py
+++ b/tests/contract/test_build_identity.py
@@ -1,0 +1,111 @@
+"""Each image reports its own baked build provenance (#351).
+
+The point of baking rather than injecting: an env var like RUNNING_IMAGE_DIGEST
+is a claim made by whoever started the container — and /update/apply writes it
+BEFORE triggering the swap, so it records intent, not outcome. A value baked into
+the image bytes cannot misreport what is actually running.
+"""
+import json
+import pathlib
+import re
+
+import pytest
+
+from aquila_web import main
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parents[2]
+
+
+def test_health_reports_build_identity(client):
+    body = client.get("/health").json()
+    assert body["status"] == "ok"
+    for key in ("app_version", "git_sha", "build_time", "running_image_digest"):
+        assert key in body, f"/health must report {key}"
+
+
+def test_health_still_reports_ok(client):
+    """It is the Docker HEALTHCHECK target — the contract must not regress."""
+    assert client.get("/health").json()["status"] == "ok"
+
+
+def test_app_version_still_matches_the_config_file(client):
+    """#340 made version.json the single source; #351 only adds keys to it."""
+    expected = json.loads((REPO_ROOT / "config_files" / "version.json").read_text())["app_version"]
+    assert client.get("/health").json()["app_version"] == expected
+    assert client.get("/version").json()["version"] == expected
+
+
+def test_identity_tolerates_an_image_built_before_this_change(tmp_path, monkeypatch):
+    """Older images have only app_version. A device running one must not crash."""
+    cfg = tmp_path / "config_files"
+    cfg.mkdir()
+    (cfg / "version.json").write_text('{"app_version": "2.1.0.5"}')
+    monkeypatch.setattr(main, "BASE_DIR", tmp_path)
+
+    identity = main._read_build_identity()
+    assert identity["app_version"] == "2.1.0.5"
+    assert identity["git_sha"] == "unknown"
+    assert identity["build_time"] == "unknown"
+
+
+def test_identity_tolerates_a_missing_or_corrupt_file(tmp_path, monkeypatch):
+    monkeypatch.setattr(main, "BASE_DIR", tmp_path)
+    identity = main._read_build_identity()
+    assert identity == {"app_version": "unknown", "git_sha": "unknown", "build_time": "unknown"}
+
+    cfg = tmp_path / "config_files"
+    cfg.mkdir()
+    (cfg / "version.json").write_text("{ not json")
+    assert main._read_build_identity()["git_sha"] == "unknown"
+
+
+def test_identity_reads_the_baked_values(tmp_path, monkeypatch):
+    cfg = tmp_path / "config_files"
+    cfg.mkdir()
+    (cfg / "version.json").write_text(json.dumps({
+        "app_version": "2.1.0.5",
+        "git_sha": "a1b2c3d4",
+        "build_time": "2026-07-28T12:00:00Z",
+    }))
+    monkeypatch.setattr(main, "BASE_DIR", tmp_path)
+    identity = main._read_build_identity()
+    assert identity["git_sha"] == "a1b2c3d4"
+    assert identity["build_time"] == "2026-07-28T12:00:00Z"
+
+
+# ── The delivery path has to be right, or the check compares an image to itself ──
+
+def test_nginx_serves_version_json_locally():
+    """Without an explicit location block, /version.json falls through to the
+    catch-all proxy and is answered by the API container — so the UI would appear
+    to match itself no matter how far the two images had drifted."""
+    conf = (REPO_ROOT / "docker" / "nginx.conf").read_text()
+    assert re.search(r"location\s*=\s*/version\.json", conf), (
+        "nginx.conf must serve /version.json locally, not proxy it to the backend"
+    )
+    # And it must come before the catch-all, or nginx never reaches it.
+    assert conf.index("/version.json") < conf.rindex("location / {")
+
+
+@pytest.mark.parametrize("dockerfile", ["Dockerfile.api", "Dockerfile.ui"])
+def test_both_images_accept_the_build_args(dockerfile):
+    text = (REPO_ROOT / "docker" / dockerfile).read_text()
+    assert "ARG GIT_SHA" in text
+    assert "ARG BUILD_TIME" in text
+
+
+@pytest.mark.parametrize("dockerfile", ["Dockerfile.api", "Dockerfile.ui"])
+def test_both_images_carry_an_oci_revision_label(dockerfile):
+    """#352 reads this from the registry manifest to resolve a digest back to a
+    build, without pulling the image."""
+    text = (REPO_ROOT / "docker" / dockerfile).read_text()
+    assert "org.opencontainers.image.revision" in text
+
+
+def test_ci_passes_the_build_args_to_both_images():
+    wf = (REPO_ROOT / ".github" / "workflows" / "docker-build.yml").read_text()
+    assert wf.count("GIT_SHA=${{ github.sha }}") == 2, "both api and ui builds"
+    assert wf.count("BUILD_TIME=${{ env.BUILD_TIME }}") == 2
+    assert "BUILD_TIME=$(date -u" in wf, (
+        "computed in a step — github.event.head_commit is absent on workflow_dispatch"
+    )


### PR DESCRIPTION
## Why

The Greengrass agent already publishes a Device Shadow every 60s, but its `container_health` / running-SHA report was always `null` / `mismatched`: the reporter read `RUNNING_BUILD_SHA` env vars that nothing on this branch sets. This makes the shadow show the **real** running build.

## What's in this PR

**1. Cherry-pick of am#365 (`3be4d49`, "bake build identity into each image", #351)** — brought over cleanly, original attribution preserved. No other epic work dragged in.
- `docker/Dockerfile.api` — bakes `git_sha` + `build_time` into `config_files/version.json` via `ARG GIT_SHA/BUILD_TIME` + OCI labels
- `docker/Dockerfile.ui` — writes `/usr/share/nginx/html/version.json` with the same
- `docker/nginx.conf` — explicit `location = /version.json` so the UI serves its **own** identity (not the API's via the catch-all proxy)
- `aquila_web/main.py` — `_read_build_identity()` + `/health` now reports `app_version`, `git_sha`, `build_time`, `running_image_digest`
- `.github/workflows/docker-build.yml` — (watchtower CI) build-args
- `tests/contract/test_build_identity.py` — 12 tests

**2. Wire the Greengrass shadow reporter to the baked identity**
- `aquila_web/main.py` — `_running_container_shas()` now returns this image's baked `git_sha` (API) + the UI container's `git_sha` fetched from its `/version.json` (best-effort, 2s timeout). Unknown / UI-unreachable degrades to `None` — an unmatched pair, never a crash and never a fabricated match; the run gate treats `None` as "allow".
- `+3 tests` in `test_build_identity.py` (baked api+ui SHAs; UI unreachable → None; unknown api → None)

**3. Stamp the *greengrass* images**
- `.github/workflows/publish-component.yml` — adds a `BUILD_TIME` step + `GIT_SHA`/`BUILD_TIME` build-args to both image builds, so the images Greengrass actually runs carry a real identity (am#365 had only wired the watchtower `docker-build.yml`).

## Result
`state.reported.images.api/ui` + `container_health` in the classic Device Shadow reflect the real running builds — visible in the IoT console and queryable via Fleet Indexing (`shadow.reported.container_health:mismatched`).

## Tests
132 passing (`unit_tests/` + `tests/contract/test_build_identity.py`, 15 in the identity file).

## Notes / still pending
- am#365 (PR #365) is still **open** on `epic/fleet-deployment-hardening`; this cherry-picks only its baked-identity commit onto the Greengrass branch. Expect a trivial resolve when the epic eventually merges to main.
- [ ] On-device: confirm the shadow shows real `git_sha`s for a matched pair, and `mismatched` when the two containers differ.

Part of #382.