### PR TITLE
Fix the shadow accessControl + the false "last update failed" banner (am#395/#394)

### DIFF
--- a/aquila_web/main.py
+++ b/aquila_web/main.py
@@ -2266,13 +2266,27 @@ def _clear_pre_update_sha() -> None:
 def _resolve_update_banner() -> None:
     """Raise/clear the 'last update failed' banner from the pre-update record.
 
-    Run on boot and on each Greengrass post-update event: compare the recorded
-    pre-apply build to the one running now (baked git_sha) and mark the gate.
+    Run at BOOT only: if we came back on the pre-update build with the record still
+    present, Greengrass rolled us back (the new build failed health and reverted, so
+    no post-update event fired) → banner. A clean boot (no record) is a no-op.
     """
     running_sha = _running_container_shas()[0]  # this image's baked git_sha
     update_gate.resolve_update_result(
         _read_pre_update_sha(), running_sha, update_gate.GATE, _clear_pre_update_sha
     )
+
+
+def _mark_update_succeeded() -> None:
+    """A Greengrass post-update event fired → the approved deployment applied.
+
+    Treat it as success and clear the pre-update record + any failure banner. Do
+    NOT re-run the git_sha compare here: a deployment that only adds a component
+    (e.g. ShadowManager) leaves the app image — and its git_sha — unchanged, which
+    the compare would misread as a rollback (the sn01 false banner). A real rollback
+    sends no post-update event and is caught on boot instead.
+    """
+    _clear_pre_update_sha()
+    update_gate.GATE.mark_update_succeeded()
 
 
 @app.get("/update/gate")
@@ -2541,5 +2555,5 @@ async def start_greengrass_update_agent() -> None:
         # and re-resolves the banner immediately on a Greengrass post-update event
         # (so a rollback shows without waiting for a reboot).
         record_pre_update=_write_pre_update_sha,
-        on_post_update=lambda deployment_id: _resolve_update_banner(),
+        on_post_update=lambda deployment_id: _mark_update_succeeded(),
     )

--- a/aquila_web/update_gate.py
+++ b/aquila_web/update_gate.py
@@ -26,6 +26,15 @@ class UpdateGate:
         """Record that the last update did not take (running the previous version)."""
         self._last_update_failed = True
 
+    def mark_update_succeeded(self):
+        """A deployment completed for this component → clear any failure banner.
+
+        A Greengrass post-update event means the update the operator approved DID
+        apply (even one that only added a component like ShadowManager and left the
+        app image — and its git_sha — unchanged). That must NOT read as a rollback.
+        """
+        self._last_update_failed = False
+
     def approve(self):
         """The operator tapped Update — release the deferred switch."""
         self._approved = True

--- a/scripts/greengrass/recipe.py
+++ b/scripts/greengrass/recipe.py
@@ -46,22 +46,25 @@ def build_recipe(component_name, version, compose_artifact_uri, image_refs=None)
         "ComponentName": component_name,
         "ComponentVersion": version,
         # Authorize the Device-Shadow IPC ops the update agent uses. Without this
