### PR TITLE
fix: address #408 review — wheels layer bloat and multi-tag rmi (#348, #397)

### DIFF
--- a/docker/Dockerfile.api
+++ b/docker/Dockerfile.api
@@ -1,6 +1,13 @@
 # syntax=docker/dockerfile:1.4
 # Pins the BuildKit frontend so `RUN --mount=type=bind,from=...` below is understood
 # regardless of the builder's default Dockerfile version.
+#
+# BUILDKIT IS REQUIRED to build this image. Both the syntax directive above and the
+# bind mount below are BuildKit features, so a legacy build --
+#     DOCKER_BUILDKIT=0 docker build ...
+# or a Docker old enough to default to the classic builder -- fails with
+# `unknown flag: mount`. CI (docker/build-push-action) and modern `docker compose
+# build` use BuildKit by default, so the normal paths are unaffected.
 
 # ── Build stage ───────────────────────────────────────────────────────────────
 # build-essential exists solely to compile RPi.GPIO and spidev from source: both

--- a/docker/Dockerfile.api
+++ b/docker/Dockerfile.api
@@ -1,3 +1,7 @@
+# syntax=docker/dockerfile:1.4
+# Pins the BuildKit frontend so `RUN --mount=type=bind,from=...` below is understood
+# regardless of the builder's default Dockerfile version.
+
 # ── Build stage ───────────────────────────────────────────────────────────────
 # build-essential exists solely to compile RPi.GPIO and spidev from source: both
 # publish wheels only for 32-bit ARM (linux_armv6l/armv7l, cp27-cp310), and the
@@ -30,10 +34,15 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 # --no-index: install only from the wheels built above, never from PyPI. If a
 # wheel is missing this fails loudly at build time rather than silently pulling
 # a compiler-free sdist that cannot build.
-COPY --from=builder /wheels /wheels
+#
+# Mounted, not COPY'd. A `COPY --from=builder /wheels /wheels` writes its own layer
+# holding every wheel (numpy/matplotlib/cryptography/awscrt ≈ 150-250 MB), and
+# deleting them in a later RUN only whites them out — the bytes stay in the earlier
+# layer and ship to every device. A bind mount exists for the duration of this RUN
+# and is never committed, so the wheels leave no trace in the image at all.
 COPY requirements-backend.txt ./requirements-backend.txt
-RUN pip install --no-cache-dir --no-index --find-links=/wheels -r requirements-backend.txt \
-    && rm -rf /wheels
+RUN --mount=type=bind,from=builder,source=/wheels,target=/wheels \
+    pip install --no-cache-dir --no-index --find-links=/wheels -r requirements-backend.txt
 
 COPY . .
 COPY profiles/bundled/ /opt/aquila/profiles_bundled/

