### PR TITLE
Correct Updates tab failure messages and the false success state (#423)

### DIFF
--- a/aquila_web/main.py
+++ b/aquila_web/main.py
@@ -2049,10 +2049,24 @@ _OTA_GHCR_REPO_UI  = _OTA_GHCR_BASE + "-ui"
 _OTA_IMAGE_TAG = os.getenv("IMAGE_TAG", "")   # dev | pilot | prod — set by device.env
 _OTA_POLL_INTERVAL = int(os.getenv("UPDATE_CHECK_INTERVAL", "300"))  # seconds
 
+# Operator-facing update messages (issue #423). The technical cause always goes
+# to the log; only these ever reach the screen.
+UPDATE_CHECK_FAILED = "Could not check for updates"
+UPDATE_APPLY_FAILED = "Update failed. Please try again."
+# A missing registry token or ring tag means the device was provisioned wrong.
+# Restarting cannot fix it, so this omits the general page's "try again or
+# restart the device" line and sends the operator straight to support.
+UPDATE_NOT_CONFIGURED = (
+    "Something went wrong. Please contact Acorn Genetics for support."
+)
+
 _update_available: bool = False
 _update_dismissed: bool = False
 _update_status: str = "idle"   # idle | checking | available | updating | error
 _update_error: str | None = None
+# Kept apart so an apply failure can never be reported as a check failure (#423).
+_check_error: str | None = None
+_apply_error: str | None = None
 _update_last_checked: str | None = None
 # Digests of the images actually running — injected at deploy time via env vars.
 # Fall back to the first GHCR poll result if not set.
@@ -2154,14 +2168,41 @@ async def _ghcr_manifest_digest(repo: str, tag: str, user: str, token: str) -> s
         return None
 
 
+def _fail_check(message: str) -> None:
+    """Record a failed check so the panel renders it as a failure.
+
+    Check and apply keep their errors apart (#423): they shared one slot, so a
+    failed update could surface to the operator under a "could not check for
+    updates" heading.
+    """
+    global _update_status, _update_error, _update_available, _check_error, _apply_error
+    _update_available = False
+    _check_error = message
+    # The check just ran and failed; an older apply failure is no longer what
+    # the operator is looking at.
+    _apply_error = None
+    _update_status = "error"
+    _update_error = message
+
+
+def _fail_apply(message: str) -> None:
+    global _update_status, _update_error, _apply_error, _check_error
+    _apply_error = message
+    _check_error = None
+    _update_status = "error"
+    _update_error = message
+
+
 async def _do_check_update() -> None:
     global _update_available, _update_status, _update_error, _update_last_checked
     global _startup_image_digest, _startup_image_digest_ui, _latest_ghcr_digest, _latest_ghcr_digest_ui
     _update_status = "checking"
     try:
         if not _OTA_GHCR_TOKEN or not _OTA_IMAGE_TAG:
-            _update_status = "idle"
-            _update_error = "Registry credentials or IMAGE_TAG not configured"
+            # Provisioned wrong, not a transient fault: retrying and restarting
+            # will not help, so the operator is pointed straight at support.
+            logger.error("update check: registry credentials or IMAGE_TAG not configured")
+            _fail_check(UPDATE_NOT_CONFIGURED)
             return
         latest_api, latest_ui = await asyncio.gather(
             _ghcr_manifest_digest(_OTA_GHCR_REPO_API, _OTA_IMAGE_TAG, _OTA_GHCR_USER, _OTA_GHCR_TOKEN),
@@ -2169,8 +2210,10 @@ async def _do_check_update() -> None:
         )
         _update_last_checked = datetime.utcnow().isoformat() + "Z"
         if latest_api is None and latest_ui is None:
-            _update_status = "idle"
-            _update_error = "Registry unreachable or credentials invalid"
+            # Left the status at "idle" until #423, which the panel renders as
+            # a green "Software is up to date." — a failed check reported success.
+            logger.warning("update check: registry unreachable or credentials invalid")
+            _fail_check(UPDATE_CHECK_FAILED)
             return
         if latest_api is not None:
             _latest_ghcr_digest = latest_api
@@ -2189,9 +2232,11 @@ async def _do_check_update() -> None:
             _update_available = False
             _update_status = "idle"
         _update_error = None
+        _check_error = None
+        _apply_error = None
     except Exception as e:
-        _update_status = "error"
-        _update_error = str(e)
+        logger.exception("update check failed: %s", e)
+        _fail_check(UPDATE_CHECK_FAILED)
 
 
 @app.get("/update/status")
@@ -2209,6 +2254,9 @@ async def get_update_status():
         "available": available,
         "dismissed": _update_dismissed,
         "status": status,
+        # Which flow produced the error, so the panel cannot render an apply
+        # failure under a "could not check for updates" heading (#423).
+        "error_kind": "check" if _check_error else ("apply" if _apply_error else None),
         "error": _update_error,
         "last_checked": _update_last_checked,
     }
