### PR TITLE
Bump app_version 2.1.0.6 → 2.1.0.7

### DIFF
--- a/config_files/version.json
+++ b/config_files/version.json
@@ -1,3 +1,3 @@
 {
-    "app_version": "2.1.0.6"
+    "app_version": "2.1.0.7"
 }


### PR DESCRIPTION
Bumps `app_version` `2.1.0.6` → `2.1.0.7` so the next published component version is visibly newer — used to test the operator **Update button** gate end-to-end on sn01 (offer → defer → approve → switch, with the new version showing in Settings once applied).

No other changes.