### PR TITLE
Make the Greengrass on-device app stack functional + persist data (Part of am#382)

### DIFF
--- a/aquila_web/main.py
+++ b/aquila_web/main.py
@@ -2461,6 +2461,21 @@ async def start_background_update_poller() -> None:
 
 
 @app.on_event("startup")
+async def init_sync_outbox_db() -> None:
+    """Create the sync-outbox schema before the sync poller reads it.
+
+    On a fresh device — or a fresh Greengrass named volume — the events table
+    otherwise does not exist until the first run completes, so the background sync
+    poller logs 'no such table: events' every tick until then. init_local_db() is
+    idempotent (CREATE TABLE IF NOT EXISTS), so this is safe on an existing DB too.
+    """
+    try:
+        init_local_db()
+    except Exception as e:  # noqa: BLE001 - never block startup on this
+        logger.warning("sync-outbox DB init failed: %s", e)
+
+
+@app.on_event("startup")
 async def start_background_sync_poller() -> None:
     asyncio.create_task(_background_sync_poller())
 

--- a/fleet-config/greengrass-compose.yaml
+++ b/fleet-config/greengrass-compose.yaml
@@ -1,10 +1,23 @@
 # On-device app stack for the Greengrass component (com.acorn.sentri).
 #
-# A clean-room version of docker-compose.yml: same app stack, but the CI
-# publish workflow pins the images to ECR digests, Greengrass (not watchtower)
-# owns updates, and state lives on named volumes. Do NOT reintroduce watchtower
-# or the #314 host-DNS forwarding here — Greengrass manages the network.
+# A clean-room version of docker-compose.yml: the SAME functional stack (web
+# backend + hardware controller + UI), but the CI publish workflow pins the images
+# to ECR digests and Greengrass (not watchtower) owns updates. Do NOT reintroduce
+# watchtower or the #314 host-DNS forwarding (dns: 172.18.0.1) here — Greengrass
+# manages the network.
+#
+# State is bind-mounted from /opt/aquila on the host — NOT Docker named volumes.
+# Greengrass runs `docker compose` from a per-VERSION artifact directory, so a
+# relative named volume (aquila-data:) gets a version-scoped project prefix
+# (0114_aquila-data, 0117_aquila-data, …) and every update would start on a fresh
+# EMPTY volume, abandoning the previous version's runs + unsynced sync-outbox.
+# Host binds are version-independent and are exactly where a device's existing
+# data already lives, so data survives every update and carries over when an
+# existing device is migrated to Greengrass. They also keep config/certs
+# consistent with the host-side cert renewal (am#363), which writes /opt/aquila/config.
 services:
+  # The web backend: serves the API/UI endpoints on 8090, accepts the Run press,
+  # and owns the sync outbox. The default image CMD (uvicorn) runs here.
   backend:
     image: aquilla-main-api
     env_file: ${DEVICE_ENV_FILE:-/opt/aquila/config/device.env}
@@ -21,63 +34,117 @@ services:
       - "/dev/spidev0.0:/dev/spidev0.0"
       - "/dev/spidev0.1:/dev/spidev0.1"
       - "/dev/gpiomem:/dev/gpiomem"
-    # Greengrass Core IPC: the update agent (am#382) connects to the nucleus over
-    # its domain socket to publish the Device Shadow and defer component updates.
-    # SVCUID + the socket path are set by Greengrass on the component process (and
-    # inherited by docker compose); AWS_IOT_THING_NAME is exported by the recipe.
+    # Reach the host (kiosk-control on :9191) by name.
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
     environment:
+      # App paths — align with the host bind-mount points below.
+      - DATA_DIR=/opt/aquila
+      - PROFILE_DIR=/opt/aquila/profiles
+      - RESULTS_PATH=/opt/aquila/results/results.json
+      - CONFIG_DIR=/opt/aquila/config
+      - KIOSK_CONTROL_URL=http://host.docker.internal:9191
+      # Greengrass Core IPC (am#382): the update agent connects to the nucleus to
+      # publish the Device Shadow + defer updates. SVCUID + the socket path are set
+      # by Greengrass on the component process and inherited by compose;
+      # AWS_IOT_THING_NAME is exported by the recipe.
       - SVCUID
       - AWS_GG_NUCLEUS_DOMAIN_SOCKET_FILEPATH_FOR_COMPONENT
       - AWS_IOT_THING_NAME
     volumes:
-      - aquila-results:/opt/aquila/results
-      - aquila-logs:/opt/aquila/logs
-      - aquila-profiles:/opt/aquila/profiles
-      - aquila-config:/opt/aquila/config
-      # The sync outbox (completed runs not yet pushed) — must survive recreate.
-      - aquila-data:/opt/aquila/data
+      # Host binds (version-independent) so data persists across every Greengrass
+      # update and an existing device's data carries over on migration.
+      - /opt/aquila/results:/opt/aquila/results
+      - /opt/aquila/logs:/opt/aquila/logs
+      - /opt/aquila/profiles:/opt/aquila/profiles
+      - /opt/aquila/config:/opt/aquila/config
+      # The sync outbox (completed runs not yet pushed) — must survive every update.
+      - /opt/aquila/data:/opt/aquila/data
       # The nucleus IPC socket, mounted at the same path the env var names so the
       # client inside the container connects to the same socket.
       - ${AWS_GG_NUCLEUS_DOMAIN_SOCKET_FILEPATH_FOR_COMPONENT:-/greengrass/v2/ipc.socket}:${AWS_GG_NUCLEUS_DOMAIN_SOCKET_FILEPATH_FOR_COMPONENT:-/greengrass/v2/ipc.socket}
+    logging:
+      driver: json-file
+      options:
+        max-size: "10m"
+        max-file: "3"
+    deploy:
+      resources:
+        limits:
+          memory: 1024M
 
+  # The hardware controller: application.py drives the instrument (AssayInterface
+  # ready/run/end) and talks to the backend over BACKEND_URL. This is what a Run
+  # press actuates — WITHOUT this command the container runs the default web server
+  # and nothing ever drives the instrument (the button returns ok but nothing runs).
   app:
     image: aquilla-main-api
     env_file: ${DEVICE_ENV_FILE:-/opt/aquila/config/device.env}
     container_name: aquila-app
+    command: ["python3", "application.py"]
     restart: unless-stopped
     privileged: true
+    pid: host
     devices:
       - "/dev/ttyUSB0:/dev/ttyUSB0"
       - "/dev/i2c-1:/dev/i2c-1"
       - "/dev/spidev0.0:/dev/spidev0.0"
       - "/dev/spidev0.1:/dev/spidev0.1"
       - "/dev/gpiomem:/dev/gpiomem"
-    # Greengrass Core IPC (see backend) — the update agent runs here too.
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
     environment:
+      - DATA_DIR=/opt/aquila
+      - PROFILE_DIR=/opt/aquila/profiles
+      - RESULTS_PATH=/opt/aquila/results/results.json
+      - CONFIG_DIR=/opt/aquila/config
+      # How application.py reaches the web backend (run_requested, events, screens).
+      - BACKEND_URL=http://aquila-backend:8090
+      - KIOSK_CONTROL_URL=http://host.docker.internal:9191
       - SVCUID
       - AWS_GG_NUCLEUS_DOMAIN_SOCKET_FILEPATH_FOR_COMPONENT
       - AWS_IOT_THING_NAME
     volumes:
-      - aquila-results:/opt/aquila/results
-      - aquila-logs:/opt/aquila/logs
-      - aquila-profiles:/opt/aquila/profiles
-      - aquila-config:/opt/aquila/config
-      - aquila-data:/opt/aquila/data
+      - /opt/aquila/results:/opt/aquila/results
+      - /opt/aquila/logs:/opt/aquila/logs
+      - /opt/aquila/profiles:/opt/aquila/profiles
+      - /opt/aquila/config:/opt/aquila/config
+      - /opt/aquila/data:/opt/aquila/data
       - ${AWS_GG_NUCLEUS_DOMAIN_SOCKET_FILEPATH_FOR_COMPONENT:-/greengrass/v2/ipc.socket}:${AWS_GG_NUCLEUS_DOMAIN_SOCKET_FILEPATH_FOR_COMPONENT:-/greengrass/v2/ipc.socket}
+    # application.py is not a web server — disable the image's /health check so the
+    # container is not flagged unhealthy (the backend answers /health for the gate).
+    healthcheck:
+      disable: true
+    depends_on:
+      - backend
+    logging:
+      driver: json-file
+      options:
+        max-size: "10m"
+        max-file: "3"
+    deploy:
+      resources:
+        limits:
+          memory: 512M
 
+  # The kiosk UI (nginx). nginx listens on port 80 inside the container (see
+  # docker/nginx.conf), so the host's 8080 maps to 80 — mapping 8080:8080 left the
+  # kiosk UI unreachable (nothing listens on container port 8080).
   ui:
     image: aquilla-main-ui
     env_file: ${DEVICE_ENV_FILE:-/opt/aquila/config/device.env}
     container_name: aquila-ui
     ports:
-      - "8080:8080"
+      - "8080:80"
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
     restart: unless-stopped
-
-# Persistent state lives in named volumes managed by the Docker engine — survives
-# container recreate on every Greengrass deployment, no host /opt binds needed.
-volumes:
-  aquila-results:
-  aquila-logs:
-  aquila-profiles:
-  aquila-config:
-  aquila-data:
+    logging:
+      driver: json-file
+      options:
+        max-size: "10m"
+        max-file: "3"
+    deploy:
+      resources:
+        limits:
+          memory: 256M

--- a/tests/fleet_device/test_greengrass_component.py
+++ b/tests/fleet_device/test_greengrass_component.py
@@ -66,6 +66,36 @@ def test_app_containers_reach_greengrass_ipc():
         )
 
 
