### PR TITLE
Make the Greengrass on-device app stack functional + persist data (Part of am#382)

### DIFF
--- a/fleet-config/greengrass-compose.yaml
+++ b/fleet-config/greengrass-compose.yaml
@@ -21,6 +21,14 @@ services:
       - "/dev/spidev0.0:/dev/spidev0.0"
       - "/dev/spidev0.1:/dev/spidev0.1"
       - "/dev/gpiomem:/dev/gpiomem"
+    # Greengrass Core IPC: the update agent (am#382) connects to the nucleus over
+    # its domain socket to publish the Device Shadow and defer component updates.
+    # SVCUID + the socket path are set by Greengrass on the component process (and
+    # inherited by docker compose); AWS_IOT_THING_NAME is exported by the recipe.
+    environment:
+      - SVCUID
+      - AWS_GG_NUCLEUS_DOMAIN_SOCKET_FILEPATH_FOR_COMPONENT
+      - AWS_IOT_THING_NAME
     volumes:
       - aquila-results:/opt/aquila/results
       - aquila-logs:/opt/aquila/logs
@@ -28,6 +36,9 @@ services:
       - aquila-config:/opt/aquila/config
       # The sync outbox (completed runs not yet pushed) — must survive recreate.
       - aquila-data:/opt/aquila/data
+      # The nucleus IPC socket, mounted at the same path the env var names so the
+      # client inside the container connects to the same socket.
+      - ${AWS_GG_NUCLEUS_DOMAIN_SOCKET_FILEPATH_FOR_COMPONENT:-/greengrass/v2/ipc.socket}:${AWS_GG_NUCLEUS_DOMAIN_SOCKET_FILEPATH_FOR_COMPONENT:-/greengrass/v2/ipc.socket}
 
   app:
     image: aquilla-main-api
@@ -41,12 +52,18 @@ services:
       - "/dev/spidev0.0:/dev/spidev0.0"
       - "/dev/spidev0.1:/dev/spidev0.1"
       - "/dev/gpiomem:/dev/gpiomem"
+    # Greengrass Core IPC (see backend) — the update agent runs here too.
+    environment:
+      - SVCUID
+      - AWS_GG_NUCLEUS_DOMAIN_SOCKET_FILEPATH_FOR_COMPONENT
+      - AWS_IOT_THING_NAME
     volumes:
       - aquila-results:/opt/aquila/results
       - aquila-logs:/opt/aquila/logs
       - aquila-profiles:/opt/aquila/profiles
       - aquila-config:/opt/aquila/config
       - aquila-data:/opt/aquila/data
+      - ${AWS_GG_NUCLEUS_DOMAIN_SOCKET_FILEPATH_FOR_COMPONENT:-/greengrass/v2/ipc.socket}:${AWS_GG_NUCLEUS_DOMAIN_SOCKET_FILEPATH_FOR_COMPONENT:-/greengrass/v2/ipc.socket}
 
   ui:
     image: aquilla-main-ui

--- a/scripts/greengrass/recipe.py
+++ b/scripts/greengrass/recipe.py
@@ -69,6 +69,12 @@ def build_recipe(component_name, version, compose_artifact_uri, image_refs=None)
                     # fails the loop exits non-zero and Greengrass marks it broken
                     # (feeds rollback in af#4).
                     "Run": (
+                        # Give the containers this core device's thing name so the
+                        # update agent (am#382) can address its own Device Shadow
+                        # over IPC. SVCUID + the nucleus socket path are already in
+                        # this process env (Greengrass sets them) and compose passes
+                        # them through; the thing name is not, so export it here.
+                        'export AWS_IOT_THING_NAME="{iot:thingName}"; '
                         "docker compose -f %s up -d; "
                         # buffer: do not check /health for the first 25s (boot ~15s)
                         "sleep 25; "

--- a/tests/fleet_device/test_greengrass_component.py
+++ b/tests/fleet_device/test_greengrass_component.py
@@ -45,6 +45,27 @@ def test_app_containers_have_pcr_hardware_access():
             assert dev in mapped, f"{name} missing device mapping {dev}"
 
 
+def test_app_containers_reach_greengrass_ipc():
+    # The update agent (am#382) talks to the nucleus over Core IPC to publish the
+    # Device Shadow and defer component updates. Inside a container that needs the
+    # IPC socket bind-mounted plus SVCUID + the socket-path + thing-name env, or the
+    # agent can't connect and silently no-ops (no shadow, no operator update gate).
+    services = _load_compose()["services"]
+    for name in ("backend", "app"):
+        svc = services[name]
+        env = " ".join(svc.get("environment", []))
+        for var in (
+            "SVCUID",
+            "AWS_GG_NUCLEUS_DOMAIN_SOCKET_FILEPATH_FOR_COMPONENT",
+            "AWS_IOT_THING_NAME",
+        ):
+            assert var in env, f"{name} missing IPC env {var}"
+        vols = " ".join(svc.get("volumes", []))
+        assert "AWS_GG_NUCLEUS_DOMAIN_SOCKET_FILEPATH_FOR_COMPONENT" in vols, (
+            f"{name} does not bind-mount the Greengrass IPC socket"
+        )
+
+
 def test_has_no_watchtower():
     compose = _load_compose()
     # Greengrass owns updates now — no watchtower service, no enable labels.
@@ -79,6 +100,9 @@ def test_persists_state_on_named_volumes():
     sources = _sources(backend.get("volumes"))
     assert sources, "backend persists nothing"
     # Named volumes, not host binds — Greengrass state must not depend on /opt paths.
+    # (The Greengrass IPC socket is a runtime bind, not app state — exclude it.)
     for src in sources:
+        if "AWS_GG_NUCLEUS_DOMAIN_SOCKET_FILEPATH_FOR_COMPONENT" in src:
+            continue
         assert not src.startswith("/"), f"backend uses a host bind ({src}); use a named volume"
         assert src in named, f"backend mounts '{src}' but it is not a declared named volume"

--- a/tests/unit/test_greengrass_recipe.py
+++ b/tests/unit/test_greengrass_recipe.py
@@ -144,3 +144,14 @@ def test_recipe_health_gate_waits_for_startup():
     # component (the app takes ~15s to become healthy after compose up).
     assert "sleep 25" in run  # buffer before the first health check
     assert "seq" in run       # grace loop after the buffer
+
+
+def test_recipe_exports_thing_name_for_ipc():
+    # The container reaches Greengrass Core IPC (to publish its shadow + defer
+    # updates, am#382) using SVCUID + the nucleus socket path — both already in the
+    # component process env, so compose passes them through. The thing name is not,
+    # so the recipe exports it (via the {iot:thingName} recipe variable) for the
+    # agent to address its own Device Shadow.
+    run = _recipe_with_images()["Manifests"][0]["Lifecycle"]["Run"]
+    assert "AWS_IOT_THING_NAME" in run
+    assert "{iot:thingName}" in run


### PR DESCRIPTION
## Why

sn01 was RUNNING `com.acorn.sentri` 0.1.17, all containers "healthy" — but the instrument wouldn't run, the Update gate never engaged, and no data persisted. The clean-room `greengrass-compose.yaml` had dropped config that made the app actually work, and its **named volumes lost data on every update**. This brings it to functional parity with the proven watchtower compose (keeping the Greengrass-appropriate choices) and fixes the sync-outbox init.

## Root causes (all found on-device)
1. **`app` had no `command`** → it ran the default web server instead of **`application.py`** (the `AssayInterface` hardware controller). A Run press was accepted by the backend, but nothing drove the instrument. *(the "button returns ok, device doesn't run" symptom)*
2. **`app` missing env** — `BACKEND_URL`, `DATA_DIR`, `PROFILE_DIR`, `RESULTS_PATH`, `CONFIG_DIR` — plus `pid: host`, healthcheck disable, `extra_hosts`, `depends_on`.
3. **UI unreachable** — `ports: 8080:8080`, but nginx listens on **80** → `curl localhost:8080` = HTTP 000 (kiosk UI dead). Fixed to `8080:80`.
4. **Data lost on every update** — state used *relative named volumes*; Greengrass runs compose from a **per-version artifact dir**, so each version got its own empty volume set (`0114_aquila-data`, `0117_aquila-data`, …). Every update abandoned the prior version's runs + **unsynced sync-outbox**, and a migrated device wouldn't see its existing `/opt/aquila` data.
5. **`no such table: events`** — the outbox schema was only created on run-complete, never at startup, so a fresh DB errored on every sync tick.

## Fixes
- **app**: `command: python3 application.py`, add app env incl. `BACKEND_URL`, `pid: host`, `healthcheck: disable`, `extra_hosts`, `depends_on: backend`.
- **backend**: add `DATA_DIR/PROFILE_DIR/RESULTS_PATH/CONFIG_DIR` + `KIOSK_CONTROL_URL`, `extra_hosts`.
- **ui**: map `8080:80`, add `extra_hosts`.
- **state → host binds**: `/opt/aquila/{results,logs,profiles,config,data}` (version-independent) so data **survives every update** and an **existing device's data carries over on migration** — also keeps config/certs consistent with the host-side cert renewal (am#363).
- **DB init at startup**: `init_local_db()` in a startup hook (idempotent) so the outbox schema exists before the sync poller reads it.
- Also (from the first commit): **Greengrass Core IPC** wired into the containers so the am#382 agent connects, publishes the shadow, and the Update gate engages.
- **Not** reintroduced: watchtower, the #314 `dns: 172.18.0.1` hack, `RUNNING_IMAGE_DIGEST`.

## Tests
app runs `application.py` + reaches the backend; app healthcheck disabled; ui maps to nginx 80; state is on `/opt/aquila` host binds (no named volumes); startup initializes the outbox schema on a fresh DB; IPC socket + creds present. Full relevant suites green (+ zero new failures vs baseline).

## Still pending (on-device)
- [ ] Republish + deploy; confirm: instrument runs, kiosk UI loads, shadow publishes + Update gate engages, and data persists across an update.

Part of #382.