-        # policy the nucleus denies UpdateThingShadow and publish_health() fails
-        # silently (the sn04-shadow gap). Scoped to THIS core device's own classic
-        # shadow (least privilege) — {iot:thingName} resolves on-device.
+        # policy ShadowManager denies UpdateThingShadow and publish_health() fails
+        # (the shadow stays dark — #395). NOTE: recipe variables like {iot:thingName}
+        # are NOT interpolated inside accessControl resources, so a scoped
+        # "$aws/things/{iot:thingName}/shadow" never matches and is denied. The
+        # resource must be "*" — the component only ever writes its own core
+        # device's shadow, so this stays effectively the device's own shadow.
         "ComponentConfiguration": {
             "DefaultConfiguration": {
                 "accessControl": {
                     "aws.greengrass.ShadowManager": {
                         component_name + ":shadow:1": {
                             "policyDescription": (
-                                "Access this core device's own classic shadow"
+                                "Read/write this core device's own shadow"
                             ),
                             "operations": [
                                 "aws.greengrass#GetThingShadow",
                                 "aws.greengrass#UpdateThingShadow",
                             ],
-                            "resources": ["$aws/things/{iot:thingName}/shadow"],
+                            "resources": ["*"],
                         }
                     }
                 }

--- a/tests/unit/test_greengrass_recipe.py
+++ b/tests/unit/test_greengrass_recipe.py
@@ -146,13 +146,15 @@ def test_recipe_authorizes_the_shadow_ipc_operations():
     assert "aws.greengrass#GetThingShadow" in ops
 
 
-def test_shadow_access_is_scoped_to_the_devices_own_shadow():
-    # Least privilege (PRD testing decision): the component may touch only THIS
-    # core device's classic shadow, not every thing's shadow.
+def test_shadow_access_grants_a_matchable_resource():
+    # {iot:thingName} is NOT interpolated inside accessControl, so a scoped
+    # "$aws/things/{iot:thingName}/shadow" resource is denied on-device (the sn01
+    # AuthorizationException). The resource must be "*" so the grant actually
+    # matches the core device's own shadow — never an unsubstituted path.
     policies = _shadow_access_policies(_recipe_with_images())
     resources = [r for pol in policies.values() for r in pol["resources"]]
-    assert "*" not in resources
-    assert any("{iot:thingName}" in r and r.endswith("/shadow") for r in resources)
+    assert resources == ["*"]
+    assert not any("{iot:thingName}" in r for r in resources)
 
 
 def test_recipe_declares_images_as_docker_artifacts():

--- a/tests/unit/test_update_gate.py
+++ b/tests/unit/test_update_gate.py
@@ -114,3 +114,15 @@ def test_status_carries_a_non_blocking_banner_after_a_failed_update():
     banner = gate.status()["banner"]
     assert banner is not None
     assert banner["blocking"] is False  # informational — the operator can still run
+
+
+def test_mark_update_succeeded_clears_the_failure_banner():
+    # A post-update event means the approved deployment applied — even one that only
+    # added ShadowManager and left the app git_sha unchanged. That must clear the
+    # banner, not read as a rollback (the sn01 false positive).
+    gate = UpdateGate()
+    gate.mark_update_failed()
+    assert gate.status()["banner"] is not None
+
+    gate.mark_update_succeeded()
+    assert gate.status()["banner"] is None


### PR DESCRIPTION
Two on-device bugs sn01 surfaced — one PR, both fixed.

## 1. Shadow stays dark (am#395 bug)
ShadowManager is installed + syncing, but the agent's write is **denied**:
```
AuthorizationException: com.acorn.sentri is not authorized to perform
aws.greengrass#UpdateThingShadow on resource $aws/things/10000000a283bd1f/shadow
```
The recipe granted the op on `$aws/things/{iot:thingName}/shadow`, but **recipe variables aren't interpolated inside `accessControl`**, so the resource never matched. **Fix: `resources: ["*"]`** — the component only ever writes its own core device's shadow. This is the change that finally makes the shadow publish.

## 2. False "last update failed" banner (am#394 bug)
am#394 infers a rollback from **git_sha equality** (recorded pre-apply sha == running sha). A deployment that only **adds a component** (ShadowManager) leaves `com.acorn.sentri`'s image — and its git_sha — **unchanged**, so the compare misread it as a rollback, and it **persisted across reboots**.

**Fix:** a Greengrass **post-update event = the approved deployment applied** → treat it as **success**: clear the pre-update record + reset the banner (`UpdateGate.mark_update_succeeded()`), instead of re-running the git_sha compare. The git_sha rollback inference now runs **on boot only** — for a real rollback, which reverts the process and sends no post-update event.

## Tests (74 pass)
- recipe grants a **matchable `"*"`** resource (not the unsubstituted `{iot:thingName}` path)
- `mark_update_succeeded()` clears the failure banner

## After merge → republish → deploy
- `get-thing-shadow` returns `reported.images` + `container_health`
- a ShadowManager/config-only deploy no longer raises a false banner

Part of #395 and #394.