--- a/scripts/greengrass/prune-images.sh
+++ b/scripts/greengrass/prune-images.sh
@@ -167,19 +167,38 @@ main() {
         # logs "could not remove" and keeps exactly the stale GHCR images it exists
         # to shed.
         #
-        # Forced only for that message, never blanket. `docker rmi -f` on an image a
-        # stopped container references removes it and orphans the container; the
-        # protected set already excludes those, so -f here is a second line rather
-        # than the first, and any other refusal still stops the removal.
+        # Forced only for that message, never blanket -- and "must be forced" alone is
+        # NOT specific enough. Verified against docker 28.4.0, a stopped-container
+        # reference produces:
+        #     conflict: unable to delete <id> (must be forced) -
+        #     image is being used by stopped container <cid>
+        # which also contains "must be forced", and `-f` on it succeeds: the image goes
+        # and the container is left pointing at nothing. That is the precise case this
+        # retry must avoid, so the guard additionally requires the refusal NOT to be a
+        # container reference.
+        #
+        # Excluding "being used by" rather than matching "referenced in multiple
+        # repositories" positively: unfamiliar wording from a future docker then means
+        # no force, which is the safe direction to be wrong in. A positive match would
+        # silently stop reclaiming multi-tag images if the phrasing ever changed.
+        #
+        # The protected set already excludes container-referenced images, but it is a
+        # start-of-run snapshot -- a container appearing after it (aquila-cert-renew
+        # runs one daily) would slip through. This guard is what actually holds.
         rmi_err="$(docker rmi "${id}" 2>&1 >/dev/null)" && rc=0 || rc=$?
-        if (( rc != 0 )) && [[ "${rmi_err}" == *"must be forced"* ]]; then
+        if (( rc != 0 )) \
+            && [[ "${rmi_err}" == *"must be forced"* ]] \
+            && [[ "${rmi_err}" != *"being used by"* ]]; then
             rmi_err="$(docker rmi -f "${id}" 2>&1 >/dev/null)" && rc=0 || rc=$?
             (( rc == 0 )) && log "removed ${id} (forced: image had several tags)"
         fi
         if (( rc == 0 )); then
             removed=$((removed + 1))
         else
-            log "could not remove ${id} (still referenced)"
+            # Log docker's own reason rather than assuming "still referenced": a failed
+            # -f retry and "cannot be forced - dependent child images" are neither, and
+            # a wrong reason misleads whoever is asking why space is not being reclaimed.
+            log "could not remove ${id}: ${rmi_err}"
         fi
     done <<< "${removals}"
 

--- a/scripts/greengrass/prune-images.sh
+++ b/scripts/greengrass/prune-images.sh
@@ -128,7 +128,7 @@ protected_ids() {
 }
 
 main() {
-    local records protected removals count=0 removed=0
+    local records protected removals count=0 removed=0 rmi_err rc
 
     records="$(collect_images)"
     if [[ -z "${records}" ]]; then
@@ -156,7 +156,27 @@ main() {
         fi
         # Failure is expected and fine: docker refuses to remove an image another
         # image layers on, and that is a floor beneath this script's own logic.
-        if docker rmi "${id}" >/dev/null 2>&1; then
+        #
+        # One refusal is not a real conflict and must be retried with -f: an image
+        # carrying more than one tag gives
+        #     conflict: unable to delete <id> (must be forced) -
+        #     image is referenced in multiple repositories
+        # despite the wording, this fires on multiple tags within a SINGLE repository
+        # too. CI pushes :latest and :<sha> on every build, so a migrated device
+        # routinely holds images under two tags -- and without the retry the script
+        # logs "could not remove" and keeps exactly the stale GHCR images it exists
+        # to shed.
+        #
+        # Forced only for that message, never blanket. `docker rmi -f` on an image a
+        # stopped container references removes it and orphans the container; the
+        # protected set already excludes those, so -f here is a second line rather
+        # than the first, and any other refusal still stops the removal.
+        rmi_err="$(docker rmi "${id}" 2>&1 >/dev/null)" && rc=0 || rc=$?
+        if (( rc != 0 )) && [[ "${rmi_err}" == *"must be forced"* ]]; then
+            rmi_err="$(docker rmi -f "${id}" 2>&1 >/dev/null)" && rc=0 || rc=$?
+            (( rc == 0 )) && log "removed ${id} (forced: image had several tags)"
+        fi
+        if (( rc == 0 )); then
             removed=$((removed + 1))
         else
             log "could not remove ${id} (still referenced)"

--- a/unit_tests/test_prune_images.py
+++ b/unit_tests/test_prune_images.py
@@ -324,7 +324,7 @@ def test_force_is_not_used_for_other_refusals() -> None:
         protected_ids() {{ printf ''; }}
         docker() {{
             if [[ "$1" == "rmi" && "$2" == "-f" ]]; then echo "FORCED" ; return 0; fi
-            echo "conflict: unable to delete old - image is being used by stopped container abc" >&2
+            echo "conflict: unable to delete old (must be forced) - image is being used by stopped container abc" >&2
             return 1
         }}
         main
@@ -369,3 +369,55 @@ def test_dry_run_never_forces() -> None:
 
     assert "DOCKER CALLED" not in result.stdout
     assert "would remove old" in result.stdout
+
+
+def test_stopped_container_refusal_is_never_forced() -> None:
+    """Regression for the #411 review.
+
+    Verified against docker 28.4.0: a stopped-container reference produces
+        conflict: unable to delete <id> (must be forced) -
+        image is being used by stopped container <cid>
+    Matching only "must be forced" therefore fires here, and `-f` succeeds — removing
+    the image and leaving the container pointing at nothing. The protected set does not
+    save this: it is a start-of-run snapshot, so a container created after it (the daily
+    aquila-cert-renew one) is not in it.
+    """
+    result = _run(f"""
+        source {SCRIPT}
+        collect_images() {{
+            printf 'new\t2026-08-03T09:35:43Z\tghcr.io/x/api:dev\\n'
+            printf 'old\t2026-01-01T00:00:00Z\tghcr.io/x/api:old\\n'
+        }}
+        protected_ids() {{ printf ''; }}
+        docker() {{
+            if [[ "$1" == "rmi" && "$2" == "-f" ]]; then echo "FORCED"; return 0; fi
+            echo "conflict: unable to delete old (must be forced) - image is being used by stopped container abc" >&2
+            return 1
+        }}
+        main
+    """)
+
+    assert "FORCED" not in result.stdout, "a container-referenced image must never be forced"
+    assert "0 removed" in result.stdout
+
+
+def test_failure_reports_dockers_own_reason() -> None:
+    """'still referenced' was hardcoded, so a failed -f retry or a dependent-child
+    refusal both reported a reason that was not true — misleading anyone asking why
+    space is not being reclaimed."""
+    result = _run(f"""
+        source {SCRIPT}
+        collect_images() {{
+            printf 'new\t2026-08-03T09:35:43Z\tghcr.io/x/api:dev\\n'
+            printf 'old\t2026-01-01T00:00:00Z\tghcr.io/x/api:old\\n'
+        }}
+        protected_ids() {{ printf ''; }}
+        docker() {{
+            echo "conflict: unable to delete old (cannot be forced) - image has dependent child images" >&2
+            return 1
+        }}
+        main
+    """)
+
+    assert "dependent child images" in result.stdout, "docker's reason must reach the log"
+    assert "still referenced" not in result.stdout

--- a/unit_tests/test_prune_images.py
+++ b/unit_tests/test_prune_images.py
@@ -265,3 +265,107 @@ def test_dangling_images_are_enumerated() -> None:
 
     assert "sha_dangling" in out, "dangling images must be collected"
     assert "sha_tagged" in out
+
+
+# --- multi-tag removals (review of #408) ------------------------------------
+# `docker rmi <id>` refuses an image carrying more than one tag. The message says
+# "referenced in multiple repositories", but it fires for two tags in a SINGLE
+# repository too — verified against docker directly. CI pushes :latest and :<sha>
+# on every build, so this is the common case on a migrated device, not an edge one.
+
+_MULTI_TAG_ERROR = (
+    "Error response from daemon: conflict: unable to delete old (must be forced) "
+    "- image is referenced in multiple repositories"
+)
+
+
+def _run(script: str) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        ["bash", "-c", textwrap.dedent(script)],
+        capture_output=True,
+        text=True,
+        timeout=60,
+    )
+
+
+def test_a_multi_tagged_image_is_removed_with_force() -> None:
+    """Without the retry the script keeps exactly the stale GHCR images #397 exists
+    to shed, and reports it as a benign 'could not remove'."""
+    result = _run(f"""
+        source {SCRIPT}
+        collect_images() {{
+            printf 'new\t2026-08-03T09:35:43Z\tghcr.io/x/api:dev\\n'
+            printf 'old\t2026-01-01T00:00:00Z\tghcr.io/x/api:old\\n'
+        }}
+        protected_ids() {{ printf ''; }}
+        docker() {{
+            if [[ "$1" == "rmi" && "$2" == "-f" ]]; then return 0; fi
+            echo "{_MULTI_TAG_ERROR}" >&2
+            return 1
+        }}
+        main
+    """)
+
+    assert "forced: image had several tags" in result.stdout
+    assert "1 removed" in result.stdout
+    assert "could not remove" not in result.stdout
+
+
+def test_force_is_not_used_for_other_refusals() -> None:
+    """The protected set is the first line; docker's own refusal is the second. A
+    blanket -f would remove that backstop, so anything but the multi-tag conflict
+    must still be left alone."""
+    result = _run(f"""
+        source {SCRIPT}
+        collect_images() {{
+            printf 'new\t2026-08-03T09:35:43Z\tghcr.io/x/api:dev\\n'
+            printf 'old\t2026-01-01T00:00:00Z\tghcr.io/x/api:old\\n'
+        }}
+        protected_ids() {{ printf ''; }}
+        docker() {{
+            if [[ "$1" == "rmi" && "$2" == "-f" ]]; then echo "FORCED" ; return 0; fi
+            echo "conflict: unable to delete old - image is being used by stopped container abc" >&2
+            return 1
+        }}
+        main
+    """)
+
+    assert "FORCED" not in result.stdout, "must not force a container-referenced image"
+    assert "could not remove old" in result.stdout
+    assert "0 removed" in result.stdout
+
+
+def test_a_forced_removal_that_still_fails_is_reported() -> None:
+    """-f is a retry, not a guarantee. If it also fails the image must be reported,
+    not silently counted as removed."""
+    result = _run(f"""
+        source {SCRIPT}
+        collect_images() {{
+            printf 'new\t2026-08-03T09:35:43Z\tghcr.io/x/api:dev\\n'
+            printf 'old\t2026-01-01T00:00:00Z\tghcr.io/x/api:old\\n'
+        }}
+        protected_ids() {{ printf ''; }}
+        docker() {{ echo "{_MULTI_TAG_ERROR}" >&2; return 1; }}
+        main
+    """)
+
+    assert "could not remove old" in result.stdout
+    assert "0 removed" in result.stdout
+    assert result.returncode == 0, "a stuck image must not fail the deployment"
+
+
+def test_dry_run_never_forces() -> None:
+    result = _run(f"""
+        source {SCRIPT}
+        DRY_RUN=1
+        collect_images() {{
+            printf 'new\t2026-08-03T09:35:43Z\tghcr.io/x/api:dev\\n'
+            printf 'old\t2026-01-01T00:00:00Z\tghcr.io/x/api:old\\n'
+        }}
+        protected_ids() {{ printf ''; }}
+        docker() {{ echo "DOCKER CALLED: $*"; }}
+        main
+    """)
+
+    assert "DOCKER CALLED" not in result.stdout
+    assert "would remove old" in result.stdout


### PR DESCRIPTION
Addresses @NicoleCornell8's review of #408. Two of the four comments needed code; the other
two are answered below.

## 1. Wheels layer (priority) — fixed

`COPY --from=builder /wheels /wheels` writes its own layer holding every wheel; the later
`rm -rf /wheels` only whites them out, so the bytes ship to every device. Replaced with a
BuildKit bind mount, which is never committed:

```dockerfile
RUN --mount=type=bind,from=builder,source=/wheels,target=/wheels \
    pip install --no-cache-dir --no-index --find-links=/wheels -r requirements-backend.txt
```

Added a `# syntax=docker/dockerfile:1.4` directive so the mount syntax is understood
regardless of the builder's default. Verified with `docker buildx build --check` — no warnings.

Note the 889 → 497 MB figure was measured, so it already included this bloat; the fix makes
the image smaller still rather than invalidating the number.

## 2. `docker rmi` multi-tag — fixed, and confirmed worse than reported

Verified against docker directly:

```
$ docker tag hello-world testrepo/x:latest && docker tag hello-world testrepo/x:v2
$ docker rmi <id>
Error response from daemon: conflict: unable to delete 7f4da0fc94bc (must be forced)
  - image is referenced in multiple repositories
```

The message says "multiple repositories" but it fires on **two tags in a single repository**.
CI pushes `:latest` and `:<sha>` on every build, so this is the common shape on a migrated
device, not an edge case.

Retried with `-f` **only** on that message, not blanket. `docker rmi -f` on an image a stopped
container references removes it and orphans the container, which would dissolve the floor the
script deliberately leans on. The protected set already excludes container-referenced images,
so `-f` is a second line here rather than the first; any other refusal still stops the removal
and is logged. A forced removal says so, since it means the device is carrying multi-tagged
images.

Four tests: forced on the multi-tag conflict, never forced on a container reference, reported
when `-f` also fails, never forced under `DRY_RUN`. The first fails against the unfixed script
with the exact reported symptom (`could not remove old` / `0 removed`).

## 3. Prune chained with `;` after `up -d` — already fixed in #409

#409 (open against this same base) moved the prune after the health poll and gated it on a
`/health` probe. That subsumes the suggested `up -d && prune`: if `up -d` fails for any reason
— bad compose, port clash, pull failure — nothing answers `/health`, so the prune does not run.
Same bug found from two directions.

## 4. Registry cache media types — does not reproduce

Checked the last `docker-build.yml` run:

```
#24 exporting cache to registry
#24 sending cache export 4.4s done
```

Both API and UI exported cleanly; GHCR accepted the default media types. The only failure in
that log is an unrelated Actions cache for `binfmt`. No change made.

## Device verification

The prune ran for real on sn03 (sandbox, Watchtower-era) during this review:

| | Before | After |
|---|---|---|
| Images | 30 | 6 |
| Image size | 11.83 GB | 1.035 GB |
| Reclaimable | 10.7 GB (90%) | 255.4 MB (24%) |
| Disk used | 24 G (43%) | 14 G (25%) |

10 GB genuinely returned to the filesystem, all four containers still healthy, and the three
running images correctly protected. Note the removal set was 22 dangling + 2 single-tag images,
so it did **not** exercise the multi-tag path fixed here — that remains device-unverified.

Full suite: 64 failed / 931 passed / 237 skipped, against an `epic/fleet-hardening-2` baseline
of 64 / 927 / 237 — same pre-existing macOS hardware and matplotlib failures.