+def test_app_runs_the_hardware_controller():
+    # The `app` service must run application.py (the AssayInterface ready/run/end
+    # loop that drives the instrument), NOT the default web-server CMD. If it falls
+    # back to the web server, a Run press is accepted by the backend but nothing
+    # ever actuates the hardware — the instrument sits idle.
+    app = _load_compose()["services"]["app"]
+    command = app.get("command")
+    assert command, "app has no command — it would run the default web server, not the controller"
+    joined = " ".join(command) if isinstance(command, list) else str(command)
+    assert "application.py" in joined
+    # application.py reaches the web backend over BACKEND_URL.
+    env = " ".join(app.get("environment", []))
+    assert "BACKEND_URL=http://aquila-backend:8090" in env, "app can't reach the backend"
+
+
+def test_app_healthcheck_disabled():
+    # application.py is not a web server, so the image's /health healthcheck would
+    # flag the container unhealthy. The backend answers /health for the gate.
+    app = _load_compose()["services"]["app"]
+    assert app.get("healthcheck", {}).get("disable") is True
+
+
+def test_ui_maps_host_port_to_nginx_80():
+    # nginx listens on port 80 in the container; the host's 8080 must map to 80, or
+    # the kiosk UI is unreachable (8080:8080 hits nothing inside the container).
+    ui = _load_compose()["services"]["ui"]
+    ports = [str(p) for p in ui.get("ports", [])]
+    assert any(p.endswith(":80") for p in ports), f"ui must map to nginx port 80, got {ports}"
+
+
 def test_has_no_watchtower():
     compose = _load_compose()
     # Greengrass owns updates now — no watchtower service, no enable labels.
