### PR TITLE
Bump app_version 2.1.0.8 → 2.1.0.9 (gate end-to-end test)

### DIFF
--- a/config_files/version.json
+++ b/config_files/version.json
@@ -1,3 +1,3 @@
 {
-    "app_version": "2.1.0.8"
+    "app_version": "2.1.0.9"
 }


### PR DESCRIPTION
Bumps `app_version` `2.1.0.8` → `2.1.0.9` so the next published component version is visibly newer than what sn01 runs (0.1.24 / 2.1.0.8). Used to test the operator Update-button gate end-to-end now that the IPC agent is confirmed connected on sn01. No other changes.