### PR TITLE
fix(greengrass): prune only once the deployment is healthy (#397)

### DIFF
--- a/scripts/greengrass/recipe.py
+++ b/scripts/greengrass/recipe.py
@@ -55,8 +55,19 @@ def build_recipe(
 
     # Nothing has ever removed an image from these devices and Greengrass does not
     # either — sn01 was measured still holding its previous deployment's 1.17 GB image
-    # after a later one. Pruning here, right after the stack is up, is the moment an
-    # image has just been superseded.
+    # after a later one.
+    #
+    # Placed *after* the health gate, not straight after `compose up -d`. By the time
+    # compose has recreated the containers, the previous image is referenced by nothing
+    # and has lost "newest per repository" to the one just deployed — so pruning there
+    # deletes it. That is precisely the image Greengrass rolls back to when the new
+    # version then fails /health, and the rollback would be left re-pulling it on a
+    # device whose update has just failed.
+    #
+    # Gated on a probe rather than merely sequenced after the grace loop: that loop
+    # falls through on exhaustion as well as on success, so position alone would still
+    # prune an unhealthy deployment. A deployment that never answers /health prunes
+    # nothing and keeps its predecessor on disk.
     prune_step = ""
     if prune_artifact_uri:
         artifacts.append({"URI": prune_artifact_uri})
@@ -66,9 +77,12 @@ def build_recipe(
         # script reports its own outcome, so failures stay visible in the logs.
         # `bash`, not `sh`: on Debian /bin/sh is dash, and the script uses [[ ]] and
         # here-strings. Naming the interpreter also avoids depending on Greengrass
-        # preserving the artifact's executable bit.
+        # preserving the artifact's executable bit. The `if` wrapper stays POSIX, since
+        # Greengrass runs the lifecycle string itself with /bin/sh.
         prune_step = (
-            'bash "{artifacts:path}/' + prune_file + '" || true; '
+            "if curl -fsS http://localhost:8090/health >/dev/null 2>&1; then "
+            + 'bash "{artifacts:path}/' + prune_file + '" || true; '
+            + "fi; "
         )
     recipe = {
         "RecipeFormatVersion": RECIPE_FORMAT_VERSION,
@@ -105,14 +119,15 @@ def build_recipe(
                         # them through; the thing name is not, so export it here.
                         'export AWS_IOT_THING_NAME="{iot:thingName}"; '
                         + ("docker compose -f %s up -d; " % compose_path)
-                        # reclaim images the deployment just superseded (#397)
-                        + prune_step
                         # buffer: do not check /health for the first 25s (boot ~15s)
                         + "sleep 25; "
                         # grace: then poll up to ~1 min for the first healthy response
                         + "for i in $(seq 1 12); do "
                         + "curl -fsS http://localhost:8090/health >/dev/null 2>&1 && break; "
                         + "sleep 5; done; "
+                        # reclaim images this deployment superseded, but only once it has
+                        # proven healthy — until then its predecessor is the rollback (#397)
+                        + prune_step
                         # monitor: stay RUNNING while healthy; exit non-zero when it fails
                         + "while curl -fsS http://localhost:8090/health >/dev/null 2>&1; "
                         + "do sleep 30; done; exit 1"

--- a/tests/unit/test_greengrass_recipe.py
+++ b/tests/unit/test_greengrass_recipe.py
@@ -214,13 +214,44 @@ def test_prune_failure_cannot_break_the_component():
     assert prune_call.startswith('prune-images.sh" || true')
 
 
-def test_prune_does_not_delay_the_health_gate():
-    """The health monitor is what keeps the component RUNNING; pruning ahead of the
-    startup buffer would eat into it, so it must come before the sleep, not inside
-    the polling loop."""
+def test_prune_waits_for_the_health_gate():
+    """The superseded image is the one Greengrass rolls back to. Once `compose up -d`
+    has recreated the containers it is referenced by nothing and is no longer newest of
+    its repository, so pruning straight after the stack starts deletes exactly the image
+    a failed deployment needs. It must come after the health poll instead."""
     run = _run_step(_recipe_with_prune())
 
-    assert run.index("prune-images.sh") < run.index("sleep 25")
+    assert run.index("sleep 25") < run.index("prune-images.sh")
+    assert run.index("seq 1 12") < run.index("prune-images.sh")
+
+
+def test_prune_is_gated_on_a_health_probe_not_merely_sequenced():
+    """Position alone is not enough: the grace loop falls through on exhaustion as well
+    as on success, so a deployment that never came up would still reach the prune and
+    delete its own rollback target. The call must sit inside a health check."""
+    run = _run_step(_recipe_with_prune())
+    before_prune = run[: run.index("prune-images.sh")]
+
+    assert before_prune.endswith(
+        "if curl -fsS http://localhost:8090/health >/dev/null 2>&1; then bash \"{artifacts:path}/"
+    )
+
+
+def test_prune_is_reachable_before_the_monitor_loop():
+    """The monitor is an unbounded foreground loop that only exits to mark the component
+    BROKEN. Anything sequenced after it never runs at all."""
+    run = _run_step(_recipe_with_prune())
+
+    assert run.index("prune-images.sh") < run.index("while curl")
+
+
+def test_prune_guard_is_closed_so_the_monitor_still_runs():
+    """Regression: an unterminated `if` would swallow the monitor loop into the guard,
+    so an unhealthy device would never mark itself BROKEN."""
+    run = _run_step(_recipe_with_prune())
+
+    assert "fi; " in run
+    assert run.index("fi; ") < run.index("while curl")
 
 
 def test_recipe_without_a_prune_uri_is_unchanged():


### PR DESCRIPTION
Closes the open question raised on #397 after the prune shipped.

## The problem

The prune ran immediately after `docker compose up -d`:

```
docker compose up -d;      ← containers recreated
prune-images.sh || true;   ← superseded image now unreferenced AND not newest → deleted
sleep 25; … /health …      ← health gate
while … /health; done; exit 1   ← exit ⇒ BROKEN ⇒ rollback
```

By the time compose has recreated the containers, the previous image is referenced by nothing
and has lost "newest per repository" to the image just deployed, so the prune deletes it. That
is precisely the image Greengrass rolls back to when the new version then fails `/health` — the
rollback is left re-pulling from ECR on a device whose update has just failed.

Not hypothetical for us: the prune runs on the operator-approved switch (`update_gate.GATE`
defers until the operator taps Update and no assay is running), so the deletion happens in the
same lifecycle invocation that then decides whether the deployment is good.

## The fix

Move the call after the health poll, **and gate it on a probe**:

```
sleep 25;
for i in $(seq 1 12); do curl … /health && break; sleep 5; done;
if curl -fsS http://localhost:8090/health >/dev/null 2>&1; then
    bash "{artifacts:path}/prune-images.sh" || true;
fi;
while curl … /health; do sleep 30; done; exit 1
```

Position alone is not enough — the grace loop falls through on exhaustion as well as on
success, so an unhealthy deployment would still reach the prune and delete its own rollback
target.

POSIX `if`, because Greengrass runs the lifecycle string with `/bin/sh` (dash on Debian); only
the prune script itself needs bash. The generated Run step is verified with both `sh -n` and
`dash -n`.

## What it costs

One extra curl against an endpoint the loop above just polled, and reclamation delayed to the
point the new version is serving. Steady state is unchanged — still one image per repository
once healthy — so this does not reintroduce the ~1.25 GB per-deployment accumulation.

## Tests

`tests/unit/test_greengrass_recipe.py`: `test_prune_does_not_delay_the_health_gate` encoded the
old (wrong) intent and is replaced by four tests — ordering after the gate, the probe guard
specifically rather than mere sequencing, reachability before the unbounded monitor loop, and a
regression test that the `if` is closed so an unhealthy device still marks itself BROKEN.

Full suite: 64 failed / 930 passed / 237 skipped, against a `epic/fleet-hardening-2` baseline of
64 failed / 927 passed / 237 skipped — the same pre-existing macOS hardware and matplotlib
failures, +3 net tests.

Real rollback behaviour is device-verified, not covered here.
