### PR TITLE
Replace raw system output in operator-facing messages (#422)

### DIFF
--- a/aquila_web/main.py
+++ b/aquila_web/main.py
@@ -1259,13 +1259,13 @@ async def button_run():
     logger.info("Run button pressed")
     if not selected_profile:
         run_requested = False
-        return {"ok": False, "message": "Select a profile before running"}
+        return {"ok": False, "message": "Select a profile before running."}
     if not run_name or not run_name.strip():
         run_requested = False
-        return {"ok": False, "message": "Enter a run name before running"}
+        return {"ok": False, "message": "Enter a run name before running."}
     if drawer_state_open and not drawer_state_closed:
         run_requested = False
-        return {"ok": False, "message": "Close the drawer before running"}
+        return {"ok": False, "message": "Close the drawer before running."}
     if DEV_SIMULATE:
         if run_in_progress:
             return {"ok": False, "message": "Run already in progress"}
@@ -1968,7 +1968,10 @@ async def wifi_connect(body: WifiConnect):
     try:
         return await _kiosk_post("/wifi/connect", {"ssid": body.ssid, "password": body.password})
     except Exception as e:
-        return {"ok": False, "error": str(e)}
+        # kiosk-control is down — a different failure from a bad password, and
+        # the operator must not be shown the raw Python error (#422).
+        logger.warning("wifi connect proxy failed for %r: %s", body.ssid, e)
+        return {"ok": False, "error": "Connection failed"}
 
 class WifiForget(BaseModel):
     ssid: str
@@ -1978,7 +1981,9 @@ async def wifi_forget(body: WifiForget):
     try:
         return await _kiosk_post("/wifi/forget", {"ssid": body.ssid})
     except Exception as e:
-        return {"ok": False, "error": str(e)}
+        # This one also feeds a raw alert() box on the saved-networks list.
+        logger.warning("wifi forget proxy failed for %r: %s", body.ssid, e)
+        return {"ok": False, "error": "Connection failed"}
 
 @app.get("/wifi/saved")
 async def wifi_saved():

--- a/aquila_web/static/profiles/builder.html
+++ b/aquila_web/static/profiles/builder.html
@@ -164,6 +164,7 @@
     </main>
   </div>
   <script src="/static/nav.js?v=1"></script>
+  <script src="/static/save_error.js?v=1"></script>
   <script src="/static/profiles/builder.js?v=6"></script>
   <script src="/static/keyboard.js?v=14"></script>
 </body>

--- a/aquila_web/static/profiles/builder.js
+++ b/aquila_web/static/profiles/builder.js
@@ -239,7 +239,7 @@
         } catch (e) {
           /* non-JSON error body */
         }
-        if (status) status.textContent = err.detail || "Failed to save";
+        if (status) status.textContent = formatSaveError(err.detail);
         return;
       }
       if (status) status.textContent = "Saved";

--- a/aquila_web/static/profiles/edit.html
+++ b/aquila_web/static/profiles/edit.html
@@ -69,6 +69,7 @@
       </div>
     </main>
   </div>
+  <script src="/static/save_error.js?v=1"></script>
   <script src="/static/profiles/edit.js?v=16"></script>
   <script src="/static/keyboard.js?v=14"></script>
 </body>

--- a/aquila_web/static/profiles/edit.js
+++ b/aquila_web/static/profiles/edit.js
@@ -634,7 +634,7 @@ async function saveProfile() {
     });
     if (!response.ok) {
       const error = await response.json();
-      saveStatus.textContent = error.detail || "Failed to save";
+      saveStatus.textContent = formatSaveError(error.detail);
       return;
     }
     saveStatus.textContent = "Saved";

--- a/aquila_web/static/profiles/edit_form.html
+++ b/aquila_web/static/profiles/edit_form.html
@@ -114,6 +114,7 @@
     </main>
   </div>
   <script src="/static/nav.js?v=1"></script>
+  <script src="/static/save_error.js?v=1"></script>
   <script src="/static/profiles/edit.js?v=23"></script>
   <script src="/static/keyboard.js?v=14"></script>
 </body>

