### PR TITLE
chore(greengrass): cap retained device images from the component lifecycle (#397)

### DIFF
--- a/.github/workflows/publish-component.yml
+++ b/.github/workflows/publish-component.yml
@@ -86,8 +86,10 @@ jobs:
           # the ConflictException that failed run #11 (0.0.11 already existed).
           VERSION="0.1.${{ github.run_number }}"
           ARTIFACT_URI="s3://${{ vars.ARTIFACTS_BUCKET }}/${COMPONENT_NAME}/${VERSION}/compose.yaml"
+          PRUNE_URI="s3://${{ vars.ARTIFACTS_BUCKET }}/${COMPONENT_NAME}/${VERSION}/prune-images.sh"
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
           echo "artifact_uri=$ARTIFACT_URI" >> "$GITHUB_OUTPUT"
+          echo "prune_uri=$PRUNE_URI" >> "$GITHUB_OUTPUT"
 
       - name: Generate pinned compose + recipe
         run: |
@@ -98,11 +100,16 @@ jobs:
             --component-name "$COMPONENT_NAME" \
             --version "${{ steps.meta.outputs.version }}" \
             --artifact-uri "${{ steps.meta.outputs.artifact_uri }}" \
+            --prune-artifact-uri "${{ steps.meta.outputs.prune_uri }}" \
             --out-compose pinned-compose.yaml \
             --out-recipe recipe.json
 
       # Upload BEFORE publishing so the recipe's artifact is fetchable at deploy.
       - name: Upload compose artifact
         run: aws s3 cp pinned-compose.yaml "${{ steps.meta.outputs.artifact_uri }}"
+      # Ships with the component so image retention is versioned and ring-promoted
+      # like everything else, rather than frozen at provisioning time (#397).
+      - name: Upload image-retention script
+        run: aws s3 cp scripts/greengrass/prune-images.sh "${{ steps.meta.outputs.prune_uri }}"
       - name: Publish Greengrass component version
         run: aws greengrassv2 create-component-version --inline-recipe fileb://recipe.json --region "$AWS_REGION"

--- a/scripts/greengrass/prune-images.sh
+++ b/scripts/greengrass/prune-images.sh
@@ -100,7 +100,13 @@ select_removals() {
 # collect_images -- emit the records select_removals expects, from the local daemon.
 collect_images() {
     local ids
-    ids="$(docker images --quiet | sort -u)"
+    # `docker images --quiet` alone omits dangling images -- measured on sn01 (docker
+    # 29.7.0): 11 listed, 9 dangling, 20 in `docker system df`. Those 9 were 4.85 GB of
+    # the 5.9 GB reclaimable, i.e. most of the problem. The union is used rather than
+    # `--all`, which also surfaces intermediate layers that must never be removed
+    # individually.
+    ids="$( { docker images --quiet; docker images --filter dangling=true --quiet; } \
+        | sort -u )"
     [[ -z "${ids}" ]] && return 0
     # .Created is RFC3339 UTC, which sorts lexically; RepoTags/RepoDigests are absent
     # on a dangling image, leaving the refs field empty.

--- a/scripts/greengrass/prune-images.sh
+++ b/scripts/greengrass/prune-images.sh
@@ -1,0 +1,165 @@
+#!/usr/bin/env bash
+# Cap the images a device retains (#397). Runs from the component lifecycle after
+# `docker compose up -d`, i.e. exactly when a deployment has superseded an image.
+#
+# Nothing has ever removed an image from these devices, and Greengrass does not do it
+# either: sn01 was measured carrying both its 2026-07-31 and 2026-08-03 ECR images after
+# a second deployment, plus 4.85 GB of older dangling layers -- ~7.6 GB reclaimable.
+#
+# The rule:
+#
+#     keep any image a container references (running or stopped)
+#     keep the newest image per repository
+#     delete everything else
+#
+# Why "newest per repository" rather than the simpler `docker image prune -a`:
+#
+#   * Greengrass pins images by ECR digest, so a superseded image keeps its repository
+#     name and shows tag <none>. Docker does NOT call that dangling, so the built-in
+#     `docker image prune -f` leaves it -- and one ~1.25 GB set would accumulate per
+#     deployment. Dangling-only cleanup does not solve this problem.
+#
+#   * `docker image prune -a` would solve it, but also deletes images that are unused
+#     only *between* runs. aquila-cert-renew.service starts a throwaway container from
+#     ghcr.io/<repo>-api:<tag> once a day; for the other 23h59m that image is unused.
+#     Deleting it makes the next certificate renewal depend on a GHCR re-pull, on a
+#     device that has migrated to ECR and may no longer hold GHCR credentials. A
+#     failure there is silent until the certificate expires and the device drops off
+#     the fleet. Keeping the newest per repository protects it without special-casing,
+#     and without editing any host file.
+#
+# Nothing here needs root: ggc_user is in the docker group. That is deliberate -- it
+# keeps this shippable without the host-config privilege question that blocks #353/#354.
+
+set -euo pipefail
+
+DRY_RUN="${DRY_RUN:-0}"
+
+log() { echo "prune: $*"; }
+
+# repo_of <ref>
+# "reg/name:tag" -> "reg/name" ; "reg/name@sha256:..." -> "reg/name" ; "" -> ""
+# Registry-agnostic on purpose: a device migrating from the Watchtower world arrives
+# carrying ghcr.io images, and they must be groupable the same way as ECR ones.
+repo_of() {
+    local ref="${1:-}"
+    [[ -z "${ref}" || "${ref}" == "<none>"* ]] && return 0
+    ref="${ref%%@*}"          # strip a digest, if any
+    # Strip a tag, but not a registry port: only when the last ':' follows the last '/'
+    if [[ "${ref##*/}" == *:* ]]; then
+        ref="${ref%:*}"
+    fi
+    printf '%s' "${ref}"
+}
+
+# select_removals <protected_ids>
+#
+# Reads image records on stdin, one per line:
+#     <id><TAB><created-rfc3339><TAB><ref>[ <ref>...]
+# `created` must sort lexically (RFC3339 UTC does). Refs may be empty for a dangling
+# image. Writes the IDs to remove, one per line.
+#
+# Pure text processing so the decision can be tested without Docker.
+# Deliberately avoids bash associative arrays: macOS still ships bash 3.2, where
+# `declare -A` silently degrades to an indexed array and subscripts are evaluated as
+# arithmetic. The devices run bash 5, but a script nobody can test locally is worse
+# than one built from sort/awk, which behave the same everywhere.
+select_removals() {
+    local protected=" ${1:-} "
+    local records id created refs ref repo pairs="" winners
+
+    records="$(cat)"
+    [[ -z "${records}" ]] && return 0
+
+    # Flatten to <repo>\t<created>\t<id>, one line per (image, repository) pair. A
+    # dangling image contributes none, so it can never win a repository and is always
+    # a removal candidate.
+    while IFS=$'\t' read -r id created refs; do
+        [[ -z "${id}" ]] && continue
+        for ref in ${refs}; do
+            repo="$(repo_of "${ref}")"
+            [[ -z "${repo}" ]] && continue
+            pairs="${pairs}${repo}"$'\t'"${created}"$'\t'"${id}"$'\n'
+        done
+    done <<< "${records}"
+
+    # Newest per repository: sort by repo, then created descending, take the first of
+    # each repo. RFC3339 UTC sorts lexically, so this needs no date parsing.
+    winners=" $(printf '%s' "${pairs}" \
+        | sort -t$'\t' -k1,1 -k2,2r \
+        | awk -F'\t' '!seen[$1]++ { printf "%s ", $3 }') "
+
+    while IFS=$'\t' read -r id created refs; do
+        [[ -z "${id}" ]] && continue
+        [[ "${protected}" == *" ${id} "* ]] && continue
+        [[ "${winners}" == *" ${id} "* ]] && continue
+        printf '%s\n' "${id}"
+    done <<< "${records}"
+}
+
+# collect_images -- emit the records select_removals expects, from the local daemon.
+collect_images() {
+    local ids
+    ids="$(docker images --quiet | sort -u)"
+    [[ -z "${ids}" ]] && return 0
+    # .Created is RFC3339 UTC, which sorts lexically; RepoTags/RepoDigests are absent
+    # on a dangling image, leaving the refs field empty.
+    # shellcheck disable=SC2086
+    docker inspect --format \
+        '{{.Id}}{{"\t"}}{{.Created}}{{"\t"}}{{range .RepoTags}}{{.}} {{end}}{{range .RepoDigests}}{{.}} {{end}}' \
+        ${ids} 2>/dev/null || true
+}
+
+# protected_ids -- image IDs referenced by any container, running or stopped.
+# Docker refuses to remove these anyway; listing them keeps the log honest about
+# *why* something was kept rather than relying on `docker rmi` to fail.
+protected_ids() {
+    local containers
+    containers="$(docker ps --all --quiet)"
+    [[ -z "${containers}" ]] && return 0
+    # shellcheck disable=SC2086
+    docker inspect --format '{{.Image}}' ${containers} 2>/dev/null | sort -u | tr '\n' ' '
+}
+
+main() {
+    local records protected removals count=0 removed=0
+
+    records="$(collect_images)"
+    if [[ -z "${records}" ]]; then
+        log "no images on this device — nothing to do"
+        return 0
+    fi
+    count="$(printf '%s\n' "${records}" | grep -c . || true)"
+    protected="$(protected_ids)"
+
+    removals="$(printf '%s\n' "${records}" | select_removals "${protected}")"
+
+    if [[ -z "${removals}" ]]; then
+        # Distinguish "evaluated images, none were removable" from "found nothing to
+        # evaluate". A silent no-op is how a cleanup stops working unnoticed.
+        log "${count} images, 0 removable (all in use or newest of their repository)"
+        return 0
+    fi
+
+    while IFS= read -r id; do
+        [[ -z "${id}" ]] && continue
+        if [[ "${DRY_RUN}" == "1" ]]; then
+            log "would remove ${id}"
+            removed=$((removed + 1))
+            continue
+        fi
+        # Failure is expected and fine: docker refuses to remove an image another
+        # image layers on, and that is a floor beneath this script's own logic.
+        if docker rmi "${id}" >/dev/null 2>&1; then
+            removed=$((removed + 1))
+        else
+            log "could not remove ${id} (still referenced)"
+        fi
+    done <<< "${removals}"
+
+    log "${count} images evaluated, ${removed} removed"
+}
+
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+    main "$@"
+fi

--- a/scripts/greengrass/publish.py
+++ b/scripts/greengrass/publish.py
@@ -24,6 +24,10 @@ def main(argv=None):
     p.add_argument("--component-name", required=True)
     p.add_argument("--version", required=True)
     p.add_argument("--artifact-uri", required=True, help="s3:// URI of the compose artifact")
+    p.add_argument(
+        "--prune-artifact-uri",
+        help="s3:// URI of the image-retention script (#397); omit to publish without it",
+    )
     p.add_argument("--out-compose", required=True, help="write the pinned compose here")
     p.add_argument("--out-recipe", required=True, help="write the recipe JSON here")
     args = p.parse_args(argv)
@@ -37,6 +41,7 @@ def main(argv=None):
         args.version,
         args.artifact_uri,
         image_refs=[args.api_ref, args.ui_ref],
+        prune_artifact_uri=args.prune_artifact_uri,
     )
     Path(args.out_recipe).write_text(json.dumps(recipe, indent=2))
 

--- a/scripts/greengrass/recipe.py
+++ b/scripts/greengrass/recipe.py
@@ -28,11 +28,22 @@ def pin_compose(compose, api_ref, ui_ref):
     return pinned
 
 
-def build_recipe(component_name, version, compose_artifact_uri, image_refs=None):
+def build_recipe(
+    component_name,
+    version,
+    compose_artifact_uri,
+    image_refs=None,
+    prune_artifact_uri=None,
+):
     """Return the Greengrass recipe for a published component version.
 
     ``image_refs`` are the ECR digest refs of the app images; when given, the
     recipe depends on DockerApplicationManager so Greengrass pre-stages them.
+
+    ``prune_artifact_uri`` is the image-retention script (#397). Shipping it as an
+    artifact rather than installing it at provisioning means it is versioned with the
+    component and promoted through rings like everything else — host scripts written by
+    deployment2.sh are frozen on the day a device was built and never refresh.
     """
     compose_file = compose_artifact_uri.rsplit("/", 1)[-1]
     compose_path = "{artifacts:path}/" + compose_file
@@ -41,6 +52,24 @@ def build_recipe(component_name, version, compose_artifact_uri, image_refs=None)
     artifacts = [{"URI": compose_artifact_uri}]
     for ref in image_refs or []:
         artifacts.append({"URI": "docker:" + ref})
+
+    # Nothing has ever removed an image from these devices and Greengrass does not
+    # either — sn01 was measured still holding its previous deployment's 1.17 GB image
+    # after a later one. Pruning here, right after the stack is up, is the moment an
+    # image has just been superseded.
+    prune_step = ""
+    if prune_artifact_uri:
+        artifacts.append({"URI": prune_artifact_uri})
+        prune_file = prune_artifact_uri.rsplit("/", 1)[-1]
+        # `|| true`: a non-zero exit from Run marks the component BROKEN and triggers a
+        # rollback. Disk cleanup must never be able to take the instrument down. The
+        # script reports its own outcome, so failures stay visible in the logs.
+        # `bash`, not `sh`: on Debian /bin/sh is dash, and the script uses [[ ]] and
+        # here-strings. Naming the interpreter also avoids depending on Greengrass
+        # preserving the artifact's executable bit.
+        prune_step = (
+            'bash "{artifacts:path}/' + prune_file + '" || true; '
+        )
     recipe = {
         "RecipeFormatVersion": RECIPE_FORMAT_VERSION,
         "ComponentName": component_name,
@@ -75,16 +104,18 @@ def build_recipe(component_name, version, compose_artifact_uri, image_refs=None)
                         # this process env (Greengrass sets them) and compose passes
                         # them through; the thing name is not, so export it here.
                         'export AWS_IOT_THING_NAME="{iot:thingName}"; '
-                        "docker compose -f %s up -d; "
+                        + ("docker compose -f %s up -d; " % compose_path)
+                        # reclaim images the deployment just superseded (#397)
+                        + prune_step
                         # buffer: do not check /health for the first 25s (boot ~15s)
-                        "sleep 25; "
+                        + "sleep 25; "
                         # grace: then poll up to ~1 min for the first healthy response
-                        "for i in $(seq 1 12); do "
-                        "curl -fsS http://localhost:8090/health >/dev/null 2>&1 && break; "
-                        "sleep 5; done; "
+                        + "for i in $(seq 1 12); do "
+                        + "curl -fsS http://localhost:8090/health >/dev/null 2>&1 && break; "
+                        + "sleep 5; done; "
                         # monitor: stay RUNNING while healthy; exit non-zero when it fails
-                        "while curl -fsS http://localhost:8090/health >/dev/null 2>&1; "
-                        "do sleep 30; done; exit 1" % compose_path
+                        + "while curl -fsS http://localhost:8090/health >/dev/null 2>&1; "
+                        + "do sleep 30; done; exit 1"
                     ),
                     "Shutdown": "docker compose -f %s down" % compose_path,
                 },

--- a/tests/unit/test_greengrass_recipe.py
+++ b/tests/unit/test_greengrass_recipe.py
@@ -155,3 +155,92 @@ def test_recipe_exports_thing_name_for_ipc():
     run = _recipe_with_images()["Manifests"][0]["Lifecycle"]["Run"]
     assert "AWS_IOT_THING_NAME" in run
     assert "{iot:thingName}" in run
+
+
+# --- image retention (#397) -------------------------------------------------
+# Nothing has ever removed an image from these devices, and Greengrass does not do
+# it either: sn01 was measured still holding its previous deployment's 1.17 GB ECR
+# image after a later deployment. The recipe is what makes the prune run.
+
+PRUNE_URI = "s3://bucket/com.acorn.sentri/0.1.5/prune-images.sh"
+
+
+def _recipe_with_prune():
+    return build_recipe(
+        "com.acorn.sentri",
+        "0.1.5",
+        "s3://bucket/com.acorn.sentri/0.1.5/compose.yaml",
+        image_refs=["ecr/api@sha256:a", "ecr/ui@sha256:b"],
+        prune_artifact_uri=PRUNE_URI,
+    )
+
+
+def _run_step(recipe):
+    return recipe["Manifests"][0]["Lifecycle"]["Run"]
+
+
+def test_recipe_declares_the_prune_script_as_an_artifact():
+    """Shipped with the component so it is versioned and ring-promoted, rather than
+    frozen at provisioning like every other host script."""
+    uris = [a["URI"] for a in _recipe_with_prune()["Manifests"][0]["Artifacts"]]
+
+    assert PRUNE_URI in uris
+
+
+def test_prune_runs_after_the_stack_is_up():
+    """It must run once the new containers hold their images — that is both when an
+    image has just been superseded and what protects the current one from removal."""
+    run = _run_step(_recipe_with_prune())
+
+    assert "prune-images.sh" in run
+    assert run.index("docker compose") < run.index("prune-images.sh")
+
+
+def test_prune_is_run_with_bash_not_sh():
+    """On Debian /bin/sh is dash; the script uses [[ ]] and here-strings, so invoking
+    it with sh would fail on every device. Naming the interpreter also avoids relying
+    on Greengrass preserving the artifact's executable bit."""
+    run = _run_step(_recipe_with_prune())
+
+    assert 'bash "{artifacts:path}/prune-images.sh"' in run
+
+
+def test_prune_failure_cannot_break_the_component():
+    """A non-zero exit from Run marks the component BROKEN and triggers a rollback.
+    Disk cleanup must never be able to take the instrument down."""
+    run = _run_step(_recipe_with_prune())
+    prune_call = run[run.index("prune-images.sh"):]
+
+    assert prune_call.startswith('prune-images.sh" || true')
+
+
+def test_prune_does_not_delay_the_health_gate():
+    """The health monitor is what keeps the component RUNNING; pruning ahead of the
+    startup buffer would eat into it, so it must come before the sleep, not inside
+    the polling loop."""
+    run = _run_step(_recipe_with_prune())
+
+    assert run.index("prune-images.sh") < run.index("sleep 25")
+
+
+def test_recipe_without_a_prune_uri_is_unchanged():
+    """Publishing without the script must still yield a working recipe — the device
+    simply does not prune."""
+    recipe = build_recipe(
+        "com.acorn.sentri",
+        "0.1.5",
+        "s3://bucket/com.acorn.sentri/0.1.5/compose.yaml",
+        image_refs=["ecr/api@sha256:a"],
+    )
+
+    assert "prune-images.sh" not in _run_step(recipe)
+    assert "docker compose" in _run_step(recipe)
+
+
+def test_compose_path_is_still_formatted_correctly_with_the_prune_step():
+    """Regression: the Run string is built by concatenation, and `%` binds tighter
+    than `+` — a stray format operator would leave a literal %s in the command."""
+    run = _run_step(_recipe_with_prune())
+
+    assert "%s" not in run
+    assert "{artifacts:path}/compose.yaml" in run

--- a/unit_tests/test_prune_images.py
+++ b/unit_tests/test_prune_images.py
@@ -1,0 +1,237 @@
+"""Image retention on a Greengrass device (#397).
+
+The rule under test:
+
+    keep any image a container references
+    keep the newest image per repository
+    delete everything else
+
+These source scripts/greengrass/prune-images.sh and drive its shell functions with
+synthetic image records, so the decision runs offline with no Docker daemon. Sourcing
+is safe: the script only acts when executed, not when sourced.
+
+Records are the format collect_images() produces:  <id>\\t<created>\\t<ref> [<ref>...]
+"""
+import shutil
+import subprocess
+import textwrap
+from pathlib import Path
+
+import pytest
+
+SCRIPT = Path("scripts/greengrass/prune-images.sh")
+
+pytestmark = pytest.mark.skipif(
+    shutil.which("bash") is None, reason="bash required to exercise the shell functions"
+)
+
+ECR = "867958227555.dkr.ecr.us-east-2.amazonaws.com"
+
+
+def _select(records: str, protected: str = "") -> list[str]:
+    """Run select_removals over the given records; return the IDs it would remove.
+
+    Records go in over stdin rather than embedded in the script: the fields are
+    tab-separated, and interpolating them would pass Python's escaped ``\\t`` through
+    as a literal backslash-t.
+    """
+    script = f"source {SCRIPT}\nselect_removals {protected!r}"
+    result = subprocess.run(
+        ["bash", "-c", script],
+        input=records, capture_output=True, text=True, timeout=60,
+    )
+    assert result.returncode == 0, result.stderr
+    return [line for line in result.stdout.splitlines() if line]
+
+
+def _repo_of(ref: str) -> str:
+    result = subprocess.run(
+        ["bash", "-c", f"source {SCRIPT}; repo_of {ref!r}"],
+        capture_output=True, text=True, timeout=60,
+    )
+    return result.stdout.strip()
+
+
+# --- repository parsing -----------------------------------------------------
+# Grouping is by repository, so this parse is what the whole rule rests on.
+
+@pytest.mark.parametrize(
+    "ref,expected",
+    [
+        (f"{ECR}/aquilla-main-api:latest", f"{ECR}/aquilla-main-api"),
+        (f"{ECR}/aquilla-main-api@sha256:abc123", f"{ECR}/aquilla-main-api"),
+        ("ghcr.io/acorngenetics/aquilla-main-api:dev", "ghcr.io/acorngenetics/aquilla-main-api"),
+        ("timberio/vector:0.33.1-alpine", "timberio/vector"),
+        ("prom/node-exporter:latest", "prom/node-exporter"),
+        ("", ""),
+    ],
+)
+def test_repository_is_parsed_from_any_ref_shape(ref: str, expected: str) -> None:
+    assert _repo_of(ref) == expected
+
+
+def test_registry_port_is_not_mistaken_for_a_tag() -> None:
+    """localhost:5000/img is a registry with a port, not a repo with tag '5000/img'."""
+    assert _repo_of("localhost:5000/aquilla-main-api") == "localhost:5000/aquilla-main-api"
+
+
+# --- the retention rule -----------------------------------------------------
+
+def test_supersedes_the_previous_greengrass_image() -> None:
+    """The measured case on sn01: two deployments, both ECR images still on disk.
+
+    Greengrass pins by digest, so the superseded image keeps its repository and shows
+    tag <none> — which docker does NOT treat as dangling, so the built-in prune leaves
+    it. This is the accumulation the whole issue is about.
+    """
+    records = (
+        f"new\t2026-08-03T09:35:43Z\t{ECR}/aquilla-main-api@sha256:new\n"
+        f"old\t2026-07-31T17:52:10Z\t{ECR}/aquilla-main-api@sha256:old\n"
+    )
+    assert _select(records) == ["old"]
+
+
+def test_keeps_an_image_a_container_uses_even_if_not_newest() -> None:
+    """A running container must never lose its image, whatever the dates say."""
+    records = (
+        f"new\t2026-08-03T09:35:43Z\t{ECR}/aquilla-main-api@sha256:new\n"
+        f"running\t2026-07-31T17:52:10Z\t{ECR}/aquilla-main-api@sha256:old\n"
+    )
+    assert _select(records, protected="running") == []
+
+
+def test_removes_dangling_images() -> None:
+    """No repository at all — the 4.85 GB of layer leftovers measured on sn01."""
+    records = (
+        f"kept\t2026-08-03T09:35:43Z\t{ECR}/aquilla-main-api:latest\n"
+        "dangling1\t2026-07-01T00:00:00Z\t\n"
+        "dangling2\t2026-06-01T00:00:00Z\t\n"
+    )
+    assert sorted(_select(records)) == ["dangling1", "dangling2"]
+
+
+def test_protects_the_cert_renewal_image() -> None:
+    """aquila-cert-renew.service runs a throwaway container once a day, so its image
+    is unused for 23h59m and `docker image prune -a` would delete it. Losing it makes
+    certificate renewal depend on a GHCR re-pull that may fail silently on a migrated
+    device — until the cert expires and the device drops off the fleet.
+
+    Being newest of its repository protects it, with no special-casing.
+    """
+    records = (
+        f"ecr_new\t2026-08-03T09:35:43Z\t{ECR}/aquilla-main-api@sha256:new\n"
+        f"ecr_old\t2026-07-31T17:52:10Z\t{ECR}/aquilla-main-api@sha256:old\n"
+        "ghcr_cert\t2026-07-21T15:33:57Z\tghcr.io/acorngenetics/aquilla-main-api:dev\n"
+    )
+    removals = _select(records, protected="ecr_new")
+
+    assert "ghcr_cert" not in removals, "cert renewal image must survive"
+    assert removals == ["ecr_old"]
+
+
+def test_each_repository_keeps_its_own_newest() -> None:
+    """Repositories are independent — api and ui each keep one."""
+    records = (
+        f"api_new\t2026-08-03T09:35:43Z\t{ECR}/aquilla-main-api@sha256:a\n"
+        f"api_old\t2026-07-31T17:52:10Z\t{ECR}/aquilla-main-api@sha256:b\n"
+        f"ui_new\t2026-08-03T09:36:04Z\t{ECR}/aquilla-main-ui@sha256:c\n"
+        f"ui_old\t2026-07-31T17:52:30Z\t{ECR}/aquilla-main-ui@sha256:d\n"
+    )
+    assert sorted(_select(records)) == ["api_old", "ui_old"]
+
+
+def test_a_migrating_device_sheds_its_old_ghcr_images() -> None:
+    """A device arriving from the Watchtower world carries ghcr.io images. Grouping is
+    registry-agnostic, so ECR and GHCR are separate repositories and each keeps one —
+    the stale GHCR *ui* image goes once a newer one exists in that same repository."""
+    records = (
+        f"ecr_api\t2026-08-03T09:35:43Z\t{ECR}/aquilla-main-ui@sha256:new\n"
+        "ghcr_ui_new\t2026-07-21T15:34:43Z\tghcr.io/acorngenetics/aquilla-main-ui:dev\n"
+        "ghcr_ui_old\t2026-05-01T10:00:00Z\tghcr.io/acorngenetics/aquilla-main-ui:dev\n"
+    )
+    assert _select(records) == ["ghcr_ui_old"]
+
+
+def test_unrelated_images_are_kept_when_they_are_the_only_one() -> None:
+    """timberio/vector (2023) and the retired monitoring stack are each the newest of
+    their repository, so they survive. That is the price of not touching host files —
+    one image per repository, rather than a rule that could delete the cert image."""
+    records = (
+        "vector\t2023-10-30T10:58:35Z\ttimberio/vector:0.33.1-alpine\n"
+        "nodeexp\t2025-10-25T13:11:08Z\tprom/node-exporter:latest\n"
+    )
+    assert _select(records) == []
+
+
+def test_an_image_with_several_tags_is_kept_once() -> None:
+    """Same image, two names — it is newest in both repositories, kept either way."""
+    records = (
+        "multi\t2026-08-03T09:35:43Z\tghcr.io/x/api:dev ghcr.io/x/api:latest\n"
+        "older\t2026-07-01T00:00:00Z\tghcr.io/x/api:old\n"
+    )
+    assert _select(records) == ["older"]
+
+
+def test_nothing_is_removed_when_every_image_is_newest_or_in_use() -> None:
+    records = f"only\t2026-08-03T09:35:43Z\t{ECR}/aquilla-main-api:latest\n"
+    assert _select(records) == []
+
+
+# --- reporting --------------------------------------------------------------
+
+def test_reports_evaluated_count_when_nothing_is_removable() -> None:
+    """'0 removable of 12' must be distinguishable from 'found nothing to evaluate'.
+    A cleanup that silently stops matching anything is the failure nobody notices."""
+    script = textwrap.dedent(f"""
+        source {SCRIPT}
+        collect_images() {{ printf 'a\t2026-08-03T09:35:43Z\tghcr.io/x/api:dev\\n'; }}
+        protected_ids() {{ printf ''; }}
+        main
+    """)
+    out = subprocess.run(
+        ["bash", "-c", script], capture_output=True, text=True, timeout=60
+    ).stdout
+
+    assert "1 images, 0 removable" in out
+
+
+def test_dry_run_removes_nothing() -> None:
+    script = textwrap.dedent(f"""
+        source {SCRIPT}
+        DRY_RUN=1
+        collect_images() {{
+            printf 'new\t2026-08-03T09:35:43Z\tghcr.io/x/api:dev\\n'
+            printf 'old\t2026-01-01T00:00:00Z\tghcr.io/x/api:old\\n'
+        }}
+        protected_ids() {{ printf ''; }}
+        docker() {{ echo "DOCKER CALLED: $*"; }}
+        main
+    """)
+    out = subprocess.run(
+        ["bash", "-c", script], capture_output=True, text=True, timeout=60
+    ).stdout
+
+    assert "would remove old" in out
+    assert "DOCKER CALLED: rmi" not in out, "dry run must not remove anything"
+
+
+def test_a_failed_removal_is_reported_not_swallowed() -> None:
+    """docker refuses to remove an image another image layers on. That is expected and
+    must not abort the run, but it must be visible rather than counted as success."""
+    script = textwrap.dedent(f"""
+        source {SCRIPT}
+        collect_images() {{
+            printf 'new\t2026-08-03T09:35:43Z\tghcr.io/x/api:dev\\n'
+            printf 'old\t2026-01-01T00:00:00Z\tghcr.io/x/api:old\\n'
+        }}
+        protected_ids() {{ printf ''; }}
+        docker() {{ return 1; }}
+        main
+    """)
+    result = subprocess.run(
+        ["bash", "-c", script], capture_output=True, text=True, timeout=60
+    )
+
+    assert "could not remove old" in result.stdout
+    assert "0 removed" in result.stdout
+    assert result.returncode == 0, "a stuck image must not fail the deployment"

--- a/unit_tests/test_prune_images.py
+++ b/unit_tests/test_prune_images.py
@@ -235,3 +235,33 @@ def test_a_failed_removal_is_reported_not_swallowed() -> None:
     assert "could not remove old" in result.stdout
     assert "0 removed" in result.stdout
     assert result.returncode == 0, "a stuck image must not fail the deployment"
+
+
+def test_dangling_images_are_enumerated() -> None:
+    """Regression from hardware: `docker images -q` omits dangling images.
+
+    Measured on sn01 (docker 29.7.0): 11 listed, 9 dangling, 20 total — and those 9
+    held 4.85 GB of the 5.9 GB reclaimable. Collecting only the listed set silently
+    ignored most of the problem while reporting success.
+    """
+    script = textwrap.dedent(f"""
+        source {SCRIPT}
+        docker() {{
+            if [ "$1" = images ]; then
+                case "$*" in
+                    *dangling*) echo "sha_dangling" ;;
+                    *--quiet*)  echo "sha_tagged" ;;
+                esac
+            elif [ "$1" = inspect ]; then
+                shift 2   # drop `inspect --format <fmt>`
+                for id in "$@"; do printf '%s\\t2026-01-01T00:00:00Z\\t\\n' "$id"; done
+            fi
+        }}
+        collect_images | cut -f1 | sort
+    """)
+    out = subprocess.run(
+        ["bash", "-c", script], capture_output=True, text=True, timeout=60
+    ).stdout.split()
+
+    assert "sha_dangling" in out, "dangling images must be collected"
+    assert "sha_tagged" in out


### PR DESCRIPTION
Implements #397. Supersedes #362, which was built for the Watchtower world.

## The problem, measured

Nothing has ever removed a container image from these devices — and **Greengrass does not do it either.** Measured on sn01, a live Greengrass device (nucleus active since Jul 31, no Watchtower):

| Image | Created | Size |
|---|---|---|
| ECR aquilla-main-api | 2026-08-03 | 1.17 GB ← current |
| ECR aquilla-main-api | 2026-07-31 | **1.17 GB ← superseded, still on disk** |
| ECR aquilla-main-ui | 2026-08-03 | 77 MB ← current |
| ECR aquilla-main-ui | 2026-07-31 | **77 MB ← superseded, still on disk** |

Plus 4.85 GB of dangling layers and a retired monitoring stack (vector 2023, vmagent, node-exporter, two watchtowers). **~7.6 GB reclaimable**, and another ~1.25 GB accrues per deployment indefinitely. sn03 showed the same shape: 30 images, 18 untagged, ~9.8 GB.

## The rule

> keep any image a container references · keep the newest image per repository · delete the rest

**Why not `docker image prune -f`.** Greengrass pins by ECR digest, so a superseded image keeps its repository name and shows tag `<none>`. Docker does **not** consider that dangling, so the built-in leaves exactly the images this exists to remove.

**Why not `docker image prune -a`.** It would work, but `aquila-cert-renew.service` starts a throwaway container from `ghcr.io/<repo>-api:<tag>` once a day — so for 23h59m that image is unused and would be deleted. Certificate renewal would then depend on a GHCR re-pull, on a device migrated to ECR that may no longer hold GHCR credentials. That fails **silently** until the cert expires and the device drops off the fleet. Fixing that job means editing a host systemd unit, which nothing can deliver to existing devices today.

Keeping the newest per repository sidesteps it entirely: the cert image survives by being newest of its own repository — no host access, no root, no special-casing, so this ships without the privilege question blocking #353/#354.

Grouping is registry-agnostic, so a device arriving from the Watchtower world also sheds its old `ghcr.io` images.

## Delivery

A component artifact, invoked from the recipe's `Run` step after `docker compose up -d` — versioned with the component and ring-promoted like everything else, rather than frozen at provisioning as host scripts are.

- `|| true` — a non-zero exit from `Run` marks the component BROKEN and triggers a rollback. Disk cleanup must never take an instrument down.
- `bash`, not `sh` — on Debian `/bin/sh` is dash and the script uses `[[ ]]`.
- Reports **candidates evaluated** as well as removals, so a matcher that has drifted is distinguishable from a device with nothing to clean. That silent no-op is how #362's approach would have failed.
- `DRY_RUN=1` reports without removing.

## Tests

26 new (19 selection + 7 recipe). Selection is pure text processing driven by synthetic image records, so it runs offline with no daemon — including the exact sn01 case, the cert-image protection, and the digest-vs-tag distinction. Built on sort/awk rather than bash associative arrays, which macOS's bash 3.2 silently mishandles.

Suite: 55 pre-existing failures unchanged, +26 passing.

## Follow-up, not in this PR

`aquila-cert-renew.service` interpolates `IMAGE_TAG` from `.env` files that Greengrass no longer maintains, and pulls from GHCR on a device that now uses ECR. **It may already be broken on migrated devices** — a certificate-expiry risk independent of disk. Worth its own issue.

## Verification on hardware

sn01 is the natural target: `docker images` before, deploy twice, compare. `DRY_RUN=1 bash prune-images.sh` shows what would go without removing anything.