### PR TITLE
Install awsiotsdk so the Greengrass update agent can connect (Part of am#382)

### DIFF
--- a/aquila_web/greengrass_ipc.py
+++ b/aquila_web/greengrass_ipc.py
@@ -66,7 +66,12 @@ def start_update_agent(gate, running_shas, assay_running, publish_interval_s=60)
     except Exception as e:  # noqa: BLE001 - off-device / IPC unavailable is fine
         import logging
 
-        logging.getLogger(__name__).info("Greengrass IPC unavailable, agent not started: %s", e)
+        # WARNING, not INFO: off-device this is expected, but on a real Sentri it
+        # means the agent silently did nothing (no shadow, no operator Update gate)
+        # — e.g. a missing awsiotsdk import. Make that visible in the logs.
+        logging.getLogger(__name__).warning(
+            "Greengrass IPC unavailable, update agent not started: %s", e
+        )
         return None
 
     agent = UpdateAgent(ipc, gate, running_shas, assay_running)

--- a/requirements-backend.txt
+++ b/requirements-backend.txt
@@ -12,3 +12,8 @@ spidev
 smbus2
 simple-rpc
 cryptography
+# AWS IoT Device SDK v2 — provides awsiot.greengrasscoreipc, which the on-device
+# update agent (am#382) uses to talk to the Greengrass nucleus over Core IPC
+# (publish the Device Shadow, defer component updates). Without it the agent's
+# import fails and it silently no-ops — no shadow, no operator Update gate.
+awsiotsdk

--- a/tests/fleet_device/test_greengrass_component.py
+++ b/tests/fleet_device/test_greengrass_component.py
@@ -66,6 +66,15 @@ def test_app_containers_reach_greengrass_ipc():
         )
 
 
+def test_image_includes_the_ipc_sdk():
+    # The update agent imports awsiot.greengrasscoreipc to reach the nucleus over
+    # Core IPC. If awsiotsdk isn't installed in the api image the import raises,
+    # the agent catches it and silently no-ops — no Device Shadow, no operator
+    # Update gate (the sn01 symptom: IPC env wired, but ModuleNotFoundError: awsiot).
+    reqs = Path("requirements-backend.txt").read_text()
+    assert "awsiotsdk" in reqs, "awsiotsdk missing — the IPC update agent can't import awsiot"
+
+
 def test_app_runs_the_hardware_controller():
     # The `app` service must run application.py (the AssayInterface ready/run/end
     # loop that drives the instrument), NOT the default web-server CMD. If it falls


### PR DESCRIPTION
## Root cause

On sn01 the update agent never connected — no Device Shadow, and the Update gate never engaged — **even though the IPC env + socket were wired correctly** (#390/#391). The reason: the api image never installed the **AWS IoT Device SDK**. The agent's first step is `import awsiot.greengrasscoreipc`; with `awsiotsdk` absent that raises `ModuleNotFoundError`, which `start_update_agent` catches and turns into a **silent no-op**.

Confirmed on-device:
```
docker exec aquila-backend python -c "import awsiot.greengrasscoreipc.clientv2"
→ ModuleNotFoundError: No module named 'awsiot'
```
Nucleus log showed **zero** IPC activity for `com.acorn.sentri` (not even an authorization denial) — consistent with the agent dying on import before it ever connected.

## Fix
- **`requirements-backend.txt`**: add `awsiotsdk` (provides `awsiot.greengrasscoreipc`).
- **`greengrass_ipc.py`**: log the "IPC unavailable, agent not started" path at **WARNING**, not INFO — on a real device this is a functional failure and must be visible. (Logging it at INFO is exactly what hid this.)
- **test**: assert the image ships `awsiotsdk`.

## Scope
This restores the agent's IPC connection, which is what the **Update gate** (SubscribeToComponentUpdates + DeferComponentUpdate) needs — those operations don't require `accessControl` or Shadow Manager.

The **Device Shadow** publishing is a *separate* follow-up: it additionally needs the `aws.greengrass.ShadowManager` component (not currently deployed) + an IPC `accessControl` policy in the recipe. Filing/handling that separately so it doesn't block the Update-button test.

## Verify on-device (after republish + deploy)
- [ ] `docker exec aquila-backend python -c "import awsiot"` succeeds
- [ ] deploying a new version is **held** (badge on Settings) until Update Now