--- a/aquila_web/static/save_error.js
+++ b/aquila_web/static/save_error.js
@@ -1,0 +1,31 @@
+"use strict";
+// Turn a profile-save failure response into something an operator can act on
+// (issue #422).
+//
+// The server sends validation failures as {errors: [...]} and everything else
+// as a plain string. Assigning the object straight to textContent rendered the
+// literal "[object Object]", so an out-of-range field told the operator nothing
+// at all. Anything unrecognised falls back rather than leaking a shape.
+
+var DEFAULT_SAVE_ERROR = "Failed to save";
+
+function formatSaveError(detail) {
+  if (typeof detail === "string" && detail.trim()) {
+    return detail;
+  }
+  if (detail && Array.isArray(detail.errors) && detail.errors.length) {
+    var messages = detail.errors.filter(function (e) {
+      return typeof e === "string" && e.trim();
+    });
+    if (messages.length) {
+      return messages.join("; ");
+    }
+  }
+  return DEFAULT_SAVE_ERROR;
+}
+
+// Enable unit testing under Node (node:test) without affecting the browser,
+// where `module` is undefined. Not a build step — a guarded CommonJS export.
+if (typeof module !== "undefined" && module.exports) {
+  module.exports = { formatSaveError };
+}

--- a/scripts/kiosk-control/kiosk_control.py
+++ b/scripts/kiosk-control/kiosk_control.py
@@ -212,6 +212,19 @@ def _delete_profiles_for_ssid(ssid: str) -> None:
             _nmcli("connection", "delete", name)
 
 
+def _connect_failed(ssid: str, stage: str, err: str) -> dict:
+    """Log what nmcli actually said; hand the operator something actionable.
+
+    nmcli reports a too-short password when the profile is created
+    ("802-11-wireless-security.psk: property is invalid") and a wrong-but-valid
+    password when the profile is activated ("Secrets were required, but not
+    provided"). Both used to be painted verbatim onto the kiosk. The operator's
+    next step is identical either way, so both give one message (#422).
+    """
+    log.warning("wifi connect failed for %r at %s: %s", ssid, stage, err)
+    return {"ok": False, "error": f'Failed to add "{ssid}". Please try again'}
+
+
 def _wifi_connect(ssid: str, password: str) -> dict:
     _delete_profiles_for_ssid(ssid)
     if password:
@@ -227,7 +240,7 @@ def _wifi_connect(ssid: str, password: str) -> dict:
             "802-11-wireless.bssid", "",
         )
         if code != 0:
-            return {"ok": False, "error": err}
+            return _connect_failed(ssid, "add", err)
         code, _, err = _nmcli("connection", "up", ssid)
     else:
         code, _, err = _nmcli(
@@ -239,11 +252,12 @@ def _wifi_connect(ssid: str, password: str) -> dict:
             "connection.permissions", "",
         )
         if code != 0:
-            return {"ok": False, "error": err}
+            return _connect_failed(ssid, "add", err)
         code, _, err = _nmcli("connection", "up", ssid)
-    if code == 0:
-        _nmcli("connection", "modify", ssid, "802-11-wireless.bssid", "")
-    return {"ok": code == 0, "error": err if code != 0 else None}
+    if code != 0:
+        return _connect_failed(ssid, "up", err)
+    _nmcli("connection", "modify", ssid, "802-11-wireless.bssid", "")
+    return {"ok": True, "error": None}
 
 
 def _wifi_forget(ssid: str) -> dict:

