### PR TITLE
fix(kiosk): tear down the legacy console autologin path (#424)

### DIFF
--- a/scripts/deploy/deployment3_greengrass.sh
+++ b/scripts/deploy/deployment3_greengrass.sh
@@ -281,12 +281,39 @@ Section "ServerFlags"
 EndSection
 EOF
 
+# Tear down the legacy console-autologin path from deployment1.sh: an agetty
+# --autologin override on tty1 plus `startx` in ~/.bash_profile (server_web/
+# .bash_profile). LightDM owns autologin now, but the two are not mutually
+# exclusive — a device provisioned before Phase 4 existed carries both, and
+# nothing here previously removed the old one.
+#
+# Left in place, agetty logs in on tty1 and prints the login banner, the Debian
+# MOTD and the X.Org version block to the display before LightDM takes the
+# screen, and ~/.bash_profile races LightDM to start a second X on VT1.
+# Measured on sn03: removing both cleared the text entirely, kiosk unaffected.
+rm -rf /etc/systemd/system/getty@tty1.service.d
+systemctl daemon-reload
+
+# Rewrite rather than filter: deleting only the startx line leaves an empty
+# `if ... then / fi`, which is a bash syntax error on every login shell.
+if [[ -f "${PI_HOME}/.bash_profile" ]] && grep -q startx "${PI_HOME}/.bash_profile"; then
+    cat > "${PI_HOME}/.bash_profile" <<'EOF'
+if [ -f ~/.bashrc ]; then
+   . ~/.bashrc
+fi
+EOF
+    chown pi:pi "${PI_HOME}/.bash_profile"
+fi
+
 run_test "autologin.conf exists"           "test -f /etc/lightdm/lightdm.conf.d/autologin.conf"
 run_test "autologin-user=pi"               "grep -q 'autologin-user=pi' /etc/lightdm/lightdm.conf.d/autologin.conf"
 run_test "autologin-session=openbox"       "grep -q 'autologin-session=openbox' /etc/lightdm/lightdm.conf.d/autologin.conf"
 run_test "main lightdm.conf not rpd-labwc" "! grep -q 'autologin-session=rpd-labwc' /etc/lightdm/lightdm.conf"
 run_test "cursor disabled (-nocursor)"     "grep -q 'X -nocursor' /etc/lightdm/lightdm.conf.d/autologin.conf"
 run_test "lightdm enabled"                 "systemctl is-enabled lightdm | grep -q enabled"
+run_test "no console autologin override"   "! test -d /etc/systemd/system/getty@tty1.service.d"
+run_test "no startx in .bash_profile"      "! grep -q startx ${PI_HOME}/.bash_profile 2>/dev/null"
+run_test ".bash_profile is valid bash"     "test ! -f ${PI_HOME}/.bash_profile || bash -n ${PI_HOME}/.bash_profile"
 run_test "xorg.conf has AutoAddGPU off"    "grep -q 'AutoAddGPU' /etc/X11/xorg.conf"
 run_test "fbdev not installed"            "! dpkg -l xserver-xorg-video-fbdev 2>/dev/null | grep -q '^ii'"
 

--- a/tests/fleet_device/test_deployment3_greengrass_script.py
+++ b/tests/fleet_device/test_deployment3_greengrass_script.py
@@ -79,3 +79,33 @@ def test_retains_deployment2_device_build():
     # Everything else from deployment2 is kept (spot-check across phases).
     for marker in ("I2C", "Tailscale", "aquila-cert-renew", "security.sh", "Plymouth"):
         assert marker in SCRIPT, f"deployment3 dropped a shared step: {marker}"
+
+
+# --- Legacy console autologin teardown ---------------------------------------
+# deployment1.sh set up console autologin (agetty --autologin on tty1) plus
+# `startx` in ~/.bash_profile. Phase 4 configures LightDM autologin but never
+# removed the old path, so devices provisioned before it carried both: agetty
+# printed the login banner, MOTD and X.Org block on the display before LightDM
+# took the screen, and .bash_profile raced it to start a second X on VT1.
+# Confirmed on sn03.
+
+def test_removes_legacy_console_autologin_override():
+    assert "rm -rf /etc/systemd/system/getty@tty1.service.d" in SCRIPT
+    assert "systemctl daemon-reload" in SCRIPT
+
+
+def test_removes_startx_from_bash_profile():
+    assert "grep -q startx" in SCRIPT
+
+
+def test_bash_profile_rewritten_not_filtered():
+    # Deleting only the startx line leaves `if ... then / fi` with an empty body,
+    # which is a bash syntax error on every login shell. Must rewrite the file.
+    assert "sed -i '/startx/d'" not in SCRIPT
+    assert "grep -v startx" not in SCRIPT
+
+
+def test_console_autologin_teardown_is_asserted():
+    assert 'run_test "no console autologin override"' in SCRIPT
+    assert 'run_test "no startx in .bash_profile"' in SCRIPT
+    assert 'run_test ".bash_profile is valid bash"' in SCRIPT


### PR DESCRIPTION
Closes #424.

## The problem

Devices carry **two competing autologin mechanisms**. `deployment1.sh` set up console autologin (`agetty --autologin pi` on tty1 + `startx` in `~/.bash_profile`). Phase 4 of deployment2/3 replaced it with LightDM autologin — but **never tore the old one down**, and they are not mutually exclusive.

Confirmed on sn03, both active at once:

```
$ cat /etc/systemd/system/getty@tty1.service.d/*.conf
[Service]
ExecStart=
ExecStart=-/sbin/agetty --autologin pi --noclear %I $TERM

$ systemctl is-active lightdm
active
```

So agetty logs in on tty1 and prints the login banner, Debian MOTD and X.Org version block to the display before LightDM takes the screen — and `~/.bash_profile` races LightDM to start a **second X server** on VT1.

The cmdline is already correct (`console=tty3 quiet ... vt.global_cursor_default=0`), so this is not kernel output and `console=tty3` cannot suppress it. A login shell is being started on the console deliberately.

## The fix

Phase 4 now removes the getty override and rewrites `~/.bash_profile`.

**Rewritten, not filtered** — deleting only the `startx` line leaves:

```bash
if [ -z $DISPLAY ] && [ "${XDG_VTNR:-0}" -eq 1 ]; then
fi
```

An empty `then` body is a bash syntax error that fires on every login shell. Found the hard way while testing on sn03.

## Verification

Applied by hand on sn03: the console text was **gone** on the next boot, kiosk unaffected. `.hushlogin` was tried first and did *not* fix it — it only suppresses the MOTD, not the agetty banner or the X.Org block.

## Tests

Four guard tests in `tests/fleet_device/test_deployment3_greengrass_script.py`, including one that fails if anyone reintroduces the `sed`/`grep -v` filtering approach.

```
tests/fleet_device/test_deployment3_greengrass_script.py — 14 passed
bash -n scripts/deploy/deployment3_greengrass.sh — OK
```

## Not included

- `scripts/deploy/deployment2.sh` needs the same teardown — it's a fork on `main` where deployment3 doesn't exist.
- `spec_boot_splash.md` specifies `loglevel=3` and `logo.nologo`; **neither is implemented** in Phase 14 of either script. Noted in #424, not fixed here.

Independent of #419 (bootloader setup screen) — same visible complaint, different boot stage, different fix. Both branch from `feat/greengrass-migration` and don't touch the same lines.