### PR TITLE
Recipe: ShadowManager dependency + shadow IPC accessControl (Part of am#395)

### DIFF
--- a/aquila_web/greengrass_ipc.py
+++ b/aquila_web/greengrass_ipc.py
@@ -92,11 +92,21 @@ def start_update_agent(gate, running_shas, assay_running, record_pre_update=None
 
     # Report health (running SHAs + Container Health) on an interval.
     def _publish_loop():
+        import logging
+
+        log = logging.getLogger(__name__)
+        warned = False
         while True:
             try:
                 agent.publish_health()
-            except Exception:  # noqa: BLE001 - a transient IPC error must not kill the loop
-                pass
+                warned = False
+            except Exception as e:  # noqa: BLE001 - must not kill the loop
+                # Log the FIRST failure of a run at WARNING (a persistently failing
+                # shadow — e.g. missing ShadowManager/accessControl, #395 — must be
+                # visible, not silently swallowed), then stay quiet to avoid spam.
+                if not warned:
+                    log.warning("Device Shadow publish failed: %s", e)
+                    warned = True
             time.sleep(publish_interval_s)
 
     threading.Thread(target=_publish_loop, daemon=True).start()

--- a/aquila_web/greengrass_ipc.py
+++ b/aquila_web/greengrass_ipc.py
@@ -41,20 +41,27 @@ class GreengrassIpc:
             payload=json.dumps({"state": {"reported": payload}}).encode(),
         )
 
-    def subscribe_to_component_updates(self, on_pre_update):
+    def subscribe_to_component_updates(self, on_pre_update, on_post_update=None):
         # PreComponentUpdateEvent carries the deploymentId; the handler decides
-        # whether to defer. Returns after establishing the stream.
-        self._client.subscribe_to_component_updates(
-            on_stream_event=lambda ev: (
+        # whether to defer. PostComponentUpdateEvent fires once a deployment
+        # completes — used to re-resolve the "last update failed" banner (am#394)
+        # without waiting for a reboot. Returns after establishing the stream.
+        def _handle(ev):
+            if getattr(ev, "pre_update_event", None):
                 on_pre_update(ev.pre_update_event.deployment_id)
-                if getattr(ev, "pre_update_event", None)
-                else None
-            )
-        )
+            elif on_post_update and getattr(ev, "post_update_event", None):
+                on_post_update(ev.post_update_event.deployment_id)
+
+        self._client.subscribe_to_component_updates(on_stream_event=_handle)
 
 
-def start_update_agent(gate, running_shas, assay_running, publish_interval_s=60):
+def start_update_agent(gate, running_shas, assay_running, record_pre_update=None,
+                       on_post_update=None, publish_interval_s=60):
     """Bring up the on-device agent: defer-gate on updates + periodic shadow publish.
+
+    ``record_pre_update`` persists the build running just before a switch; the agent
+    calls it when it lets an update apply. ``on_post_update`` fires when a Greengrass
+    deployment completes, so the banner is re-resolved immediately (am#394).
 
     Best-effort — if Greengrass IPC isn't available (off-device), it logs and
     returns without starting, so it never breaks a non-Greengrass boot.
@@ -74,10 +81,13 @@ def start_update_agent(gate, running_shas, assay_running, publish_interval_s=60)
         )
         return None
 
-    agent = UpdateAgent(ipc, gate, running_shas, assay_running)
-    # Defer/apply each offered update via the gate.
+    agent = UpdateAgent(ipc, gate, running_shas, assay_running,
+                        record_pre_update=record_pre_update)
+    # Defer/apply each offered update via the gate; re-resolve the banner on the
+    # post-update event.
     ipc.subscribe_to_component_updates(
-        lambda deployment_id: agent.handle_update_offer(deployment_id, deployment_id)
+        lambda deployment_id: agent.handle_update_offer(deployment_id, deployment_id),
+        on_post_update=on_post_update,
     )
 
     # Report health (running SHAs + Container Health) on an interval.

--- a/aquila_web/main.py
+++ b/aquila_web/main.py
@@ -2232,6 +2232,48 @@ async def _do_check_update() -> None:
 
 from aquila_web import update_gate
 
+# Persisted (host-bind) record of the build running just before a switch is
+# allowed. Written by the agent when it lets an update apply; read on the next
+# boot / post-update event to tell whether Greengrass applied it or rolled back —
+# the signal behind the "last update failed" banner (am#394). On /opt/aquila/data
+# so it survives the container recreate an update causes.
+_PRE_UPDATE_SHA_PATH = os.getenv("AQ_PRE_UPDATE_SHA_PATH", "/opt/aquila/data/.pre_update_sha")
+
+
+def _write_pre_update_sha(sha: str | None) -> None:
+    try:
+        with open(_PRE_UPDATE_SHA_PATH, "w") as f:
+            f.write(sha or "")
+    except OSError as e:
+        logger.warning("could not record pre-update sha: %s", e)
+
+
+def _read_pre_update_sha() -> str | None:
+    try:
+        with open(_PRE_UPDATE_SHA_PATH) as f:
+            return f.read().strip() or None
+    except OSError:
+        return None
+
+
+def _clear_pre_update_sha() -> None:
+    try:
+        os.remove(_PRE_UPDATE_SHA_PATH)
+    except OSError:
+        pass
+
+
+def _resolve_update_banner() -> None:
+    """Raise/clear the 'last update failed' banner from the pre-update record.
+
+    Run on boot and on each Greengrass post-update event: compare the recorded
+    pre-apply build to the one running now (baked git_sha) and mark the gate.
+    """
+    running_sha = _running_container_shas()[0]  # this image's baked git_sha
+    update_gate.resolve_update_result(
+        _read_pre_update_sha(), running_sha, update_gate.GATE, _clear_pre_update_sha
+    )
+
 
 @app.get("/update/gate")
 async def get_update_gate():
@@ -2487,8 +2529,17 @@ async def start_greengrass_update_agent() -> None:
     No-ops off-device (Greengrass IPC unavailable) so local/dev boots are unaffected."""
     from aquila_web.greengrass_ipc import start_update_agent
 
+    # Boot-time trigger: if we came back on the pre-update build, an update rolled
+    # back → raise the banner (am#394). Safe no-op when nothing was in flight.
+    _resolve_update_banner()
+
     start_update_agent(
         update_gate.GATE,
         running_shas=_running_container_shas,
         assay_running=lambda: current_item.screen == "running",
+        # The agent records the build we're leaving behind just before a switch,
+        # and re-resolves the banner immediately on a Greengrass post-update event
+        # (so a rollback shows without waiting for a reboot).
+        record_pre_update=_write_pre_update_sha,
+        on_post_update=lambda deployment_id: _resolve_update_banner(),
     )

--- a/aquila_web/static/nav.js
+++ b/aquila_web/static/nav.js
@@ -14,6 +14,30 @@ document.addEventListener("click", (event) => {
   link.blur();
 });
 
+// Non-blocking banner when the last update failed and the Sentri rolled back to
+// the previous version (am#394). Shown on every screen so the operator knows
+// which version they're on; it never blocks runs. Sourced from /update/gate.
+(function showUpdateFailedBanner() {
+  if (document.getElementById("update-failed-banner")) return;
+  fetch("/update/gate")
+    .then(r => r.ok ? r.json() : null)
+    .then(data => {
+      const banner = data && data.banner;
+      if (!banner || !banner.message) return;
+      const bar = document.createElement("div");
+      bar.id = "update-failed-banner";
+      bar.textContent = banner.message;
+      bar.style.cssText = [
+        "position:fixed", "top:0", "left:0", "width:100%", "z-index:9998",
+        "box-sizing:border-box", "padding:8px 16px", "text-align:center",
+        "font-size:14px", "font-weight:600", "background:#fef3c7",
+        "color:#92400e", "border-bottom:1px solid #f59e0b",
+      ].join(";");
+      document.body.appendChild(bar);
+    })
+    .catch(() => {});
+})();
+
 // Show a red "1" badge on the Settings nav item when Greengrass has a version
 // pending the operator's approval (am#382). Cleared once approved (or applied).
 (function checkUpdateBadge() {

--- a/aquila_web/static/settings.html
+++ b/aquila_web/static/settings.html
@@ -275,6 +275,11 @@
         `;
         return;
       }
+      // Non-blocking notice when the last update failed and the device reverted
+      // to the previous version (am#394). Reused across the states below.
+      const bannerHtml = (data.banner && data.banner.message)
+        ? `<div style="margin:0 0 16px;padding:10px 14px;border-radius:8px;background:#fef3c7;color:#92400e;border:1px solid #f59e0b;font-size:14px;font-weight:600;">${_escHtml(data.banner.message)}</div>`
+        : "";
       if (data.pending && data.approved) {
         // Already approved — the deferred switch will apply when idle and restart
         // the app; hold the overlay until it does.
@@ -285,7 +290,7 @@
         if (dot) dot.style.display = "block";
         const ver = data.target_version
           ? ` (version ${_escHtml(String(data.target_version))})` : "";
-        area.innerHTML = `
+        area.innerHTML = bannerHtml + `
           <p style="font-size:15px;color:#1a1c1c;line-height:1.6;margin:0 0 18px;">
             A software update${ver} is ready to install. It applies when the instrument is idle.
           </p>
@@ -300,7 +305,7 @@
         `;
       } else {
         if (dot) dot.style.display = "none";
-        area.innerHTML = '<p style="color:#16a34a;font-size:15px;font-weight:600;">✓ Software is up to date.</p>';
+        area.innerHTML = bannerHtml + '<p style="color:#16a34a;font-size:15px;font-weight:600;">✓ Software is up to date.</p>';
       }
     }
 

--- a/aquila_web/update_agent.py
+++ b/aquila_web/update_agent.py
@@ -11,11 +11,15 @@ from aquila_web.version_health import build_shadow_report
 
 
 class UpdateAgent:
-    def __init__(self, ipc, gate, running_shas, assay_running):
+    def __init__(self, ipc, gate, running_shas, assay_running, record_pre_update=None):
         self._ipc = ipc
         self._gate = gate
         self._running_shas = running_shas
         self._assay_running = assay_running
+        # Records the build running just before a switch is allowed, so a later
+        # boot/post-update event can tell whether Greengrass applied or rolled back
+        # (am#394). No-op by default (off-device / tests that don't care).
+        self._record_pre_update = record_pre_update or (lambda sha: None)
 
     def handle_update_offer(self, deployment_id, version):
         """Greengrass offers `version` — hold it until idle AND operator-approved."""
@@ -23,6 +27,9 @@ class UpdateAgent:
         if not self._gate.should_apply(self._assay_running()):
             self._ipc.defer_component_update(deployment_id)
             return "deferred"
+        # About to let the switch take — record the build we're leaving behind.
+        api_sha, _ = self._running_shas()
+        self._record_pre_update(api_sha)
         return "applied"
 
     def publish_health(self):

--- a/aquila_web/update_gate.py
+++ b/aquila_web/update_gate.py
@@ -6,7 +6,7 @@ operator approves, and the switch only applies when idle. Pure in-process state
 built on the tested version_health decisions — the Phase-2 Greengrass IPC agent
 reads it to decide whether to DeferComponentUpdate.
 """
-from aquila_web.version_health import should_defer_update, update_banner
+from aquila_web.version_health import should_defer_update, update_banner, update_outcome
 
 
 class UpdateGate:
@@ -44,6 +44,22 @@ class UpdateGate:
             "approved": self._approved,
             "banner": update_banner(self._last_update_failed),
         }
+
+
+def resolve_update_result(recorded_sha, running_sha, gate, clear_record):
+    """Turn the pre-apply sha + the running sha into a banner decision (am#394).
+
+    ``recorded_sha`` is the build recorded just before a switch was allowed;
+    ``running_sha`` is what's running now. On success the switch took, so forget
+    the record. On rollback we're back on the old build — raise the banner and
+    KEEP the record so the banner survives reboots until a later update succeeds.
+    """
+    outcome = update_outcome(recorded_sha, running_sha)
+    if outcome == "succeeded":
+        clear_record()
+    elif outcome == "rolled_back":
+        gate.mark_update_failed()
+    return outcome
 
 
 # Process-wide gate shared by the FastAPI endpoints and the Phase-2 Greengrass IPC

--- a/aquila_web/version_health.py
+++ b/aquila_web/version_health.py
@@ -52,6 +52,22 @@ def update_banner(last_update_failed):
     }
 
 
+def update_outcome(recorded_sha, running_sha):
+    """Did the last update apply, given the git_sha recorded just before the switch?
+
+    ``recorded_sha`` is the build the device was running when it let an update
+    apply (``None`` if no update was in flight); ``running_sha`` is the build it is
+    running now — the ground truth of what Greengrass actually left it on.
+
+    - ``none`` — nothing was in flight, or the current build is unknown (fail safe)
+    - ``succeeded`` — now on a different build ⇒ the switch took
+    - ``rolled_back`` — same build as before ⇒ Greengrass reverted us (update failed)
+    """
+    if not recorded_sha or not running_sha:
+        return "none"
+    return "succeeded" if running_sha != recorded_sha else "rolled_back"
+
+
 def should_defer_update(assay_running, operator_approved):
     """Whether to DeferComponentUpdate instead of switching now.
 

--- a/scripts/greengrass/recipe.py
+++ b/scripts/greengrass/recipe.py
@@ -45,6 +45,28 @@ def build_recipe(component_name, version, compose_artifact_uri, image_refs=None)
         "RecipeFormatVersion": RECIPE_FORMAT_VERSION,
         "ComponentName": component_name,
         "ComponentVersion": version,
+        # Authorize the Device-Shadow IPC ops the update agent uses. Without this
+        # policy the nucleus denies UpdateThingShadow and publish_health() fails
+        # silently (the sn04-shadow gap). Scoped to THIS core device's own classic
+        # shadow (least privilege) — {iot:thingName} resolves on-device.
+        "ComponentConfiguration": {
+            "DefaultConfiguration": {
+                "accessControl": {
+                    "aws.greengrass.ShadowManager": {
+                        component_name + ":shadow:1": {
+                            "policyDescription": (
+                                "Access this core device's own classic shadow"
+                            ),
+                            "operations": [
+                                "aws.greengrass#GetThingShadow",
+                                "aws.greengrass#UpdateThingShadow",
+                            ],
+                            "resources": ["$aws/things/{iot:thingName}/shadow"],
+                        }
+                    }
+                }
+            }
+        },
         # Greengrass pulls/pre-stages the ECR images (via the device's token
         # exchange creds) before the compose stack runs. TokenExchangeService is
         # what mints those creds from the device cert — required for private ECR,
@@ -54,6 +76,13 @@ def build_recipe(component_name, version, compose_artifact_uri, image_refs=None)
                 "VersionRequirement": ">=2.0.0",
             },
             "aws.greengrass.TokenExchangeService": {
+                "VersionRequirement": ">=2.0.0",
+            },
+            # Services the Device-Shadow IPC ops the update agent uses (am#382/#395)
+            # — publishing running SHAs + Container Health. As a recipe dependency it
+            # ships with every deployment; the deployment configures it to sync the
+            # core device's classic shadow to the cloud.
+            "aws.greengrass.ShadowManager": {
                 "VersionRequirement": ">=2.0.0",
             },
         },