@@ -91,18 +121,25 @@ def _sources(mounts):
     return out
 
 
-def test_persists_state_on_named_volumes():
+def test_persists_state_on_host_binds():
+    # State is bind-mounted from /opt/aquila (version-independent), NOT relative
+    # named volumes. Greengrass runs compose from a per-VERSION artifact dir, so a
+    # relative named volume gets a version-scoped project prefix (0114_aquila-data,
+    # 0117_aquila-data, …) and every update would start on a fresh EMPTY volume,
+    # abandoning prior runs + the unsynced sync-outbox. Host binds persist across
+    # updates and carry an existing device's data over on migration.
     compose = _load_compose()
-    named = compose.get("volumes") or {}
-    assert named, "no top-level named volumes defined"
+    assert not compose.get("volumes"), "no top-level named volumes — state must be host-bound"
 
-    backend = compose["services"]["backend"]
-    sources = _sources(backend.get("volumes"))
-    assert sources, "backend persists nothing"
-    # Named volumes, not host binds — Greengrass state must not depend on /opt paths.
-    # (The Greengrass IPC socket is a runtime bind, not app state — exclude it.)
-    for src in sources:
-        if "AWS_GG_NUCLEUS_DOMAIN_SOCKET_FILEPATH_FOR_COMPONENT" in src:
-            continue
-        assert not src.startswith("/"), f"backend uses a host bind ({src}); use a named volume"
-        assert src in named, f"backend mounts '{src}' but it is not a declared named volume"
+    for name in ("backend", "app"):
+        binds = _sources(compose["services"][name].get("volumes"))
+        assert binds, f"{name} persists nothing"
+        # The sync outbox must be a stable /opt/aquila host bind.
+        assert "/opt/aquila/data" in binds, f"{name} sync outbox is not a /opt/aquila host bind"
+        # Every state mount (excluding the runtime IPC socket) is an /opt/aquila host bind.
+        for src in binds:
+            if "AWS_GG_NUCLEUS_DOMAIN_SOCKET_FILEPATH_FOR_COMPONENT" in src:
+                continue
+            assert src.startswith("/opt/aquila/"), (
+                f"{name} mounts '{src}' — state must bind /opt/aquila for cross-update persistence"
+            )

