### PR TITLE
fix(clock): install fake-hwclock during Greengrass provisioning (#353)

### DIFF
--- a/scripts/deploy/deployment3_greengrass.sh
+++ b/scripts/deploy/deployment3_greengrass.sh
@@ -113,7 +113,38 @@ DEBIAN_FRONTEND=noninteractive apt-get install -y \
     chromium openbox \
     xserver-xorg x11-xserver-utils xinput \
     python3-gi gir1.2-gtk-3.0 gir1.2-webkit2-4.1 libwebkit2gtk-4.1-0 \
-    xterm unclutter
+    xterm unclutter \
+    fake-hwclock
+
+# ── Device clock (#353) ───────────────────────────────────────────────────────
+# A Pi has no battery-backed RTC, so on every power loss the clock resets and stays
+# wrong until NTP resyncs. Two consequences, and the second is the serious one:
+#
+#   * Every Event on the sync outbox is stamped with the local clock, so a device
+#     that boots wrong writes wrong timestamps into the analytics warehouse —
+#     permanently, and indistinguishable from real data afterwards.
+#
+#   * TLS checks a certificate's notBefore/notAfter against system time. A device
+#     that boots believing it is outside its own certificate's validity window
+#     rejects its own credential, and authenticates to neither AWS IoT nor
+#     acorn-ca. The device is then unreachable by the very channel that would fix
+#     it, and cannot renew (renewal authenticates with the current cert).
+#
+# fake-hwclock saves the time at shutdown and restores it at boot, before NTP has
+# synced; systemd-timesyncd then corrects it precisely once the network is up.
+# Neither helps a device that never reaches an NTP server, which is why the backend
+# also reports its clock state (clock_health.py, ships in the image).
+#
+# NTP and timesyncd are already enabled on measured devices (sn01, sn08), so those
+# two commands are no-ops there — they are here so a fresh install is deterministic
+# rather than relying on the OS image's defaults.
+systemctl enable --now fake-hwclock 2>/dev/null || true
+timedatectl set-ntp true 2>/dev/null || true
+systemctl enable --now systemd-timesyncd 2>/dev/null || true
+
+run_test "fake-hwclock installed" "dpkg -l fake-hwclock | grep -q '^ii'"
+run_test "NTP enabled"            "timedatectl show -p NTP --value | grep -q yes"
+run_test "timesyncd active"       "systemctl is-active systemd-timesyncd | grep -q active"
 
 run_test "curl installed"       "which curl"
 run_test "chromium installed"   "which chromium"

--- a/tests/fleet_device/test_deployment3_greengrass_script.py
+++ b/tests/fleet_device/test_deployment3_greengrass_script.py
@@ -79,3 +79,36 @@ def test_retains_deployment2_device_build():
     # Everything else from deployment2 is kept (spot-check across phases).
     for marker in ("I2C", "Tailscale", "aquila-cert-renew", "security.sh", "Plymouth"):
         assert marker in SCRIPT, f"deployment3 dropped a shared step: {marker}"
+
+
+# ── Device clock (#353) ───────────────────────────────────────────────────────
+# A Pi has no battery-backed RTC. A wrong clock corrupts warehouse timestamps and,
+# more seriously, breaks TLS: a device that boots outside its own certificate's
+# validity window authenticates to neither AWS IoT nor acorn-ca, and cannot renew
+# its way out because renewal authenticates with that same certificate.
+
+
+def test_installs_fake_hwclock():
+    """The only part of the clock fix that genuinely needs host provisioning.
+
+    It must run in the host's boot sequence before Docker exists, and it sets the
+    system clock — neither of which a container can do. Measured absent on sn01 and
+    sn08, so this is a real gap rather than a codification of the status quo.
+    """
+    assert "fake-hwclock" in SCRIPT
+    assert "systemctl enable --now fake-hwclock" in SCRIPT
+
+
+def test_ntp_is_enabled_deterministically():
+    """Already true on measured devices, so these are no-ops there — present so a
+    fresh install does not depend on the OS image's defaults."""
+    assert "timedatectl set-ntp true" in SCRIPT
+    assert "systemctl enable --now systemd-timesyncd" in SCRIPT
+
+
+def test_clock_setup_is_verified_not_just_attempted():
+    """The enable commands are `|| true` so provisioning survives an odd image;
+    without assertions a silently unconfigured clock would pass provisioning."""
+    assert 'run_test "fake-hwclock installed"' in SCRIPT
+    assert 'run_test "NTP enabled"' in SCRIPT
+    assert 'run_test "timesyncd active"' in SCRIPT


### PR DESCRIPTION
Part of #353 — the host half. The application half (`clock_health.py` reporting an untrustworthy clock) ships in the image and needs nothing from provisioning.

## Why

A Pi has **no battery-backed clock**. On every power loss it resets and stays wrong until NTP resyncs. Two consequences:

**1. Corrupted warehouse data.** Every Event on the sync outbox is stamped with the local clock, so a device that boots wrong writes wrong timestamps into analytics — permanently, and indistinguishable from real data afterwards. This is what #353 was filed for.

**2. Broken authentication.** TLS validates certificates against system time. A device that boots believing it is outside its own certificate's validity window **rejects its own credential** and authenticates to neither AWS IoT nor acorn-ca. It cannot renew its way out either, because renewal authenticates using that same certificate. With 14-day certificates the margin is thin.

The second only became obvious while investigating #401 today, and it makes this the cheapest mitigation available for that whole class of failure.

## Measured, not assumed

Checked sn01 and sn08 directly:

```
fake-hwclock installed: 0        ← the actual gap
NTP enabled:            yes      ← already true
timesyncd active:       active   ← already true
clock synchronized:     yes
```

So of the three commands in the original #367 proposal, **only the package install is a real gap.** The other two are no-ops on existing devices; they are included so a fresh install is deterministic rather than inheriting whatever the OS image defaulted to.

## Why it has to be provisioning

Installing a package must happen on the host, and `fake-hwclock` must run in the boot sequence **before Docker exists** — it restores the clock at boot and saves it at shutdown. A container can do neither. So unlike config-file changes, this genuinely cannot ride the image, and Phase 1 of `deployment3_greengrass.sh` is where every device will run it during migration.

`deployment2.sh` is unchanged; devices that never migrate keep their current behaviour.

## Safety

The enable commands are `|| true` so an unusual image cannot fail provisioning — with `run_test` assertions immediately after, since otherwise a silently unconfigured clock would pass provisioning and nobody would know until a device wrote bad timestamps.

## Tests

3 new static assertions. Suite: 55 pre-existing failures unchanged, +3 passing.

## Verification

After migrating a device: `dpkg -l fake-hwclock`, `systemctl is-enabled fake-hwclock`, and `timedatectl`. The real test is a power-cycle with the network unplugged — the clock should come back approximately right instead of at epoch.