@@ -2217,7 +2265,14 @@ async def get_update_status():
 @app.post("/update/check")
 async def trigger_update_check():
     if not _OTA_GHCR_TOKEN or not _OTA_IMAGE_TAG:
-        return {"ok": False, "error": "Registry credentials or IMAGE_TAG not configured"}
+        # Answered 200 with ok=false until #423, so the page's error branch —
+        # which tests the HTTP status — never fired and this was unreachable.
+        logger.error("update check requested but registry credentials/IMAGE_TAG are unset")
+        _fail_check(UPDATE_NOT_CONFIGURED)
+        return JSONResponse(
+            status_code=503,
+            content={"ok": False, "error": UPDATE_NOT_CONFIGURED},
+        )
     asyncio.create_task(_do_check_update())
     return {"ok": True, "message": "checking"}
 
@@ -2276,13 +2331,13 @@ async def apply_update():
                     await _do_check_update()
             asyncio.create_task(_deferred_status_reset())
             return {"ok": True, "message": "Update triggered — containers will restart shortly."}
-        _update_status = "error"
-        _update_error = f"Watchtower returned HTTP {r.status_code}"
-        return {"ok": False, "error": _update_error}
+        logger.error("update apply: watchtower returned HTTP %s", r.status_code)
+        _fail_apply(UPDATE_APPLY_FAILED)
+        return {"ok": False, "error": UPDATE_APPLY_FAILED}
     except Exception as e:
-        _update_status = "error"
-        _update_error = str(e)
-        return {"ok": False, "error": str(e)}
+        logger.exception("update apply failed: %s", e)
+        _fail_apply(UPDATE_APPLY_FAILED)
+        return {"ok": False, "error": UPDATE_APPLY_FAILED}
 
 
 @app.post("/update/dismiss")