--- a/tests/unit/test_background_sync.py
+++ b/tests/unit/test_background_sync.py
@@ -28,6 +28,23 @@ def _seed_event(local_db, tmp_path):
     local_db.enqueue_event("run_complete", {"run_name": "Run 1", "profile": "p.json", "result": "ok"})
 
 
+def test_startup_initializes_sync_outbox_schema(tmp_path, monkeypatch):
+    # Regression: on a fresh device — or a fresh Greengrass named volume — the
+    # events table did not exist until the first run completed, so the background
+    # sync poller logged "no such table: events" every tick. App startup must
+    # create the schema so the outbox is readable immediately.
+    monkeypatch.setenv("AQ_LOCAL_DB_PATH", str(tmp_path / "fresh.db"))
+    from aquila_web import local_db, main as web_main
+
+    # Deliberately NO explicit init_local_db() here — the app's startup hook must
+    # do it. Entering the TestClient context runs the startup events.
+    with TestClient(web_main.app):
+        pass
+
+    # Reading the outbox works (returns empty) instead of raising "no such table".
+    assert local_db.get_pending_events() == []
+
+
 class TestClientCertificate:
     """Sync authenticates with the Device Certificate (mTLS), not x-api-key."""
 


### PR DESCRIPTION
Re-opens the app-stack fixes that were pushed to #390 *after* it merged (so they never landed). Cherry-picked cleanly onto the current `feat/greengrass-migration` (which already has the IPC wiring from #390).

## Why

sn01 was RUNNING `com.acorn.sentri` 0.1.17, all containers "healthy" — but the instrument wouldn't run, the kiosk UI was unreachable, the Update gate never engaged, and data didn't persist. The clean-room `greengrass-compose.yaml` had dropped config that made the app work, and its named volumes lost data on every update.

## Root causes (all found on-device)
1. **`app` had no `command`** → ran the default web server instead of **`application.py`** (the `AssayInterface` hardware controller). A Run press was accepted but nothing drove the instrument.
2. **`app` missing env** — `BACKEND_URL`, `DATA_DIR`, `PROFILE_DIR`, `RESULTS_PATH`, `CONFIG_DIR` — plus `pid: host`, healthcheck disable, `extra_hosts`, `depends_on`.
3. **UI unreachable** — `ports: 8080:8080`, but nginx listens on **80** → `curl localhost:8080` = HTTP 000. Fixed to `8080:80`.
4. **Data lost on every update** — relative *named volumes* get a per-version project prefix (`0114_aquila-data`, `0117_aquila-data`, …), so every update started on a fresh empty volume, abandoning prior runs + the unsynced sync-outbox, and a migrated device wouldn't see its `/opt/aquila` data.
5. **`no such table: events`** — the outbox schema was only created on run-complete, never at startup, so a fresh DB errored on every sync tick.

## Fixes
- **app**: `command: python3 application.py`, add app env incl. `BACKEND_URL`, `pid: host`, `healthcheck: disable`, `extra_hosts`, `depends_on: backend`.
- **backend**: add `DATA_DIR/PROFILE_DIR/RESULTS_PATH/CONFIG_DIR` + `KIOSK_CONTROL_URL`, `extra_hosts`.
- **ui**: map `8080:80`, add `extra_hosts`.
- **state → host binds**: `/opt/aquila/{results,logs,profiles,config,data}` (version-independent) so data survives every update and an existing device's data carries over on migration — also consistent with the host-side cert renewal (am#363).
- **DB init at startup**: `init_local_db()` in a startup hook (idempotent).
- Not reintroduced: watchtower, the #314 `dns: 172.18.0.1` hack, `RUNNING_IMAGE_DIGEST`.

## Tests
app runs `application.py` + reaches the backend; app healthcheck disabled; ui maps to nginx 80; state on `/opt/aquila` host binds (no named volumes); startup initializes the outbox schema on a fresh DB. 45 relevant tests green; zero new failures vs baseline.

## Still pending (on-device)
- [ ] Republish + deploy; confirm the instrument runs, the kiosk UI loads, the shadow publishes + the Update gate engages, and data persists across an update.

Part of #382.