--- a/tests/contract/test_run_warning_copy.py
+++ b/tests/contract/test_run_warning_copy.py
@@ -1,0 +1,59 @@
+"""Contract tests for the run-guard warnings (issue #422).
+
+The same three refusals are worded in two places — the client checks them before
+POSTing, and the server checks them again — and the two copies had drifted apart
+by a trailing full stop. The operator saw slightly different punctuation
+depending on which layer caught the problem.
+"""
+from pathlib import Path
+
+import pytest
+
+SCRIPT_JS = Path(__file__).parents[2] / "aquila_web" / "static" / "script.js"
+
+NO_PROFILE = "Select a profile before running."
+NO_RUN_NAME = "Enter a run name before running."
+DRAWER_OPEN = "Close the drawer before running."
+
+
+@pytest.mark.contract
+def test_run_without_a_profile_is_refused_with_the_full_message(client):
+    body = client.post("/button/run").json()
+    assert body["ok"] is False
+    assert body["message"] == NO_PROFILE
+
+
+@pytest.mark.contract
+def test_run_without_a_run_name_is_refused_with_the_full_message(client, monkeypatch):
+    """The run name is set through module state, not the API.
+
+    POST /run/name ignores an empty value and run_name always carries an
+    auto-generated default, so this guard cannot be reached over HTTP — the
+    client-side check is what fires in practice. Reaching it directly is the
+    only way to pin its wording.
+    """
+    from aquila_web import main as web_main
+
+    client.post("/profile/select", json={"profile": "anything.json"})
+    monkeypatch.setattr(web_main, "run_name", "")
+    body = client.post("/button/run").json()
+    assert body["ok"] is False
+    assert body["message"] == NO_RUN_NAME
+
+
+@pytest.mark.contract
+def test_run_with_the_drawer_open_is_refused_with_the_full_message(client):
+    client.post("/profile/select", json={"profile": "anything.json"})
+    client.post("/run/name", json={"name": "run1"})
+    client.post("/drawer/state", json={"open": True, "closed": False})
+    body = client.post("/button/run").json()
+    assert body["ok"] is False
+    assert body["message"] == DRAWER_OPEN
+
+
+@pytest.mark.contract
+def test_client_and_server_word_the_refusals_identically():
+    """Both layers guard the same three rules; they must say the same thing."""
+    script = SCRIPT_JS.read_text(encoding="utf-8")
+    for message in (NO_PROFILE, NO_RUN_NAME, DRAWER_OPEN):
+        assert f'"{message}"' in script, f"client copy drifted from {message!r}"

--- a/tests/contract/test_wifi_endpoints.py
+++ b/tests/contract/test_wifi_endpoints.py
@@ -164,6 +164,19 @@ def test_wifi_connect_kiosk_unreachable(client):
     assert "error" in data
 
 
+@pytest.mark.contract
+def test_wifi_connect_kiosk_unreachable_hides_the_exception(client):
+    """The operator gets 'Connection failed', not a raw Python error (#422)."""
+    with patch(
+        "aquila_web.main._kiosk_post",
+        side_effect=Exception("[Errno 111] Connection refused"),
+    ):
+        response = client.post("/wifi/connect", json={"ssid": "HomeNetwork", "password": "secret"})
+    error = response.json()["error"]
+    assert error == "Connection failed"
+    assert "Errno" not in error
+
+
 # ---------------------------------------------------------------------------
 # POST /wifi/forget
 # ---------------------------------------------------------------------------
@@ -196,3 +209,16 @@ def test_wifi_forget_kiosk_unreachable(client):
     data = response.json()
     assert data["ok"] is False
     assert "error" in data
+
+
+@pytest.mark.contract
+def test_wifi_forget_kiosk_unreachable_hides_the_exception(client):
+    """The forget path shows the same message — and it also feeds an alert box."""
+    with patch(
+        "aquila_web.main._kiosk_post",
+        side_effect=Exception("[Errno 111] Connection refused"),
+    ):
+        response = client.post("/wifi/forget", json={"ssid": "HomeNetwork"})
+    error = response.json()["error"]
+    assert error == "Connection failed"
+    assert "Errno" not in error