--- a/aquila_web/static/settings.html
+++ b/aquila_web/static/settings.html
@@ -301,8 +301,11 @@
       } else if (data.status === "updating") {
         _showUpdateOverlay();
       } else if (data.status === "error") {
+        // The backend sends a complete operator sentence and says which flow
+        // failed, so render it as-is — the old "Could not check for updates:"
+        // prefix mislabelled apply failures as check failures (#423).
         area.innerHTML = `
-          <p style="color:#dc2626;font-size:15px;">Could not check for updates: ${_escHtml(data.error || "unknown error")}</p>
+          <p style="color:#dc2626;font-size:15px;">${_escHtml(data.error || "Could not check for updates")}</p>
           <button onclick="openUpdateTab()"
             style="margin-top:12px;padding:8px 18px;border-radius:8px;border:1px solid #cbd5e1;background:#fff;font-size:14px;cursor:pointer;color:#374151;">Try again</button>
         `;
@@ -353,7 +356,7 @@
       if (attempt > 200) {
         _hideUpdateOverlay();
         const msg = fallbackError
-          ? `<p style="color:#dc2626;font-size:15px;">Update failed: ${_escHtml(fallbackError)}</p>`
+          ? `<p style="color:#dc2626;font-size:15px;">${_escHtml(fallbackError)}</p>`
           : '<p style="color:#6b7280;font-size:15px;">Update timed out. Please check the device and try again.</p>';
         document.getElementById("update-status-area").innerHTML = msg;
         return;
@@ -368,9 +371,9 @@
         if (!data || data.status === "updating" || data.available) { _pollForUpdateComplete(attempt + 1, fallbackError); return; }
         if (data.status === "error") {
           _hideUpdateOverlay();
-          const errMsg = fallbackError || data.error || "unknown error";
+          const errMsg = fallbackError || data.error || "Update failed. Please try again.";
           document.getElementById("update-status-area").innerHTML =
-            `<p style="color:#dc2626;font-size:15px;">Update failed: ${_escHtml(errMsg)}</p>`;
+            `<p style="color:#dc2626;font-size:15px;">${_escHtml(errMsg)}</p>`;
           return;
         }
         _hideUpdateOverlay();

--- a/tests/contract/test_update_failure_messages.py
+++ b/tests/contract/test_update_failure_messages.py
@@ -1,0 +1,265 @@
+"""Contract tests for Updates-tab failure reporting (issue #423).
+
+A check that could not reach the image registry used to leave the status at
+"idle" while quietly setting an error string. The Updates panel renders an idle
+status as a green "Software is up to date." — so a check that had actually
+failed reported success to the operator.
+"""
+import asyncio
+
+import pytest
+
+
+@pytest.fixture
+def configured(monkeypatch):
+    """A device provisioned with registry credentials and a ring tag."""
+    from aquila_web import main as web_main
+
+    monkeypatch.setattr(web_main, "_OTA_GHCR_TOKEN", "token")
+    monkeypatch.setattr(web_main, "_OTA_IMAGE_TAG", "prod")
+    monkeypatch.setattr(web_main, "_update_dismissed", False)
+    return web_main
+
+
+def _run_check(web_main):
+    asyncio.run(web_main._do_check_update())
+
+
+@pytest.mark.contract
+def test_unreachable_registry_is_not_reported_as_up_to_date(client, configured, monkeypatch):
+    """The failure must not fall through to the panel's success branch."""
+    async def _unreachable(*a, **kw):
+        return None
+
+    monkeypatch.setattr(configured, "_ghcr_manifest_digest", _unreachable)
+    _run_check(configured)
+
+    body = client.get("/update/status").json()
+    assert body["status"] == "error", "an unreachable registry reported a non-error status"
+    assert body["available"] is False
+
+
+@pytest.mark.contract
+def test_failed_check_message_carries_no_technical_detail(client, configured, monkeypatch):
+    async def _boom(*a, **kw):
+        raise RuntimeError("[Errno -3] Temporary failure in name resolution")
+
+    monkeypatch.setattr(configured, "_ghcr_manifest_digest", _boom)
+    _run_check(configured)
+
+    error = client.get("/update/status").json()["error"]
+    assert error == "Could not check for updates"
+    assert "Errno" not in error
+
+
+@pytest.mark.contract
+def test_misconfigured_device_is_told_to_contact_support(client, monkeypatch):
+    """No registry token or ring tag: retrying and restarting cannot help."""
+    from aquila_web import main as web_main
+
+    monkeypatch.setattr(web_main, "_OTA_GHCR_TOKEN", "")
+    monkeypatch.setattr(web_main, "_OTA_IMAGE_TAG", "")
+    _run_check(web_main)
+
+    body = client.get("/update/status").json()
+    assert body["status"] == "error"
+    assert "contact Acorn Genetics for support" in body["error"]
+    assert "IMAGE_TAG" not in body["error"]
+    assert "credentials" not in body["error"]
+
+
+@pytest.mark.contract
+def test_a_later_successful_check_clears_the_failure(client, configured, monkeypatch):
+    """A failure must not stick once the registry is reachable again."""
+    async def _unreachable(*a, **kw):
+        return None
+
+    monkeypatch.setattr(configured, "_ghcr_manifest_digest", _unreachable)
+    _run_check(configured)
+    assert client.get("/update/status").json()["status"] == "error"
+
+    async def _same_digest(*a, **kw):
+        return "sha256:same"
+
+    monkeypatch.setattr(configured, "_ghcr_manifest_digest", _same_digest)
+    monkeypatch.setattr(configured, "_startup_image_digest", "sha256:same")
+    monkeypatch.setattr(configured, "_startup_image_digest_ui", "sha256:same")
+    _run_check(configured)
+
+    body = client.get("/update/status").json()
+    assert body["status"] == "idle"
+    assert body["error"] is None
+
+
+@pytest.mark.contract
+def test_misconfigured_check_request_signals_failure_over_http(client, monkeypatch):
+    """The panel branches on the HTTP status.
+
+    POST /update/check answered 200 with {"ok": false}, so the page's error
+    branch never fired and the message was unreachable (#423).
+    """
+    from aquila_web import main as web_main
+
+    monkeypatch.setattr(web_main, "_OTA_GHCR_TOKEN", "")
+    monkeypatch.setattr(web_main, "_OTA_IMAGE_TAG", "")
+
+    response = client.post("/update/check")
+    assert response.status_code >= 400, "a 2xx leaves the failure undetectable"
+    body = response.json()
+    assert body["ok"] is False
+    assert "contact Acorn Genetics for support" in body["error"]
+
+
+@pytest.mark.contract
+def test_a_healthy_check_request_is_accepted(client, configured):
+    assert client.post("/update/check").status_code == 200
+
+
+# ---------------------------------------------------------------------------
+# Applying an update
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.contract
+def test_update_service_error_gives_the_operator_message(client, monkeypatch, tmp_path):
+    """Watchtower answered but refused; the HTTP status is not the operator's problem."""
+    from unittest.mock import AsyncMock, patch
+
+    from aquila_web import main as web_main
+
+    monkeypatch.setattr(web_main, "_UPDATE_SENTINEL_PATH", str(tmp_path / "s.json"))
+    monkeypatch.setattr(web_main.current_item, "screen", "ready")
+
+    class _Resp:
+        status_code = 500
+
+    with patch.object(web_main.httpx, "AsyncClient") as mock_client:
+        mock_client.return_value.__aenter__.return_value.post = AsyncMock(return_value=_Resp())
+        body = client.post("/update/apply").json()
+
+    assert body["ok"] is False
+    assert body["error"] == "Update failed. Please try again."
+    assert "500" not in body["error"]
+    assert "Watchtower" not in body["error"]
+
+
+@pytest.mark.contract
+def test_unreachable_update_service_gives_the_same_message(client, monkeypatch, tmp_path):
+    from unittest.mock import AsyncMock, patch
+
+    from aquila_web import main as web_main
+
+    monkeypatch.setattr(web_main, "_UPDATE_SENTINEL_PATH", str(tmp_path / "s.json"))
+    monkeypatch.setattr(web_main.current_item, "screen", "ready")
+
+    with patch.object(web_main.httpx, "AsyncClient") as mock_client:
+        mock_client.return_value.__aenter__.return_value.post = AsyncMock(
+            side_effect=Exception("All connection attempts failed")
+        )
+        body = client.post("/update/apply").json()
+
+    assert body["ok"] is False
+    assert body["error"] == "Update failed. Please try again."
+    assert "connection attempts" not in body["error"]
+
+
+@pytest.mark.contract
+def test_a_failed_apply_is_reported_as_an_apply_failure(client, monkeypatch, tmp_path):
+    """Check and apply shared one error slot, so an apply failure could be
+    rendered under the panel's 'could not check for updates' heading."""
+    from unittest.mock import AsyncMock, patch
+
+    from aquila_web import main as web_main
+
+    monkeypatch.setattr(web_main, "_UPDATE_SENTINEL_PATH", str(tmp_path / "s.json"))
+    monkeypatch.setattr(web_main.current_item, "screen", "ready")
+
+    with patch.object(web_main.httpx, "AsyncClient") as mock_client:
+        mock_client.return_value.__aenter__.return_value.post = AsyncMock(
+            side_effect=Exception("boom")
+        )
+        client.post("/update/apply")
+
+    body = client.get("/update/status").json()
+    assert body["error_kind"] == "apply"
+    assert body["error"] == "Update failed. Please try again."
+
+
+@pytest.mark.contract
+def test_a_failed_check_after_a_failed_apply_reports_the_check(client, configured, monkeypatch, tmp_path):
+    """The newer failure wins; the stale apply message must not leak through."""
+    from unittest.mock import AsyncMock, patch
+
+    monkeypatch.setattr(configured, "_UPDATE_SENTINEL_PATH", str(tmp_path / "s.json"))
+    monkeypatch.setattr(configured.current_item, "screen", "ready")
+
+    with patch.object(configured.httpx, "AsyncClient") as mock_client:
+        mock_client.return_value.__aenter__.return_value.post = AsyncMock(
+            side_effect=Exception("boom")
+        )
+        client.post("/update/apply")
+
+    async def _unreachable(*a, **kw):
+        return None
+
+    monkeypatch.setattr(configured, "_ghcr_manifest_digest", _unreachable)
+    _run_check(configured)
+
+    body = client.get("/update/status").json()
+    assert body["error_kind"] == "check"
+    assert body["error"] == "Could not check for updates"
+    assert "Update failed" not in body["error"]
+
+
+@pytest.mark.contract
+def test_the_technical_cause_is_kept_in_the_log(client, configured, monkeypatch):
+    """Hiding the detail from the operator must not lose it for diagnosis.
+
+    Asserts against the logger rather than caplog: other modules in the suite
+    call logging.config.dictConfig, which disables existing loggers by default.
+    """
+    from unittest.mock import MagicMock
+
+    async def _boom(*a, **kw):
+        raise RuntimeError("[Errno -3] Temporary failure in name resolution")
+
+    monkeypatch.setattr(configured, "_ghcr_manifest_digest", _boom)
+    mock_logger = MagicMock()
+    monkeypatch.setattr(configured, "logger", mock_logger)
+    _run_check(configured)
+
+    logged = " ".join(
+        str(a)
+        for call in mock_logger.exception.call_args_list + mock_logger.warning.call_args_list
+        for a in call[0]
+    )
+    assert "name resolution" in logged or "Errno" in logged
+
+
+@pytest.mark.contract
+def test_panel_renders_the_message_verbatim():
+    """The panel prefixed every error with 'Could not check for updates:'.
+
+    That prefix is what let an apply failure read as a check failure, and it
+    also double-headed the message now that the backend sends a complete
+    sentence.
+    """
+    from pathlib import Path
+
+    settings = (
+        Path(__file__).parents[2] / "aquila_web" / "static" / "settings.html"
+    ).read_text(encoding="utf-8")
+
+    assert "Could not check for updates: $" not in settings
+    assert "Update failed: $" not in settings
+
+
+@pytest.mark.contract
+def test_active_run_refusal_keeps_its_specific_wording(client, monkeypatch):
+    """This one names a real next step, so it must not be genericised."""
+    from aquila_web import main as web_main
+
+    monkeypatch.setattr(web_main.current_item, "screen", "running")
+    response = client.post("/update/apply")
+    assert response.status_code == 409
+    assert response.json()["error"] == "Cannot update during an active run. Stop the run first."


### PR DESCRIPTION
Closes #423.

Targets `error-message-revamp`, completing the error-message work alongside #429 and #430.

## The bug that matters most

A check that could not reach the image registry left the status at `idle` while quietly setting an error string. The panel renders an idle status as a green **"✓ Software is up to date."** — so a check that had actually *failed* reported success to the operator, on a device that may have been unable to update for weeks.

Both check failure paths now report an error status.

## Messages

| Situation | Before | After |
|---|---|---|
| Check failed | `Could not check for updates: [Errno -3] Temporary failure in name resolution` | `Could not check for updates` |
| Update failed | `Update failed: Watchtower returned HTTP 500` / `Update failed: All connection attempts failed` | `Update failed. Please try again.` |
| Device misconfigured | *(unreachable — never displayed)* | `Something went wrong. Please contact Acorn Genetics for support.` |
| Active run / timeout | unchanged | unchanged — both name a real next step |

The technical cause always goes to the log.

## Misconfigured devices

`POST /update/check` answered **200 with `ok:false`** when the registry token or ring tag was unset. The panel branches on the HTTP status, so its error branch never fired and the message was unreachable. It now answers **503**.

The wording deliberately omits the general error page's "try again or restart the device" line — neither can fix a device provisioned without credentials, so it points straight at support. **Flagging this as a deviation from the issue**, which said to reuse the general page wording verbatim. One-line change if you'd rather it match.

## Cross-wiring

Check and apply wrote to one shared error slot, so an apply failure could render under a "could not check for updates" heading. Their errors are now kept apart, and `/update/status` reports `error_kind` (`"check"` | `"apply"` | `null`). The panel renders the message verbatim rather than prefixing it.

## Tests

13 new contract tests, each driven red → green. Full suite matches the baseline exactly — no regressions.

Verified end-to-end against three device configurations — unconfigured, junk credentials, and an unreachable update service — driving the real code paths with no mocking.

## Reviewer notes

- **`error_kind` is a new field on `/update/status`.** Splitting the error state internally wasn't observable through the API, so there was no way to test the cross-wiring fix through the public interface. The wire shape is otherwise unchanged.
- **`/update/check` returning 503 is a contract change.** Only `settings.html` calls it, and it's what makes the misconfigured message reachable at all.
- **The `error` field is now always an operator-safe sentence**, never a raw exception — the panel can render it directly.

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)
