### PR TITLE
fix(kiosk): neutralise the legacy system-wide Openbox autostart (#426)

### DIFF
--- a/scripts/deploy/deployment3_greengrass.sh
+++ b/scripts/deploy/deployment3_greengrass.sh
@@ -729,6 +729,28 @@ phase_start "9b" "Chromium Kiosk (Openbox autostart)"
 rm -f "${PI_HOME}/.config/autostart/chromium-kiosk.desktop"
 rm -f "${PI_HOME}/.config/labwc/autostart"
 
+# Neutralise the SYSTEM-WIDE Openbox autostart. Openbox runs /etc/xdg/openbox/
+# autostart BEFORE the per-user file written below, and both run — the user file
+# does not replace it. deployment1.sh wrote the legacy kiosk there, so any device
+# provisioned before this phase existed starts two browsers, not one.
+#
+# Measured on sn03: `python3 /home/pi/kiosk.py` (WebKit) and the Chromium kiosk
+# both running. kiosk.py loads http://localhost:8090 directly with no retry and
+# no error handling, so before the backend is listening it paints WebKit's default
+# error page ("Error receiving data: Connection reset by peer") over the splash.
+# The same file also ran `xrandr --rotate left` against this phase's `--rotate
+# right`, and `unclutter`, which the user autostart below deliberately avoids.
+#
+# Overwritten rather than deleted: openbox ships this path as a dpkg conffile, so
+# a removed file can come back on package upgrade while a modified one is kept.
+if [[ -f /etc/xdg/openbox/autostart ]]; then
+    cat > /etc/xdg/openbox/autostart <<'EOF'
+# Intentionally empty — the Aquila kiosk launches from the per-user autostart at
+# ~/.config/openbox/autostart. Openbox runs this system-wide file first and runs
+# BOTH, so anything added here starts in addition to the kiosk, not instead of it.
+EOF
+fi
+
 # Install boot splash page
 curl -fsSL \
     -H "Authorization: token ${GHCR_TOKEN}" \
@@ -805,6 +827,10 @@ run_test "xrandr auto-detect present"  "grep -q 'HDMI_OUT' ${AUTOSTART}"
 run_test "xinput transform present"    "grep -q 'Coordinate Transformation Matrix' ${AUTOSTART}"
 run_test "no stale Wayland .desktop"   "test ! -f ${PI_HOME}/.config/autostart/chromium-kiosk.desktop"
 run_test "correct file ownership"      "stat -c '%U' ${AUTOSTART} | grep -q pi"
+run_test "no legacy kiosk.py launch"   "! grep -q kiosk.py /etc/xdg/openbox/autostart 2>/dev/null"
+run_test "no system-wide unclutter"    "! grep -q '^unclutter' /etc/xdg/openbox/autostart 2>/dev/null"
+run_test "no system-wide xrandr"       "! grep -q '^xrandr' /etc/xdg/openbox/autostart 2>/dev/null"
+run_test "one kiosk launcher only"     "! grep -q 'chromium' /etc/xdg/openbox/autostart 2>/dev/null"
 
 phase_pass "Openbox autostart configured — X11 kiosk with rotation and touch mapping"
 

--- a/tests/fleet_device/test_deployment3_greengrass_script.py
+++ b/tests/fleet_device/test_deployment3_greengrass_script.py
@@ -79,3 +79,33 @@ def test_retains_deployment2_device_build():
     # Everything else from deployment2 is kept (spot-check across phases).
     for marker in ("I2C", "Tailscale", "aquila-cert-renew", "security.sh", "Plymouth"):
         assert marker in SCRIPT, f"deployment3 dropped a shared step: {marker}"
+
+
+# --- Legacy system-wide Openbox autostart teardown ---------------------------
+# Openbox runs /etc/xdg/openbox/autostart BEFORE the per-user file and runs BOTH.
+# deployment1.sh put the legacy WebKit kiosk (kiosk.py) there, so devices
+# provisioned before Phase 9b existed start two browsers. kiosk.py loads
+# localhost:8090 with no retry, painting WebKit's default error page over the
+# splash before the backend is listening. Confirmed on sn03.
+
+def test_neutralises_system_wide_openbox_autostart():
+    assert "/etc/xdg/openbox/autostart" in SCRIPT
+
+
+def test_system_autostart_overwritten_not_deleted():
+    # openbox ships this path as a dpkg conffile: a deleted file can return on
+    # package upgrade, a modified one is kept.
+    assert "rm -f /etc/xdg/openbox/autostart" not in SCRIPT
+    assert "rm -rf /etc/xdg/openbox" not in SCRIPT
+
+
+def test_legacy_kiosk_launchers_asserted_gone():
+    assert 'run_test "no legacy kiosk.py launch"' in SCRIPT
+    assert 'run_test "one kiosk launcher only"' in SCRIPT
+
+
+def test_legacy_rotation_and_unclutter_asserted_gone():
+    # The legacy file also ran `xrandr --rotate left` against this phase's
+    # `--rotate right`, and unclutter, which Phase 9b deliberately avoids.
+    assert 'run_test "no system-wide unclutter"' in SCRIPT
+    assert 'run_test "no system-wide xrandr"' in SCRIPT


### PR DESCRIPTION
Closes #426.

## The problem

Openbox reads **two** autostart files and runs **both**:

1. `/etc/xdg/openbox/autostart` — system-wide, written by `deployment1.sh`
2. `~/.config/openbox/autostart` — per-user, written by Phase 9b

Phase 9b only ever wrote the second. So on any device provisioned by `deployment1.sh`, the Chromium kiosk was **added alongside** the legacy WebKit kiosk rather than replacing it.

Confirmed on sn03 — both running at once:

```
$ pgrep -af kiosk.py
2129 python3 /home/pi/kiosk.py

$ pgrep -af chromium
2270 /usr/lib/chromium/chromium ... --kiosk file:///opt/aquila/splash.html
```

`kiosk.py` loads `http://localhost:8090` directly with no retry and no error handling, so before the backend is listening it paints WebKit's default error page over the Acorn splash:

> `Error receiving data: Connection reset by peer`

Plain unstyled text top-left on white — WebKitGTK's error page, not Chromium's (Chromium's is styled and centred). That detail is what identified the second browser.

## Three regressions from one file

sn03's legacy `/etc/xdg/openbox/autostart`:

```bash
xrandr --output HDMI-2 --rotate left
unclutter -idle 0.5 &
sleep 3
python3 /home/pi/kiosk.py &
```

1. **`kiosk.py`** — the error page.
2. **`xrandr --rotate left`** — fights Phase 9b's `--rotate right`.
3. **`unclutter`** — which Phase 9b explicitly refuses to run; its comment notes unclutter "re-shows the cursor on pointer/touch events, causing a startup flash and a lingering cursor over dropdowns on every tap." So the behaviour `specs/hardware/mouse-cursor-removal.md` set out to fix was still live on these devices.

## The fix

Phase 9b now overwrites the system-wide file with a comment-only stub explaining that Openbox runs both.

**Overwritten, not deleted** — `openbox` ships this path as a dpkg conffile. A deleted conffile can be restored on package upgrade; a modified one is kept. A test enforces this.

## Verification

Applied by hand on sn03: error page gone, `pgrep -af kiosk.py` empty, only the Chromium kiosk running.

## Tests

Four guard tests, including one that fails if anyone switches the overwrite to an `rm`.

```
tests/fleet_device/test_deployment3_greengrass_script.py — 14 passed
bash -n scripts/deploy/deployment3_greengrass.sh — OK
```

## Notes

- `deployment2.sh` needs the same teardown — fork on `main`, out of scope here.
- `scripts/deploy/deployment1.sh` is dead code. Removing it fixes nothing on-device but shouldn't survive as a template.
- Once this legacy overlay is gone, sn03 shows the same "Untitled" white splash as sn09–sn12 — a separate fleet-wide problem this error was masking. Being filed separately.

Third in a series with #425 (console autologin) and #419 (bootloader screen); all branch from `feat/greengrass-migration` and touch different phases. #425 and this one are the same underlying pattern: the replacement was added without removing what it replaced.