### PR TITLE
chore(version): bump app_version to 2.1.0.6

### DIFF
--- a/config_files/version.json
+++ b/config_files/version.json
@@ -1,3 +1,3 @@
 {
-    "app_version": "2.1.0.5"
+    "app_version": "2.1.0.6"
 }


### PR DESCRIPTION
Bumps `app_version` from `2.1.0.5` → `2.1.0.6` in `config_files/version.json` (single source of truth).

No functional changes.

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)