### PR TITLE
fix(cert): renew from the running backend instead of a throwaway GHCR container (#401)

### DIFF
--- a/scripts/deploy/deployment3_greengrass.sh
+++ b/scripts/deploy/deployment3_greengrass.sh
@@ -832,10 +832,33 @@ phase_pass "app stack owned by the Greengrass component (com.acorn.sentri)"
 phase_start "10b" "Device Certificate Auto-Renewal Timer"
 
 # The renewer runs in the app image (which carries the crypto + requests deps the
-# host lacks), mounting /opt/aquila/config so it reads the current cert/key +
-# device.env and installs the rotated pair in place. It presents the current cert
-# to acorn-ca /renew over mTLS — no operator, no AWS creds. renewal_due() no-ops
-# until the cert is past ~2/3 of its life, so a daily run is cheap.
+# host lacks) and reads /opt/aquila/config for the current cert/key + device.env,
+# installing the rotated pair in place. It presents the current cert to acorn-ca
+# /renew over mTLS — no operator, no AWS creds. renewal_due() no-ops until the
+# cert is past ~2/3 of its life, so a daily run is cheap.
+#
+# `docker exec` into the running backend rather than `docker run` from a fresh
+# container (#401). The old form named ghcr.io/<repo>-api:${IMAGE_TAG}, which on a
+# Greengrass device is wrong in three ways:
+#
+#   * It pins a tag interpolated at provisioning, so the renewal keeps running the
+#     build that tag pointed at on setup day. A fix to aq_lib.renew would reach the
+#     deployed app and never reach this job.
+#   * It names GHCR on a device that now pulls from ECR via the token exchange
+#     service. The image is only present as a pre-migration leftover; if it is ever
+#     removed, the re-pull needs GHCR credentials that may have lapsed, and the
+#     failure is silent until the certificate expires and the device leaves the fleet.
+#   * `--rm` means nothing holds that image, so any image cleanup can delete it. The
+#     retention rule in #397 keeps it alive only incidentally, by it happening to be
+#     the newest in its repository.
+#
+# Executing in the already-running container removes all three: no tag, no registry,
+# no credentials, no image to preserve — and it always runs the version the device is
+# actually running.
+#
+# NOTE the path. The old form bind-mounted /opt/aquila/config to /config inside a
+# throwaway container; the backend has it mounted at /opt/aquila/config, so the
+# argument must match the backend's view, not the old container's.
 cat > /etc/systemd/system/aquila-cert-renew.service <<EOF
 [Unit]
 Description=Renew Sentri Device Certificate (acorn-ca /renew)
@@ -845,10 +868,7 @@ Requires=docker.service
 
 [Service]
 Type=oneshot
-ExecStart=/usr/bin/docker run --rm \\
-    -v /opt/aquila/config:/config \\
-    ghcr.io/${GHCR_REPO}-api:${IMAGE_TAG} \\
-    python -m aq_lib.renew /config
+ExecStart=/usr/bin/docker exec aquila-backend python -m aq_lib.renew /opt/aquila/config
 # Greengrass loads device.crt once at startup and holds a long-lived MQTT
 # connection, so it won't pick up a renewed cert on its own (#363). The renewal
 # runs in the container above and can't touch host systemd; on a rotation it drops

--- a/tests/fleet_device/test_deployment3_greengrass_script.py
+++ b/tests/fleet_device/test_deployment3_greengrass_script.py
@@ -72,10 +72,70 @@ def test_no_meerstetter_tuning_in_provisioning():
     # tuning CODE is gone (not the word, which may appear in explanatory comments).
     assert "find_meer" not in SCRIPT
     assert "MeerStetter(" not in SCRIPT
-    assert "docker exec" not in SCRIPT  # no exec into the app during provisioning
+
+    # No exec into the app *as a provisioning step*. Narrowed from a blanket
+    # "docker exec" not in SCRIPT (#401): the cert-renew unit's ExecStart now execs
+    # into the running backend, but that is a systemd unit written here and run
+    # daily afterwards — not something provisioning does to a container.
+    provisioning_execs = [
+        line for line in SCRIPT.splitlines()
+        if line.strip().startswith(("docker exec", "sudo docker exec"))
+    ]
+    assert not provisioning_execs, f"exec run during provisioning: {provisioning_execs}"
 
 
 def test_retains_deployment2_device_build():
     # Everything else from deployment2 is kept (spot-check across phases).
     for marker in ("I2C", "Tailscale", "aquila-cert-renew", "security.sh", "Plymouth"):
         assert marker in SCRIPT, f"deployment3 dropped a shared step: {marker}"
+
+
+# ── Certificate renewal (#401) ────────────────────────────────────────────────
+# The renewal timer used to launch a throwaway container from a GHCR image. On a
+# Greengrass device that tag is frozen at provisioning, the registry is the wrong
+# one, and nothing holds the image — so any cleanup could delete it and renewal
+# would fail silently until the certificate expired.
+
+
+def _cert_renew_unit() -> str:
+    """The aquila-cert-renew.service heredoc, as deployment3 writes it."""
+    start = SCRIPT.index("cat > /etc/systemd/system/aquila-cert-renew.service")
+    body = SCRIPT[SCRIPT.index("\n", start):]      # skip the heredoc opener line
+    return body[:body.index("\nEOF")]
+
+
+def test_cert_renewal_execs_into_the_running_backend():
+    """No new container, so no image to keep alive and no registry to reach."""
+    unit = _cert_renew_unit()
+
+    assert "docker exec aquila-backend" in unit
+    assert "docker run" not in unit
+
+
+def test_cert_renewal_does_not_depend_on_a_registry():
+    """A device that has migrated to ECR may no longer hold working GHCR
+    credentials; the failure would be silent until the certificate expired."""
+    unit = _cert_renew_unit()
+
+    assert "ghcr.io" not in unit
+    assert "IMAGE_TAG" not in unit
+
+
+def test_cert_renewal_uses_the_backends_config_path():
+    """Regression, and an easy one to get wrong: the old form bind-mounted
+    /opt/aquila/config to /config inside a throwaway container. The backend has it
+    at /opt/aquila/config, so carrying the old argument over would point the
+    renewer at a directory that does not exist inside that container."""
+    unit = _cert_renew_unit()
+
+    assert "aq_lib.renew /opt/aquila/config" in unit
+    assert "aq_lib.renew /config" not in unit
+
+
+def test_cert_rotation_still_restarts_greengrass():
+    """Greengrass holds a long-lived MQTT connection and won't pick up a renewed
+    cert on its own (#363). The marker-driven restart must survive this change."""
+    unit = _cert_renew_unit()
+
+    assert ".cert-rotated" in unit
+    assert "systemctl restart greengrass" in unit


### PR DESCRIPTION
Closes #401.

## The problem

`aquila-cert-renew.timer` fires daily and renews the device certificate by launching a throwaway container:

```
ExecStart=/usr/bin/docker run --rm -v /opt/aquila/config:/config \
    ghcr.io/${GHCR_REPO}-api:${IMAGE_TAG} python -m aq_lib.renew /config
```

On a Greengrass device that is wrong three ways:

1. **The tag is frozen at provisioning.** The renewal runs whatever build `${IMAGE_TAG}` pointed at on setup day, forever. A fix to `aq_lib.renew` reaches the deployed app and never reaches this job.
2. **It names the wrong registry.** GHCR, on a device that pulls from ECR via the token exchange service. The image is present only as a pre-migration leftover; if it is ever removed, the re-pull needs GHCR credentials that may have lapsed.
3. **Nothing holds the image.** `--rm` deletes the container instantly, so for 23h59m a day that image is unused and deletable. #397's retention rule spares it *incidentally* — by it happening to be the newest in its repository. A device holding a second GHCR api image under another tag would break that.

Each failure is silent until the certificate expires and the device drops off the fleet.

## The fix

```
ExecStart=/usr/bin/docker exec aquila-backend python -m aq_lib.renew /opt/aquila/config
```

`aquila-backend` is built from the same api image, already has `/opt/aquila/config` mounted, and is already running. No new container, no registry contact, no credentials, no image to preserve — and it always runs the version the device is actually running.

**Note the path change.** The old form bind-mounted `/opt/aquila/config` → `/config` inside the throwaway container. The backend has it at `/opt/aquila/config`, so carrying the old argument across would point the renewer at a directory that does not exist there. It would fail silently, so there is a test for it.

## Scope

- `deployment3_greengrass.sh` Phase 10b only — it writes this unit during migration, so every migrated device gets the corrected version with no extra delivery step.
- `deployment2.sh` keeps the container form: on a Watchtower device GHCR is the right registry and `fleet-update.sh` still maintains token rotation.

## Tests

Four new, plus one narrowed. `test_no_meerstetter_tuning_in_provisioning` asserted `"docker exec" not in SCRIPT` — broader than the rule it documents (*"no exec into the app during provisioning"*). The cert unit's `ExecStart` is written here and runs daily from systemd, not during provisioning, so the assertion now rejects execs run *as provisioning steps*, which is what it means.

Suite: 55 pre-existing failures unchanged, +5 passing.

## Verification

sn01's certificate expires **Aug 13 2026**, so a real renewal is due within days — a natural chance to confirm this against an actual rotation rather than a no-op run. Until then `systemctl start aquila-cert-renew.service` on a migrated device should log `certificate not yet due for renewal — no action`, same as today.