### PR TITLE
Renewal: back up + verify + roll back a failed rotation (Part of am#405)

### DIFF
--- a/aq_lib/renew.py
+++ b/aq_lib/renew.py
@@ -12,6 +12,7 @@ import os
 
 import requests
 from cryptography import x509
+from cryptography.hazmat.primitives import serialization
 
 from aq_lib.device_csr import generate_device_csr
 
@@ -65,6 +66,7 @@ def renew_device_cert(
     now: dt.datetime,
     http_post=None,
     renew_at: float = DEFAULT_RENEW_AT,
+    verify=None,
 ):
     """Renew the installed Device Certificate if it is due; otherwise do nothing.
 
@@ -100,7 +102,20 @@ def renew_device_cert(
         )
     new_cert_pem = response.json()["certificate"]
 
+    # Back up the current (working) pair before overwriting, verify the new one,
+    # and roll back if it doesn't check out — so a bad rotation never bricks the
+    # device (am#405). The previous cert is still valid (renewal fires at ~2/3 of
+    # life), so rollback keeps it working until the next attempt.
+    if verify is None:
+        verify = _pair_is_valid
+    _backup_pair(cert_path, key_path)
     _install_pair(cert_path, new_cert_pem, key_path, new_key_pem)
+    if not verify(cert_path, key_path, now):
+        _restore_from_backup(cert_path, key_path)
+        raise RenewalError(
+            "renewed certificate failed verification; rolled back to the previous cert"
+        )
+    _clear_backup(cert_path, key_path)
     _signal_greengrass_reconnect(config_dir)
     return new_cert_pem
 
@@ -125,6 +140,70 @@ def _install_pair(cert_path, cert_pem, key_path, key_pem):
     """
     _write_0600(key_path, key_pem if isinstance(key_pem, bytes) else key_pem.encode())
     _write_0600(cert_path, cert_pem if isinstance(cert_pem, bytes) else cert_pem.encode())
+
+
+def _backup_pair(cert_path, key_path):
+    """Copy the current cert+key to ``.bak`` siblings before overwriting them.
+
+    Persisted (not in-memory) so a crash mid-install leaves recovery material on
+    disk — see ``recover_if_broken``.
+    """
+    for path in (cert_path, key_path):
+        with open(path, "rb") as f:
+            _write_0600(f"{path}.bak", f.read())
+
+
+def _restore_from_backup(cert_path, key_path):
+    """Roll the cert+key back to the ``.bak`` copies, then drop the backups."""
+    for path in (cert_path, key_path):
+        bak = f"{path}.bak"
+        with open(bak, "rb") as f:
+            _write_0600(path, f.read())
+        os.remove(bak)
+
+
+def _clear_backup(cert_path, key_path):
+    """Drop the ``.bak`` copies once the new pair is confirmed good. Idempotent."""
+    for path in (cert_path, key_path):
+        try:
+            os.remove(f"{path}.bak")
+        except OSError:
+            pass
+
+
+def _pair_is_valid(cert_path, key_path, now: dt.datetime) -> bool:
+    """Default verify: the installed cert+key are a matching, currently-valid pair.
+
+    Catches a partial/crashed install (new key + old cert don't match) and a
+    malformed or out-of-date cert. No network — deterministic. Any error => invalid.
+    """
+    try:
+        with open(cert_path, "rb") as f:
+            cert = x509.load_pem_x509_certificate(f.read())
+        with open(key_path, "rb") as f:
+            key = serialization.load_pem_private_key(f.read(), password=None)
+        if cert.public_key().public_numbers() != key.public_key().public_numbers():
+            return False
+        return cert.not_valid_before_utc <= now <= cert.not_valid_after_utc
+    except Exception:  # noqa: BLE001 - any failure to load/parse => not a valid pair
+        return False
+
+
+def recover_if_broken(config_dir, *, now: dt.datetime = None):
+    """Heal a crash mid-install: restore the backup if the installed pair is broken.
+
+    A crash between writing the new key and the new cert leaves a mismatched pair
+    (new key + old cert) with no rollback in that dead process. Run at renewal
+    entry: if the installed cert/key don't verify AND a ``.bak`` exists, restore
+    the previous good pair (am#405). A healthy pair is left untouched.
+    """
+    if now is None:
+        now = dt.datetime.now(dt.timezone.utc)
+    cert_path = os.path.join(config_dir, CERT_FILENAME)
+    key_path = os.path.join(config_dir, KEY_FILENAME)
+    have_backup = os.path.exists(f"{cert_path}.bak") and os.path.exists(f"{key_path}.bak")
+    if have_backup and not _pair_is_valid(cert_path, key_path, now):
+        _restore_from_backup(cert_path, key_path)
 
 
 def _signal_greengrass_reconnect(config_dir):
@@ -162,6 +241,9 @@ def run_renewal(config_dir, *, now: dt.datetime = None, http_post=None, renew_at
     """
     if now is None:
         now = dt.datetime.now(dt.timezone.utc)
+    # Heal a crash from a previous renewal before doing anything (am#405): if the
+    # installed pair is broken but a backup survives, restore the last-good pair.
+    recover_if_broken(config_dir, now=now)
     env = _read_env(config_dir)
     device_id = env.get("DEVICE_ID")
     if not device_id:

--- a/unit_tests/test_renew.py
+++ b/unit_tests/test_renew.py
@@ -19,6 +19,7 @@ from cryptography.x509.oid import NameOID
 from aq_lib.renew import (
     ROTATION_MARKER,
     RenewalError,
+    recover_if_broken,
     renew_device_cert,
     renewal_due,
     run_renewal,
@@ -61,6 +62,30 @@ def make_keypair_pem():
         serialization.PrivateFormat.PKCS8,
         serialization.NoEncryption(),
     )
+
+
+def make_matching_pair(now: dt.datetime) -> tuple[bytes, bytes]:
+    """A genuinely consistent (cert, key) pair, in-date at ``now`` — the cert is
+    signed for the returned key's public key (unlike make_cert_pem, whose key is
+    internal and discarded)."""
+    key = ec.generate_private_key(ec.SECP256R1())
+    name = x509.Name([x509.NameAttribute(NameOID.COMMON_NAME, DEVICE_ID)])
+    cert = (
+        x509.CertificateBuilder()
+        .subject_name(name)
+        .issuer_name(name)
+        .public_key(key.public_key())
+        .serial_number(x509.random_serial_number())
+        .not_valid_before(now - dt.timedelta(days=1))
+        .not_valid_after(now + dt.timedelta(days=13))
+        .sign(key, hashes.SHA256())
+    )
+    key_pem = key.private_bytes(
+        serialization.Encoding.PEM,
+        serialization.PrivateFormat.PKCS8,
+        serialization.NoEncryption(),
+    )
+    return cert.public_bytes(serialization.Encoding.PEM), key_pem
 
 
 def write_config(config_dir, cert_pem, key_pem=None):
@@ -265,6 +290,80 @@ class TestRenewDeviceCert:
         )
         (cn,) = csr.subject.get_attributes_for_oid(NameOID.COMMON_NAME)
         assert cn.value == DEVICE_ID
+
+
+class TestRenewalRollback:
+    """A rotation the device can't verify must NOT brick it (am#405).
+
+    Before overwriting, the renewer backs up the current (working) pair. After
+    installing the new one it verifies it; if verification fails it rolls back to
+    the previous cert/key — which is still valid (renewal fires at ~2/3 of life) —
+    so a bad rotation is survivable instead of needing offline re-enrollment.
+    """
+
+    def test_rolls_back_to_the_previous_pair_when_verification_fails(self, tmp_path):
+        now = dt.datetime(2026, 7, 11, tzinfo=dt.timezone.utc)
+        config = tmp_path / "config"
+        write_config(config, due_cert(now), key_pem=make_keypair_pem())
+        before_crt = (config / "device.crt").read_bytes()
+        before_key = (config / "device.key").read_bytes()
+
+        with pytest.raises(RenewalError):
+            renew_device_cert(
+                RENEW_ENDPOINT, config_dir=str(config), device_id=DEVICE_ID,
+                now=now, http_post=issuing_post(now),
+                verify=lambda cert_path, key_path, now: False,
+            )
+
+        # The installed pair is the ORIGINAL one — the unverifiable cert was not kept.
+        assert (config / "device.crt").read_bytes() == before_crt
+        assert (config / "device.key").read_bytes() == before_key
+
+    def test_clears_the_backup_after_a_verified_renewal(self, tmp_path):
+        # Once the new cert is confirmed good, the .bak copies are dropped — no
+        # stale backup lingers to confuse a later crash-recovery check.
+        now = dt.datetime(2026, 7, 11, tzinfo=dt.timezone.utc)
+        config = tmp_path / "config"
+        write_config(config, due_cert(now))
+
+        renew_device_cert(
+            RENEW_ENDPOINT, config_dir=str(config), device_id=DEVICE_ID,
+            now=now, http_post=issuing_post(now),  # default verify passes
+        )
+
+        assert not (config / "device.crt.bak").exists()
+        assert not (config / "device.key.bak").exists()
+
+    def test_recover_if_broken_restores_a_mismatched_pair_from_backup(self, tmp_path):
+        # Crash mid-install: installed = new key + old cert (they don't match); the
+        # .bak still holds the previous good pair. Recovery restores the good pair.
+        now = dt.datetime(2026, 7, 11, tzinfo=dt.timezone.utc)
+        config = tmp_path / "config"
+        good_cert, good_key = make_matching_pair(now)
+        write_config(config, good_cert, key_pem=good_key)
+        (config / "device.crt.bak").write_bytes(good_cert)
+        (config / "device.key.bak").write_bytes(good_key)
+        # Clobber the installed key with a different one → mismatched (crash state).
+        (config / "device.key").write_bytes(make_keypair_pem())
+
+        recover_if_broken(str(config), now=now)
+
+        assert (config / "device.crt").read_bytes() == good_cert
+        assert (config / "device.key").read_bytes() == good_key
+        assert not (config / "device.key.bak").exists()
+
+    def test_recover_if_broken_leaves_a_valid_pair_untouched(self, tmp_path):
+        # A healthy installed pair must never be clobbered by a stale backup.
+        now = dt.datetime(2026, 7, 11, tzinfo=dt.timezone.utc)
+        config = tmp_path / "config"
+        good_cert, good_key = make_matching_pair(now)
+        write_config(config, good_cert, key_pem=good_key)  # matching, in-date
+        (config / "device.crt.bak").write_bytes(b"STALE")
+        (config / "device.key.bak").write_bytes(b"STALE")
+
+        recover_if_broken(str(config), now=now)
+
+        assert (config / "device.crt").read_bytes() == good_cert  # untouched
 
 
 class TestGreengrassReconnectMarker:


### PR DESCRIPTION
The device-side safety net for cert renewal under Greengrass. Targets `feat/greengrass-migration`.

## Why
The renewer overwrote `device.crt`/`device.key` in place with a fresh keypair and **kept no backup**, treating "signed" as "works." So a signed-but-**rejected** cert left the device on a broken credential with **no way back** — offline re-enrollment only. Fine when only analytics (chain-trust) consumed the cert; under Greengrass a renewed cert can be signed-but-rejected, and **sn01 hit exactly this**.

## What
Make a failed rotation **survivable**:
- **Back up** the current pair to `.bak` before overwriting.
- **Verify** the new pair after install — **injectable**; default = *matching, in-date* cert+key (deterministic, no network; catches a partial install and a malformed/expired cert). *(chosen over an mTLS handshake per discussion)*
- On failure, **roll back** to the previous cert/key (still valid at ~2/3 of life) and raise `RenewalError`, so the device keeps its last-known-good credential. The Greengrass reconnect is **not** signalled on rollback.
- **Clear the backup** only once the new cert is confirmed good.
- **`recover_if_broken()`** — at renewal entry, if the installed pair is broken and a `.bak` survives, restore it → heals a **crash mid-install** (new key + old cert mismatch). A healthy pair is untouched. Wired into `run_renewal`.

Keeps per-renewal keypair rotation (security choice); just adds a recoverable backup.

## Tests (18 renew, 121 unit — all green)
rollback on verify-fail (previous pair restored); clear-on-success; crash-window recovery restores a mismatched pair from backup; a valid pair is left untouched.

## Pairing
- **acorn-ca #36** makes a renewal *succeed* on IoT (register + ACTIVE + attach, keep Ring).
- **This** makes a renewal that *fails* anyway *survivable*.

## Still open for
- [ ] On a real Sentri: force a bad rotation, confirm it rolls back to the previous cert and stays connected.

Part of #405.