### PR TITLE
Update gate: apply once approved — drop the idle (assay-running) check (am#382 follow-up)

### DIFF
--- a/aquila_web/greengrass_ipc.py
+++ b/aquila_web/greengrass_ipc.py
@@ -55,7 +55,7 @@ class GreengrassIpc:
         self._client.subscribe_to_component_updates(on_stream_event=_handle)
 
 
-def start_update_agent(gate, running_shas, assay_running, record_pre_update=None,
+def start_update_agent(gate, running_shas, record_pre_update=None,
                        on_post_update=None, publish_interval_s=60):
     """Bring up the on-device agent: defer-gate on updates + periodic shadow publish.
 
@@ -81,8 +81,7 @@ def start_update_agent(gate, running_shas, assay_running, record_pre_update=None
         )
         return None
 
-    agent = UpdateAgent(ipc, gate, running_shas, assay_running,
-                        record_pre_update=record_pre_update)
+    agent = UpdateAgent(ipc, gate, running_shas, record_pre_update=record_pre_update)
     # Defer/apply each offered update via the gate; re-resolve the banner on the
     # post-update event.
     ipc.subscribe_to_component_updates(

--- a/aquila_web/main.py
+++ b/aquila_web/main.py
@@ -2536,10 +2536,11 @@ async def start_greengrass_update_agent() -> None:
     start_update_agent(
         update_gate.GATE,
         running_shas=_running_container_shas,
-        assay_running=lambda: current_item.screen == "running",
+        # No idle-gate: the operator pressing "Update" is the go-ahead, so an
+        # approved update applies rather than being held on device state (am#382
+        # follow-up — a stale on-screen "running" flag used to wedge it).
         # The agent records the build we're leaving behind just before a switch,
-        # and re-resolves the banner immediately on a Greengrass post-update event
-        # (so a rollback shows without waiting for a reboot).
+        # and re-resolves the banner immediately on a Greengrass post-update event.
         record_pre_update=_write_pre_update_sha,
         on_post_update=lambda deployment_id: _resolve_update_banner(),
     )

--- a/aquila_web/update_agent.py
+++ b/aquila_web/update_agent.py
@@ -11,20 +11,19 @@ from aquila_web.version_health import build_shadow_report
 
 
 class UpdateAgent:
-    def __init__(self, ipc, gate, running_shas, assay_running, record_pre_update=None):
+    def __init__(self, ipc, gate, running_shas, record_pre_update=None):
         self._ipc = ipc
         self._gate = gate
         self._running_shas = running_shas
-        self._assay_running = assay_running
         # Records the build running just before a switch is allowed, so a later
         # boot/post-update event can tell whether Greengrass applied or rolled back
         # (am#394). No-op by default (off-device / tests that don't care).
         self._record_pre_update = record_pre_update or (lambda sha: None)
 
     def handle_update_offer(self, deployment_id, version):
-        """Greengrass offers `version` — hold it until idle AND operator-approved."""
+        """Greengrass offers `version` — hold it until the operator approves."""
         self._gate.mark_pending(version)
-        if not self._gate.should_apply(self._assay_running()):
+        if not self._gate.should_apply():
             self._ipc.defer_component_update(deployment_id)
             return "deferred"
         # About to let the switch take — record the build we're leaving behind.

--- a/aquila_web/update_gate.py
+++ b/aquila_web/update_gate.py
@@ -30,11 +30,11 @@ class UpdateGate:
         """The operator tapped Update — release the deferred switch."""
         self._approved = True
 
-    def should_apply(self, assay_running):
-        """Apply the pre-staged switch only when idle AND operator-approved."""
+    def should_apply(self):
+        """Apply the pre-staged switch once the operator has approved."""
         if self._pending_version is None:
             return False
-        return not should_defer_update(assay_running, self._approved)
+        return not should_defer_update(self._approved)
 
     def status(self):
         """Operator-facing gate state (served to the UI)."""

--- a/aquila_web/version_health.py
+++ b/aquila_web/version_health.py
@@ -68,11 +68,13 @@ def update_outcome(recorded_sha, running_sha):
     return "succeeded" if running_sha != recorded_sha else "rolled_back"
 
 
-def should_defer_update(assay_running, operator_approved):
+def should_defer_update(operator_approved):
     """Whether to DeferComponentUpdate instead of switching now.
 
-    The image is pre-staged; the switch is held (deferred) until the device is
-    idle AND the operator has approved. So "Update" is instant when tapped, and a
-    running assay is never interrupted.
+    The image is pre-staged; the switch is held (deferred) until the operator
+    approves. Pressing "Update" IS the operator's go-ahead — we do NOT also gate on
+    device state, because a stale on-screen "running" flag could otherwise wedge an
+    already-approved update indefinitely (am#382 follow-up). "Update" is instant
+    when tapped.
     """
-    return assay_running or not operator_approved
+    return not operator_approved

--- a/tests/unit/test_update_agent.py
+++ b/tests/unit/test_update_agent.py
@@ -34,7 +34,6 @@ def test_defers_an_update_the_operator_has_not_approved():
         ipc,
         gate=UpdateGate(),
         running_shas=lambda: ("abc", "abc"),
-        assay_running=lambda: False,
     )
 
     action = agent.handle_update_offer("deploy-1", "0.1.20")
@@ -47,7 +46,7 @@ def test_applies_on_re_offer_once_the_operator_approves():
     ipc = FakeIpc()
     gate = UpdateGate()
     agent = UpdateAgent(
-        ipc, gate, running_shas=lambda: ("a", "a"), assay_running=lambda: False
+        ipc, gate, running_shas=lambda: ("a", "a")
     )
 
     agent.handle_update_offer("deploy-1", "0.1.20")  # 1st offer → deferred (unapproved)
@@ -56,20 +55,6 @@ def test_applies_on_re_offer_once_the_operator_approves():
 
     assert action == "applied"
     assert ipc.deferred == ["deploy-1"]  # only the first was deferred
-
-
-def test_defers_during_an_assay_even_when_approved():
-    ipc = FakeIpc()
-    gate = UpdateGate()
-    agent = UpdateAgent(
-        ipc, gate, running_shas=lambda: ("a", "a"), assay_running=lambda: True
-    )
-    gate.mark_pending("0.1.20")
-    gate.approve()
-
-    action = agent.handle_update_offer("deploy-1", "0.1.20")
-
-    assert action == "deferred"  # never interrupt a run
 
 
 def test_records_the_pre_update_sha_when_it_lets_an_update_apply():
@@ -81,7 +66,7 @@ def test_records_the_pre_update_sha_when_it_lets_an_update_apply():
     recorded = []
     agent = UpdateAgent(
         ipc, gate, running_shas=lambda: ("cur_sha", "cur_sha"),
-        assay_running=lambda: False, record_pre_update=recorded.append,
+        record_pre_update=recorded.append,
     )
     gate.mark_pending("0.1.20")
     gate.approve()
@@ -95,7 +80,7 @@ def test_records_the_pre_update_sha_when_it_lets_an_update_apply():
 def test_publish_health_reports_matched_pair_to_the_shadow():
     ipc = FakeIpc()
     agent = UpdateAgent(
-        ipc, UpdateGate(), running_shas=lambda: ("sha1", "sha1"), assay_running=lambda: False
+        ipc, UpdateGate(), running_shas=lambda: ("sha1", "sha1")
     )
 
     agent.publish_health()

--- a/tests/unit/test_update_gate.py
+++ b/tests/unit/test_update_gate.py
@@ -45,28 +45,31 @@ def test_resolve_is_a_noop_when_no_update_was_in_flight():
     assert cleared == []
 
 
-def test_approved_pending_update_applies_when_idle():
+def test_approved_pending_update_applies():
     gate = UpdateGate()
     gate.mark_pending("0.1.20")
     gate.approve()
 
-    # Idle + approved + a pending update → apply the pre-staged switch.
-    assert gate.should_apply(assay_running=False) is True
+    # Approved + a pending update → apply the pre-staged switch.
+    assert gate.should_apply() is True
 
 
-def test_never_applies_during_an_assay_even_if_approved():
+def test_applies_once_approved_regardless_of_device_state():
+    # Pressing "Update" IS the operator's go-ahead — the gate must not second-guess
+    # it against device state (a stale 'running' screen could otherwise wedge an
+    # already-approved update forever). Approval is the only condition to apply.
     gate = UpdateGate()
     gate.mark_pending("0.1.20")
     gate.approve()
 
-    assert gate.should_apply(assay_running=True) is False
+    assert gate.should_apply() is True
 
 
 def test_does_not_apply_until_the_operator_approves():
     gate = UpdateGate()
     gate.mark_pending("0.1.20")
 
-    assert gate.should_apply(assay_running=False) is False
+    assert gate.should_apply() is False
 
 
 def test_a_newer_pending_update_requires_fresh_approval():
@@ -75,7 +78,7 @@ def test_a_newer_pending_update_requires_fresh_approval():
     gate.approve()
 
     gate.mark_pending("0.1.21")  # a newer version supersedes — re-approve required
-    assert gate.should_apply(assay_running=False) is False
+    assert gate.should_apply() is False
 
 
 def test_re_offering_the_same_version_keeps_approval():
@@ -85,11 +88,11 @@ def test_re_offering_the_same_version_keeps_approval():
 
     # Greengrass re-offers the same version after each defer — must not reset approval.
     gate.mark_pending("0.1.20")
-    assert gate.should_apply(assay_running=False) is True
+    assert gate.should_apply() is True
 
 
 def test_nothing_to_apply_when_no_update_pending():
-    assert UpdateGate().should_apply(assay_running=False) is False
+    assert UpdateGate().should_apply() is False
 
 
 def test_status_reports_pending_and_approval():

--- a/tests/unit/test_version_health.py
+++ b/tests/unit/test_version_health.py
@@ -99,16 +99,14 @@ def test_no_banner_when_update_healthy():
 
 
 @pytest.mark.parametrize(
-    "assay_running, operator_approved, expected_defer",
+    "operator_approved, expected_defer",
     [
-        (True, True, True),    # never switch mid-run, even if approved
-        (True, False, True),   # running + not approved → defer
-        (False, False, True),  # idle but waiting on the operator gate → defer
-        (False, True, False),  # idle AND approved → apply the pre-staged switch
+        (False, True),   # not yet approved → defer (hold at the badge)
+        (True, False),   # approved → apply; run state is not a factor (am#382 follow-up)
     ],
 )
-def test_should_defer_update(assay_running, operator_approved, expected_defer):
-    assert should_defer_update(assay_running, operator_approved) is expected_defer
+def test_should_defer_update(operator_approved, expected_defer):
+    assert should_defer_update(operator_approved) is expected_defer
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Why
The operator gate deferred an update until **both** approved **and** idle (`current_item.screen != "running"`). But **pressing "Update" is already the operator's explicit go-ahead**, so gating again on device state is redundant — and a **stale on-screen `"running"` flag** (a run that ended without resetting the screen) can wedge an **already-approved** update forever. That's exactly what hit sn01: `gate = {pending:true, approved:true}` but it never applied because the screen was stuck `"running"`.

## Change
Approval becomes the **only** condition to apply — defer only when not yet approved. The now-dead `assay_running` plumbing is removed through the whole chain:
- `version_health.should_defer_update(operator_approved)` → `not operator_approved`
- `UpdateGate.should_apply()` (no `assay_running`)
- `UpdateAgent` no longer takes/uses `assay_running`
- `start_update_agent` + the `main.py` startup wiring drop it

`record_pre_update` / banner resolution (am#394) are untouched — an update still never *silently* interrupts anything; the operator simply decides when by tapping Update.

## Tests
- Flipped `test_never_applies_during_an_assay` → `test_applies_once_approved_regardless_of_device_state`
- `should_defer_update` parametrization reduced to the approval axis
- 60 gate/agent/version_health/sync tests green; 0 new failures vs baseline

## Trade-off (intentional)
The device no longer auto-defers an approved update while a run flag is set. Acceptable because the operator explicitly approves, and it removes a real wedge. If a run is genuinely active, the operator just doesn't tap Update.

Part of #382.