--- a/tests/unit/test_greengrass_recipe.py
+++ b/tests/unit/test_greengrass_recipe.py
@@ -124,6 +124,37 @@ def test_recipe_depends_on_token_exchange_service():
     assert "aws.greengrass.TokenExchangeService" in deps
 
 
+def test_recipe_depends_on_shadow_manager():
+    deps = _recipe_with_images()["ComponentDependencies"]
+    # The update agent publishes the Device Shadow over IPC (am#382/#395); the
+    # ShadowManager component is what services those shadow IPC ops on-device.
+    # As a recipe dependency it ships with every deployment.
+    assert "aws.greengrass.ShadowManager" in deps
+
+
+def _shadow_access_policies(recipe):
+    ac = recipe["ComponentConfiguration"]["DefaultConfiguration"]["accessControl"]
+    return ac["aws.greengrass.ShadowManager"]
+
+
+def test_recipe_authorizes_the_shadow_ipc_operations():
+    # Shadow IPC ops are denied without an accessControl policy — this is exactly
+    # why publish_health() failed silently on sn01. Grant get + update.
+    policies = _shadow_access_policies(_recipe_with_images())
+    ops = [op for pol in policies.values() for op in pol["operations"]]
+    assert "aws.greengrass#UpdateThingShadow" in ops
+    assert "aws.greengrass#GetThingShadow" in ops
+
+
+def test_shadow_access_is_scoped_to_the_devices_own_shadow():
+    # Least privilege (PRD testing decision): the component may touch only THIS
+    # core device's classic shadow, not every thing's shadow.
+    policies = _shadow_access_policies(_recipe_with_images())
+    resources = [r for pol in policies.values() for r in pol["resources"]]
+    assert "*" not in resources
+    assert any("{iot:thingName}" in r and r.endswith("/shadow") for r in resources)
+
+
 def test_recipe_declares_images_as_docker_artifacts():
     artifacts = _recipe_with_images()["Manifests"][0]["Artifacts"]
     uris = [a["URI"] for a in artifacts]

