### PR TITLE
Bump app_version 2.1.0.7 → 2.1.0.8

### DIFF
--- a/config_files/version.json
+++ b/config_files/version.json
@@ -1,3 +1,3 @@
 {
-    "app_version": "2.1.0.7"
+    "app_version": "2.1.0.8"
 }


### PR DESCRIPTION
Bumps `app_version` `2.1.0.7` → `2.1.0.8` so the next published component version is visibly newer — used to test the operator **Update button** gate on sn01 now that the app stack is functional (#391) and the IPC agent is connected (#390).

Expected on deploy: the running agent defers the update → red "1" badge on Settings + the Updates tab shows it pending → tap **Update Now** → switch applies when idle → Settings shows `2.1.0.8`.

No other changes.