--- a/tests/unit/js/save_error.test.js
+++ b/tests/unit/js/save_error.test.js
@@ -1,0 +1,46 @@
+"use strict";
+// Unit tests for the profile-save error formatting (issue #422).
+// Run: node --test tests/unit/js/save_error.test.js
+//
+// The server returns validation failures as a structured object
+// ({errors: [...]}), and the editor assigned it straight to textContent — so an
+// out-of-range field showed the operator the literal string "[object Object]"
+// instead of naming the field that was wrong.
+
+const { test } = require("node:test");
+const assert = require("node:assert/strict");
+const { formatSaveError } = require("../../../aquila_web/static/save_error.js");
+
+test("a validation failure names the offending field", () => {
+  const detail = { errors: ["incubation.temp: Invalid Value"] };
+  assert.equal(formatSaveError(detail), "incubation.temp: Invalid Value");
+});
+
+test("every offending field is shown, not just the first", () => {
+  const detail = {
+    errors: ["incubation.temp: Invalid Value", "amplification.cycles: Invalid Value"],
+  };
+  const out = formatSaveError(detail);
+  assert.match(out, /incubation\.temp/);
+  assert.match(out, /amplification\.cycles/);
+});
+
+test("a plain string detail is passed through", () => {
+  assert.equal(
+    formatSaveError("Bundled profiles are read-only."),
+    "Bundled profiles are read-only."
+  );
+});
+
+test("a missing detail falls back to a usable message", () => {
+  assert.equal(formatSaveError(undefined), "Failed to save");
+  assert.equal(formatSaveError(null), "Failed to save");
+});
+
+test("an unexpected shape never renders as [object Object]", () => {
+  for (const detail of [{}, { errors: [] }, { errors: "nope" }, { other: 1 }, []]) {
+    const out = formatSaveError(detail);
+    assert.doesNotMatch(out, /\[object Object\]/, `leaked for ${JSON.stringify(detail)}`);
+    assert.ok(out.length > 0);
+  }
+});

--- a/tests/unit/test_wifi_helpers.py
+++ b/tests/unit/test_wifi_helpers.py
@@ -277,24 +277,70 @@ class TestWifiConnect:
         assert result["ok"] is True
         assert result["error"] is None
 
-    def test_returns_ok_false_when_connection_add_fails(self):
+    # A password that is too short fails when the profile is created; a password
+    # that is well-formed but wrong fails when the profile is activated. nmcli
+    # words those two very differently, and the operator was shown the raw text
+    # ("802-11-wireless-security.psk: property is invalid"). Both now give the
+    # same actionable message (#422).
+    OPERATOR_MESSAGE = 'Failed to add "HomeNet". Please try again'
+
+    def test_malformed_password_gives_the_operator_message(self):
         side_effects = self._no_profiles() + [
-            _nmcli_result(1, "", "Error: failed to add connection"),
+            _nmcli_result(
+                1, "",
+                "Error: Failed to add 'HomeNet' connection: "
+                "802-11-wireless-security.psk: property is invalid",
+            ),
         ]
         with patch.object(kc, "_nmcli", side_effect=side_effects):
-            result = kc._wifi_connect("HomeNet", "wrongpass")
+            result = kc._wifi_connect("HomeNet", "short")
         assert result["ok"] is False
-        assert "failed to add" in result["error"]
+        assert result["error"] == self.OPERATOR_MESSAGE
 
-    def test_returns_ok_false_when_connection_up_fails(self):
+    def test_wrong_password_gives_the_same_operator_message(self):
         side_effects = self._no_profiles() + [
             _nmcli_result(0, ""),                              # connection add OK
-            _nmcli_result(1, "", "Secrets were required"),     # connection up fails
+            _nmcli_result(
+                1, "",
+                "Error: Connection activation failed: (7) Secrets were required, "
+                "but not provided.",
+            ),
         ]
         with patch.object(kc, "_nmcli", side_effect=side_effects):
             result = kc._wifi_connect("HomeNet", "wrongpass")
         assert result["ok"] is False