--- a/tests/unit/test_update_agent.py
+++ b/tests/unit/test_update_agent.py
@@ -72,6 +72,26 @@ def test_defers_during_an_assay_even_when_approved():
     assert action == "deferred"  # never interrupt a run
 
 
+def test_records_the_pre_update_sha_when_it_lets_an_update_apply():
+    # Just before the switch takes, the agent records the build it's running now,
+    # so that after the switch (or a rollback) it can tell what Greengrass left it
+    # on — the signal that drives the "last update failed" banner (am#394).
+    ipc = FakeIpc()
+    gate = UpdateGate()
+    recorded = []
+    agent = UpdateAgent(
+        ipc, gate, running_shas=lambda: ("cur_sha", "cur_sha"),
+        assay_running=lambda: False, record_pre_update=recorded.append,
+    )
+    gate.mark_pending("0.1.20")
+    gate.approve()
+
+    action = agent.handle_update_offer("deploy-1", "0.1.20")
+
+    assert action == "applied"
+    assert recorded == ["cur_sha"]  # the (api) build running just before the switch
+
+
 def test_publish_health_reports_matched_pair_to_the_shadow():
     ipc = FakeIpc()
     agent = UpdateAgent(

--- a/tests/unit/test_update_gate.py
+++ b/tests/unit/test_update_gate.py
@@ -14,7 +14,35 @@ import pytest
 
 pytestmark = pytest.mark.unit
 
-from aquila_web.update_gate import UpdateGate
+from aquila_web.update_gate import UpdateGate, resolve_update_result
+
+
+def test_resolve_marks_failed_and_keeps_record_on_rollback():
+    # Recorded "old" before applying, still "old" now ⇒ Greengrass rolled back.
+    # The banner shows, and the record is KEPT so the banner persists across
+    # reboots until a later successful update clears it (am#394).
+    gate = UpdateGate()
+    cleared = []
+    resolve_update_result("old", "old", gate, clear_record=lambda: cleared.append(True))
+    assert gate.status()["banner"] is not None
+    assert cleared == []
+
+
+def test_resolve_clears_and_no_banner_on_success():
+    # Now on a different build ⇒ the switch took. Forget the record, no banner.
+    gate = UpdateGate()
+    cleared = []
+    resolve_update_result("old", "new", gate, clear_record=lambda: cleared.append(True))
+    assert gate.status()["banner"] is None
+    assert cleared == [True]
+
+
+def test_resolve_is_a_noop_when_no_update_was_in_flight():
+    gate = UpdateGate()
+    cleared = []
+    resolve_update_result(None, "new", gate, clear_record=lambda: cleared.append(True))
+    assert gate.status()["banner"] is None
+    assert cleared == []
 
 
 def test_approved_pending_update_applies_when_idle():

--- a/tests/unit/test_version_health.py
+++ b/tests/unit/test_version_health.py
@@ -19,7 +19,36 @@ from aquila_web.version_health import (
     runs_allowed,
     should_defer_update,
     update_banner,
+    update_outcome,
 )
+
+
+class TestUpdateOutcome:
+    """Did the last update apply, or did Greengrass roll it back? (am#394)
+
+    The device records the git_sha it was running just before it let an update
+    apply. On the next boot (or a post-update event) it compares that to the sha
+    it's actually running now — the ground truth of what Greengrass left it on.
+    """
+
+    def test_rolled_back_when_still_on_the_pre_update_build(self):
+        # Recorded "old" before applying, but we're STILL "old" — Greengrass
+        # reverted us. The last update failed.
+        assert update_outcome("old_sha", "old_sha") == "rolled_back"
+
+    def test_none_when_no_update_was_in_flight(self):
+        # No pre-apply sha recorded ⇒ this is a normal boot, not a post-update one.
+        # Must never surface a banner.
+        assert update_outcome(None, "any_sha") == "none"
+
+    def test_succeeded_when_now_on_a_different_build(self):
+        # Recorded "old", now running "new" — the switch took. No banner.
+        assert update_outcome("old_sha", "new_sha") == "succeeded"
+
+    def test_none_when_current_build_is_unknown(self):
+        # We recorded a pre-apply sha but can't read our own build now — don't
+        # guess a failure (fail safe: no banner).
+        assert update_outcome("old_sha", None) == "none"
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
The device side of publishing the Device Shadow. Pairs with **acorn-fleet #24** (the deployment configures Shadow Manager to sync to the cloud).

## Why
The update agent builds the shadow report and calls `UpdateThingShadow` over IPC, but on sn01 it **silently failed** — I confirmed on-device that the shadow never appears. Two gaps in the recipe:
1. **No Shadow Manager** — nothing services the shadow IPC ops.
2. **No `accessControl`** — the nucleus denies `UpdateThingShadow`.

## Fix (`recipe.py`)
- **ComponentDependencies**: add `aws.greengrass.ShadowManager` (`>=2.0.0`) so it ships with every deployment.
- **ComponentConfiguration.DefaultConfiguration.accessControl**: grant `GetThingShadow` + `UpdateThingShadow`, **scoped to this core device's own classic shadow** (`$aws/things/{iot:thingName}/shadow`) — least privilege, not `*`.
- **`greengrass_ipc`**: the shadow-publish loop now **logs the first failure at WARNING** instead of swallowing it silently (that swallow is exactly what hid this bug).

Cloud sync (so `get-thing-shadow` actually returns) is configured on Shadow Manager in the deployment → **acorn-fleet #24**.

## Tests
15 recipe tests (Shadow Manager dependency; accessControl grants the ops; scoped to the device's own shadow, not wildcard). 20 in the recipe+agent run, green.

## Still pending (on-device, after both land + deploy)
- [ ] `get-thing-shadow` returns `reported.images.{api,ui}` + `container_health`
- [ ] Fleet Indexing query `shadow.reported.container_health:mismatched` works

Part of #395. Blocked-with: AcornGenetics/acorn-fleet#24.