### PR TITLE
fix(boot): suppress the bootloader network-install screen (#418)

### DIFF
--- a/scripts/deploy/deployment3_greengrass.sh
+++ b/scripts/deploy/deployment3_greengrass.sh
@@ -1159,6 +1159,70 @@ run_test "acorn theme is default"       "plymouth-set-default-theme | grep -q ac
 phase_pass "Plymouth Acorn theme installed (takes effect on next reboot)"
 
 # ═══════════════════════════════════════════════════════════════════════════════
+# Phase 14c — Bootloader Setup Screen (EEPROM)
+# ═══════════════════════════════════════════════════════════════════════════════
+phase_start "14c" "Bootloader Setup Screen (EEPROM)"
+
+# Boards with a newer factory bootloader ship NET_INSTALL_AT_POWER_ON=1, which
+# paints a "Configure this Raspberry Pi 4 Model B" panel over the whole display
+# on every cold boot. The bootloader draws it before the kernel loads, so the
+# suppression in Phases 6, 14 and 14b (piwiz, cmdline, Plymouth) all runs far too
+# late to hide it. NET_INSTALL_ENABLED=0 additionally skips the USB enumeration
+# the network-install keyboard probe performs, saving ~1s of boot.
+#
+# Applied to every device, not just affected ones: Phase 1 runs `apt-get upgrade`,
+# which can pull a newer rpi-eeprom and update the bootloader on an older board —
+# so a device that does not show the screen today can inherit the new defaults
+# from this very script. Setting the keys explicitly pins the behaviour instead
+# of depending on whichever bootloader the board happens to carry.
+#
+# This config lives in the on-board SPI EEPROM, NOT on the SD card: it survives
+# reimaging and is not undone by --revert. rpi-eeprom-config --apply does not
+# write the chip directly; it stages pieeprom.upd + recovery.bin on the boot
+# partition and the ROM programs the EEPROM during the next reboot. A power cut
+# in that window needs physical recovery, so the write is skipped entirely
+# whenever the config already matches — re-running this script never reflashes.
+
+EEPROM_CONF_CURRENT="/tmp/aquila-eeprom-current.conf"
+EEPROM_CONF_DESIRED="/tmp/aquila-eeprom-desired.conf"
+
+if ! command -v rpi-eeprom-config &>/dev/null; then
+    echo "  ⚠ rpi-eeprom-config not present — skipping (no Pi bootloader EEPROM)"
+    phase_pass "bootloader EEPROM not applicable on this hardware"
+elif ! rpi-eeprom-config > "${EEPROM_CONF_CURRENT}" 2>/dev/null \
+        || [[ ! -s "${EEPROM_CONF_CURRENT}" ]]; then
+    echo "  ⚠ could not read EEPROM config — skipping rather than writing blind"
+    phase_pass "bootloader EEPROM left untouched (config unreadable)"
+else
+    # Desired state: drop both keys wherever they sit, then pin network install
+    # off at the end. Deterministic ordering keeps this diff-stable on re-runs.
+    grep -v -E '^(NET_INSTALL_AT_POWER_ON|NET_INSTALL_ENABLED)=' \
+        "${EEPROM_CONF_CURRENT}" > "${EEPROM_CONF_DESIRED}" || true
+    echo "NET_INSTALL_ENABLED=0" >> "${EEPROM_CONF_DESIRED}"
+
+    if diff -q "${EEPROM_CONF_CURRENT}" "${EEPROM_CONF_DESIRED}" &>/dev/null; then
+        echo "  ✓ EEPROM config already correct — no update staged"
+    else
+        if rpi-eeprom-config --apply "${EEPROM_CONF_DESIRED}" &>/dev/null; then
+            echo "  ✓ EEPROM update staged — the ROM flashes it on the next reboot"
+            echo "    previous config: /var/lib/raspberrypi/bootloader/backup/"
+        else
+            phase_fail "rpi-eeprom-config --apply failed"
+        fi
+    fi
+
+    # Assert against the staged config, not the live chip: rpi-eeprom-config
+    # reads the CURRENT EEPROM, which still holds the old values until the
+    # flashing reboot, so asserting there would fail on an affected device.
+    run_test "power-on setup screen off" \
+        "! grep -q '^NET_INSTALL_AT_POWER_ON' ${EEPROM_CONF_DESIRED}"
+    run_test "network install disabled" \
+        "grep -q '^NET_INSTALL_ENABLED=0' ${EEPROM_CONF_DESIRED}"
+
+    phase_pass "bootloader setup screen suppressed (takes effect after reboot)"
+fi
+
+# ═══════════════════════════════════════════════════════════════════════════════
 # Phase 15 — Download Security Script
 # ═══════════════════════════════════════════════════════════════════════════════
 phase_start 15 "Download Security Script"

--- a/scripts/deploy/deployment3_greengrass.sh
+++ b/scripts/deploy/deployment3_greengrass.sh
@@ -1170,11 +1170,13 @@ phase_start "14c" "Bootloader Setup Screen (EEPROM)"
 # late to hide it. NET_INSTALL_ENABLED=0 additionally skips the USB enumeration
 # the network-install keyboard probe performs, saving ~1s of boot.
 #
-# Applied to every device, not just affected ones: Phase 1 runs `apt-get upgrade`,
-# which can pull a newer rpi-eeprom and update the bootloader on an older board —
-# so a device that does not show the screen today can inherit the new defaults
-# from this very script. Setting the keys explicitly pins the behaviour instead
-# of depending on whichever bootloader the board happens to carry.
+# Applied to every device, not just affected ones: `rpi-eeprom-config --apply`
+# updates the bootloader to the LATEST available image, not only its config.
+# Measured on sn01 and sn03 — both jumped from a 2025 bootloader to 2026/01/09
+# (d76c4603) when this ran. Newer bootloaders are precisely the ones that default
+# the setup screen on, so an old board that is fine today can inherit the problem
+# from this very phase. Writing the key in the same operation pins the behaviour
+# rather than leaving it to whichever bootloader the board ends up carrying.
 #
 # This config lives in the on-board SPI EEPROM, NOT on the SD card: it survives
 # reimaging and is not undone by --revert. rpi-eeprom-config --apply does not

--- a/tests/fleet_device/test_deployment3_greengrass_script.py
+++ b/tests/fleet_device/test_deployment3_greengrass_script.py
@@ -79,3 +79,39 @@ def test_retains_deployment2_device_build():
     # Everything else from deployment2 is kept (spot-check across phases).
     for marker in ("I2C", "Tailscale", "aquila-cert-renew", "security.sh", "Plymouth"):
         assert marker in SCRIPT, f"deployment3 dropped a shared step: {marker}"
+
+
+# --- Bootloader setup screen (EEPROM), #418 ----------------------------------
+# Newer factory bootloaders ship NET_INSTALL_AT_POWER_ON=1, which paints a
+# "Configure this Raspberry Pi" panel over the display on every cold boot. The
+# bootloader draws it pre-kernel, so the piwiz/cmdline/Plymouth suppression in
+# Phases 6, 14 and 14b all run too late to hide it.
+
+def test_disables_power_on_network_install_ui():
+    # Both keys are stripped, then network install is pinned off.
+    assert "NET_INSTALL_AT_POWER_ON" in SCRIPT
+    assert "NET_INSTALL_ENABLED=0" in SCRIPT
+    assert "rpi-eeprom-config --apply" in SCRIPT
+
+
+def test_eeprom_write_is_skipped_when_already_correct():
+    # The risk is the flash, not the setting: a power cut mid-write needs
+    # physical recovery. Re-running deployment3 must not reflash a correct chip.
+    assert "diff -q" in SCRIPT
+    assert "already correct" in SCRIPT
+
+
+def test_eeprom_phase_degrades_instead_of_writing_blind():
+    # No rpi-eeprom-config, or an unreadable config, must skip the phase rather
+    # than apply a config built from nothing.
+    assert "command -v rpi-eeprom-config" in SCRIPT
+    assert "writing blind" in SCRIPT
+
+
+def test_eeprom_asserts_against_staged_config_not_live_chip():
+    # rpi-eeprom-config reads the CURRENT EEPROM, which still holds the old
+    # values until the flashing reboot — asserting there fails on an affected
+    # device. The run_tests must check the staged file instead.
+    assert "EEPROM_CONF_DESIRED" in SCRIPT
+    assert 'run_test "power-on setup screen off"' in SCRIPT
+    assert 'run_test "network install disabled"' in SCRIPT


### PR DESCRIPTION
Closes #418.

Adds **Phase 14c — Bootloader Setup Screen (EEPROM)** to `deployment3_greengrass.sh`, so the fix lands on every device as the Greengrass migration rolls out.

## The symptom

New Sentri units paint a **"Configure this Raspberry Pi 4 Model B - 4GB"** panel across the display on every cold boot — before the Acorn splash, before any Aquila software, before the kernel. It renders tiled and misaligned because `config.txt` sets `display_hdmi_rotate=1` and this boot stage doesn't honour it.

## How we proved it's the bootloader, not our software

Every suppression step we already ship acts at a later stage, which is why none of them touch it:

| Existing control | Stage | Why it misses |
|---|---|---|
| `config.txt: disable_splash=1` | firmware | later |
| Phase 14 — `cmdline.txt` `quiet logo.nologo` | kernel | later |
| Phase 14b — Plymouth | initramfs | later |
| Phase 6 — `rm piwiz.desktop` | desktop | much later |

The screen is drawn by the **EEPROM bootloader**, ahead of all four.

**The first hypothesis was wrong, and testing is what caught it.** The red panel in the failure photo (`Boot mode: SD (01) order f4`) reads like the boot-failure diagnostics screen, which is gated by `HDMI_DELAY` (default 5s). We set `HDMI_DELAY=30` on the affected unit and cold-booted it — **the screen still appeared.** Per the Pi docs, `HDMI_DELAY` skips the diagnostics display *"unless a fatal error occurs"*, and the diagnostics page only appears when the bootloader *"is unable to boot from any boot media."* Neither was happening. That falsified the timing hypothesis and pointed at a different display entirely.

## How we proved the actual cause

The Pi bootloader docs describe `NET_INSTALL_AT_POWER_ON`:

> When set to `1`, displays the network install UI briefly after a cold boot to make this feature more obvious to new users. **The default bootloader images set this value to `1`.**

Everything in the field report is accounted for by that one setting:

- **Cold boot only, every time** — matches "after a cold boot", and is why warm reboots never reproduced it.
- **The panel wording** — "Configure this Raspberry Pi 4 Model B" is the network-install UI, not a diagnostics page.
- **`USB2 root HUB port 1 init` in the photo** — the docs note network install *"must initialise the USB controller and enumerate devices"* to detect a keyboard, *"increases boot time by approximately 1 second."* The USB enumeration wasn't a slow-boot symptom; it **is** the feature.

## How we proved it's only the new units

`sn01` before any change, verbatim:

```
$ sudo vcgencmd bootloader_version
2025/11/05 17:28:26
version 57db150d63864d47e6c9071f6b086a5401eb4e92 (release)

$ sudo rpi-eeprom-config | grep -i net_install
(no output)
```

No `NET_INSTALL` keys at all — the screen was never possible there. Affected units carry a newer factory bootloader whose defaults enable it.

Old and new units diverged because **nothing we deploy has ever written to the EEPROM**, so each board kept whatever its factory bootloader shipped with. There was no mechanism to bring them into line.

## The fix

Strip `NET_INSTALL_AT_POWER_ON`, pin `NET_INSTALL_ENABLED=0`. The second key also drops the USB keyboard probe, buying back ~1s of boot.

**Verified on sn12 (affected):** screen present on cold boot before the change, gone after, across repeated full power-cycles.

## Why it applies to unaffected devices too — and the measured reason

The original rationale was that Phase 1's `apt-get upgrade` could pull a newer `rpi-eeprom`. Testing on two old devices found something stronger and more direct:

**`rpi-eeprom-config --apply` upgrades the bootloader to the latest available image, not only its config.**

| Device | Bootloader before | Bootloader after |
|---|---|---|
| sn01 | `2025/11/05` `57db150d` | `2026/01/09` `d76c4603` |
| sn03 | 2025 (date not captured) | `2026/01/09` `d76c4603` |

Two independent old boards converged on the identical newer bootloader. This is not incidental to the fix — **newer bootloaders are exactly the ones that default the setup screen on.** Applying this phase to an old device hands it a bootloader that would show the screen, and pins the setting off in the same operation. Doing the EEPROM write *without* the key would create the problem on the old fleet rather than prevent it.

The operational consequence, worth stating plainly for review: **rolling deployment3 across the fleet will upgrade every old device's bootloader to 2026/01/09.** The upside is that the fleet converges on one bootloader version instead of a spread of factory dates.

The in-code comment has been corrected to reflect the measured behaviour rather than the original `apt-get` reasoning.

## Why the write is guarded

The risk is the flash, not the setting. `rpi-eeprom-config --apply` doesn't touch the chip directly — it stages `pieeprom.upd` + `recovery.bin` on the boot partition, and the ROM programs the EEPROM during the next reboot. A power cut in that window needs physical recovery (`recovery.bin` on a FAT32 card, i.e. hands on the device).

So the phase:

- **diffs desired against current and stages nothing when they match** — re-running deployment3 never reflashes a correct chip;
- **skips rather than writing blind** if `rpi-eeprom-config` is missing or its output is unreadable;
- **asserts against the staged config, not the live chip** — `rpi-eeprom-config` reads the *current* EEPROM, which still holds the old values until the flashing reboot, so asserting there would fail on precisely the devices the fix targets.

Simulated across all four cases, then **confirmed on hardware**:

| Device | Run | Result |
|---|---|---|
| sn01 (old) | first | stages update |
| sn01 (old) | second | no flash |
| sn12 (new) | first | stages update |
| sn12 (new) | second | no flash |

sn03, second run, on-device:

```
$ diff /tmp/cur2.conf /tmp/des2.conf && echo "IDENTICAL — no reflash"
IDENTICAL — no reflash
```

This config lives in on-board SPI flash, not the SD card: it survives reimaging and is not undone by `--revert`.

## Old-device safety

sn01 and sn03 both took the write cleanly, rebooted normally, and came back with `NET_INSTALL_ENABLED=0` and a working kiosk. No rollback was needed on either.

Neither is evidence that the fix *suppresses* the screen — neither device ever showed it. That evidence comes from sn12. What the old devices establish is that the write is safe on a device with nothing to fix, which was the open question.

## Tests

Four guard tests in `tests/fleet_device/test_deployment3_greengrass_script.py` covering the keys, the skip-when-correct behaviour, the degrade-don't-write-blind path, and asserting against the staged file.

```
tests/fleet_device/test_deployment3_greengrass_script.py — 14 passed
bash -n scripts/deploy/deployment3_greengrass.sh — OK
```

**Full-suite note:** `pytest tests unit_tests` is 37 failed / 944 passed on this branch, against **52 failed / 925 passed on the base branch unchanged**. The failures are pre-existing hardware-test ordering flakiness (`test_lid_heater.py`, `test_homing_sample.py`) — they pass in isolation both with and without this change, and none are in files this PR touches. Worth a separate look.

## Not included

`scripts/deploy/deployment2.sh` does **not** get this phase. deployment3 is a fork of deployment2, not a layer on it, and deployment2 lives on `main` where deployment3 doesn't exist. Any device still provisioned via deployment2 before the Greengrass migration lands will show the screen. Flagging rather than fixing here since the stated plan is to run deployment3 on the whole fleet — one-line follow-up PR against `main` on request.

Separately, an unrelated boot-noise problem surfaced while testing sn03: console autologin + `startx` prints the login banner, Debian MOTD and X.Org version block after Plymouth exits. Different stage, different cause, not addressed here — and `spec_boot_splash.md` specifies `loglevel=3` and `logo.nologo` which Phase 14 never implemented. Both belong in their own issue.