-        assert "Secrets were required" in result["error"]
+        assert result["error"] == self.OPERATOR_MESSAGE
+
+    def test_raw_nmcli_output_never_reaches_the_operator(self):
+        raw = "802-11-wireless-security.psk: property is invalid"
+        side_effects = self._no_profiles() + [_nmcli_result(1, "", raw)]
+        with patch.object(kc, "_nmcli", side_effect=side_effects):
+            result = kc._wifi_connect("HomeNet", "short")
+        assert raw not in result["error"]
+        assert "nmcli" not in result["error"]
+        assert "802-11" not in result["error"]
+
+    def test_the_network_name_is_named_back_to_the_operator(self):
+        side_effects = self._no_profiles() + [_nmcli_result(1, "", "boom")]
+        with patch.object(kc, "_nmcli", side_effect=side_effects):
+            result = kc._wifi_connect("acorn-wifi", "short")
+        assert result["error"] == 'Failed to add "acorn-wifi". Please try again'
+
+    def test_raw_nmcli_output_is_kept_in_the_log(self):
+        """Hiding it from the operator must not lose it for diagnosis.
+
+        Asserts against the logger rather than caplog: other modules in the
+        suite call logging.config.dictConfig, which disables existing loggers by
+        default, so caplog captures nothing here once those have been imported.
+        """
+        raw = "802-11-wireless-security.psk: property is invalid"
+        side_effects = self._no_profiles() + [_nmcli_result(1, "", raw)]
+        with patch.object(kc, "log") as mock_log:
+            with patch.object(kc, "_nmcli", side_effect=side_effects):
+                kc._wifi_connect("HomeNet", "short")
+        logged = " ".join(str(a) for c in mock_log.warning.call_args_list for a in c[0])
+        assert raw in logged
+        assert "HomeNet" in logged
 
     def test_purges_existing_stale_profile_before_connecting(self):
         side_effects = [


### PR DESCRIPTION
Closes #422.

Targets `error-message-revamp` alongside #429, so the error-message work lands on `main` as one merge.

## Wi-Fi

A failed connection painted `nmcli`'s stderr straight onto the kiosk:

> Error: Failed to add 'acorn-wifi' connection: 802-11-wireless-security.psk: property is invalid

nmcli words the two failure modes completely differently — a password under 8 characters fails when the profile is *created*, a wrong-but-valid password fails when it is *activated* — but the operator's next step is identical either way. Both now give:

> Failed to add "acorn-wifi". Please try again

The raw text goes to the kiosk-control log instead, so nothing is lost for diagnosis.

When kiosk-control itself is unreachable, the proxy returns **"Connection failed"** rather than a raw Python exception like `[Errno 111] Connection refused`. That path also fed a bare `alert()` box on the saved-networks list.

A friendly fallback already existed in the page but was unreachable — `d.error` always won. That precedence is now moot because the backend only ever returns safe strings.

## Run

The three run guards are worded in two places — the client checks them before POSTing, the server checks them again — and the copies had drifted by a trailing full stop. An operator saw different punctuation depending on which layer caught them. The server copies now match the client's, with a test that fails if either side drifts again.

## Profiles

Validation failures rendered as the literal string **`[object Object]`**. The server returns them as `{"errors": [...]}` and the editor assigned that object straight to `textContent`. It now reads:

> incubation.temp: Invalid Value; amplification.cycles: Invalid Value

Formatting is extracted to `save_error.js` so both editors share it and it's unit testable — same pattern as `screen_routing.js` in #429.

## Tests

61 across the touched files (42 Python, 19 JS). Each behaviour driven red → green.

Full suite matches the `main` baseline exactly — 59 pre-existing failures from hardware/analysis modules needing `RPi.GPIO`, `cryptography` and Pi-only deps. No regressions.

Verified manually end-to-end against a stubbed `nmcli`, driving the real `_wifi_connect` — all four messages confirmed in the browser.

## Reviewer notes

- **The server's "Enter a run name" guard is unreachable over HTTP.** `_set_run_name` ignores an empty value and `run_name` always carries a generated default, so only the client check ever fires. Its wording is fixed and pinned with a test that sets module state directly, with a comment explaining why. Worth a separate decision on whether to make it reachable or delete it.
- **`caplog` doesn't work on non-root loggers in this suite.** Other modules call `logging.config.dictConfig`, which disables existing loggers by default. My first version of the log assertion passed alone and failed in the full run; it now asserts against the logger directly. Likely to bite anyone writing a similar test.
- **The message lives in kiosk-control**, not the frontend, so the page still renders whatever `error` the backend sends. A more defensive option — having the frontend build the message from the SSID it already knows and never trust the backend string — was considered and set aside as out of scope.

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)
