### PR TITLE
fix(kiosk): disable Openbox window decorations (#428)

### DIFF
--- a/scripts/deploy/deployment3_greengrass.sh
+++ b/scripts/deploy/deployment3_greengrass.sh
@@ -798,13 +798,21 @@ EOF
 # this explicitly (server_web/kiosk.py, set_decorated(False)); the Chromium path
 # relies on --kiosk alone and had no equivalent until now.
 #
+# The rule also forces the window fullscreen at map time. Without it Chromium's
+# window is mapped small and then resized up to fullscreen, and you watch it grow
+# — this is the "quadrant fill" reported on #428, which was mistaken for a slow
+# repaint for some time. Frame-by-frame capture on sn09 showed a part-sized,
+# decorated window rather than a partially painted one. Mapping it fullscreen
+# removes the intermediate sizes entirely.
+#
 # A kiosk never wants decoration on anything, so the rule is unconditional.
 # Openbox has no drop-in config directory — the only way to set a window rule is
 # to own a copy of rc.xml, which is why this copies the distro file rather than
 # patching it in place. That is the same "copied file drifts from upstream"
 # pattern that caused #424 and #426, so it is deliberate and documented here.
 #
-# Verified on sn03: title bar gone, kiosk otherwise unaffected.
+# Verified on sn03 (title bar gone) and sn09 (window arrives fullscreen; the
+# growing fill is gone). Kiosk otherwise unaffected on both.
 OPENBOX_RC="${PI_HOME}/.config/openbox/rc.xml"
 if [[ ! -f "${OPENBOX_RC}" && -f /etc/xdg/openbox/rc.xml ]]; then
     cp /etc/xdg/openbox/rc.xml "${OPENBOX_RC}"
@@ -812,7 +820,7 @@ fi
 if [[ -f "${OPENBOX_RC}" ]] && ! grep -q 'aquila-kiosk-no-decor' "${OPENBOX_RC}"; then
     # Insert inside the existing <applications> block; a second top-level
     # <applications> element would be invalid and silently ignored.
-    sed -i 's|</applications>|  <!-- aquila-kiosk-no-decor: see #428 -->\n  <application class="*">\n    <decor>no</decor>\n  </application>\n</applications>|' "${OPENBOX_RC}"
+    sed -i 's|</applications>|  <!-- aquila-kiosk-no-decor: see #428 -->\n  <application class="*">\n    <decor>no</decor>\n    <maximized>yes</maximized>\n    <fullscreen>yes</fullscreen>\n  </application>\n</applications>|' "${OPENBOX_RC}"
     # A malformed rc.xml leaves Openbox with no window manager, so validate
     # before letting it reach a reboot. Restore the stock file if we broke it.
     if ! python3 -c "import xml.etree.ElementTree as ET; ET.parse('${OPENBOX_RC}')" 2>/dev/null; then

--- a/scripts/deploy/deployment3_greengrass.sh
+++ b/scripts/deploy/deployment3_greengrass.sh
@@ -791,10 +791,43 @@ if [ ! -f /tmp/kiosk_disabled ]; then
 fi
 EOF
 
+# Openbox decorates every window by default, and --kiosk does not survive a
+# window being re-mapped: at startup Chromium's window appears briefly before it
+# is fullscreened, and Openbox paints a title bar reading "Untitled — Chromium"
+# across the top of the display (#428). The legacy WebKit kiosk guarded against
+# this explicitly (server_web/kiosk.py, set_decorated(False)); the Chromium path
+# relies on --kiosk alone and had no equivalent until now.
+#
+# A kiosk never wants decoration on anything, so the rule is unconditional.
+# Openbox has no drop-in config directory — the only way to set a window rule is
+# to own a copy of rc.xml, which is why this copies the distro file rather than
+# patching it in place. That is the same "copied file drifts from upstream"
+# pattern that caused #424 and #426, so it is deliberate and documented here.
+#
+# Verified on sn03: title bar gone, kiosk otherwise unaffected.
+OPENBOX_RC="${PI_HOME}/.config/openbox/rc.xml"
+if [[ ! -f "${OPENBOX_RC}" && -f /etc/xdg/openbox/rc.xml ]]; then
+    cp /etc/xdg/openbox/rc.xml "${OPENBOX_RC}"
+fi
+if [[ -f "${OPENBOX_RC}" ]] && ! grep -q 'aquila-kiosk-no-decor' "${OPENBOX_RC}"; then
+    # Insert inside the existing <applications> block; a second top-level
+    # <applications> element would be invalid and silently ignored.
+    sed -i 's|</applications>|  <!-- aquila-kiosk-no-decor: see #428 -->\n  <application class="*">\n    <decor>no</decor>\n  </application>\n</applications>|' "${OPENBOX_RC}"
+    # A malformed rc.xml leaves Openbox with no window manager, so validate
+    # before letting it reach a reboot. Restore the stock file if we broke it.
+    if ! python3 -c "import xml.etree.ElementTree as ET; ET.parse('${OPENBOX_RC}')" 2>/dev/null; then
+        echo "  ✗ rc.xml failed XML validation — restoring stock file"
+        cp /etc/xdg/openbox/rc.xml "${OPENBOX_RC}"
+    fi
+fi
+
 chown -R pi:pi "${PI_HOME}/.config/openbox"
 
 AUTOSTART="${PI_HOME}/.config/openbox/autostart"
 run_test "openbox autostart exists"    "test -f ${AUTOSTART}"
+run_test "openbox rc.xml exists"       "test -f ${OPENBOX_RC}"
+run_test "window decorations disabled" "grep -q 'aquila-kiosk-no-decor' ${OPENBOX_RC}"
+run_test "rc.xml is valid XML"         "python3 -c \"import xml.etree.ElementTree as ET; ET.parse('${OPENBOX_RC}')\""
 run_test "splash page installed"       "test -f /opt/aquila/splash.html"
 run_test "kiosk loads splash"          "grep -q 'splash.html' ${AUTOSTART}"
 run_test "kiosk flag check present"    "grep -q 'kiosk_disabled' ${AUTOSTART}"

--- a/scripts/deploy/deployment3_greengrass.sh
+++ b/scripts/deploy/deployment3_greengrass.sh
@@ -766,7 +766,14 @@ sleep 3
 # If kiosk_disabled flag exists, show desktop instead of kiosk.
 # Flag is in /tmp/ so it is cleared on reboot (kiosk relaunches normally).
 if [ ! -f /tmp/kiosk_disabled ]; then
-  chromium \
+  # GTK_THEME: Chromium's window background — the surface visible after the window
+  # is mapped but before the page paints — comes from GTK, not from Chromium. It is
+  # bright white by default, which makes every seam and flicker around it obvious
+  # against the black either side. No Chromium flag reaches it:
+  # --default-background-color and --cast-app-background-color both govern the PAGE
+  # area and were verified in the running process on sn09 with no effect. A dark GTK
+  # theme does reach it. See ~/.config/gtk-3.0/gtk.css above for the black override.
+  env GTK_THEME=Adwaita:dark chromium \
     --kiosk file:///opt/aquila/splash.html \
     --incognito \
     --noerrdialogs \
@@ -830,6 +837,19 @@ if [[ -f "${OPENBOX_RC}" ]] && ! grep -q 'aquila-kiosk-no-decor' "${OPENBOX_RC}"
 fi
 
 chown -R pi:pi "${PI_HOME}/.config/openbox"
+
+# Paint Chromium's window background black rather than the theme's dark grey, so
+# the empty window is indistinguishable from the black on either side of it and
+# the seams between frames have nothing to show. GTK_THEME=Adwaita:dark on the
+# launch line (Phase 9b) selects a dark theme; this pins the exact colour.
+mkdir -p "${PI_HOME}/.config/gtk-3.0"
+cat > "${PI_HOME}/.config/gtk-3.0/gtk.css" <<'EOF'
+/* Kiosk: the browser window background before any page paints (#428). */
+window, .background, decoration {
+    background-color: #000000;
+}
+EOF
+chown -R pi:pi "${PI_HOME}/.config/gtk-3.0"
 
 AUTOSTART="${PI_HOME}/.config/openbox/autostart"
 run_test "openbox autostart exists"    "test -f ${AUTOSTART}"

--- a/tests/fleet_device/test_deployment3_greengrass_script.py
+++ b/tests/fleet_device/test_deployment3_greengrass_script.py
@@ -125,3 +125,19 @@ def test_kiosk_window_mapped_fullscreen():
     """
     assert "<fullscreen>yes</fullscreen>" in SCRIPT
     assert "<maximized>yes</maximized>" in SCRIPT
+
+
+def test_kiosk_window_background_is_dark():
+    """
+    Chromium's window background — visible after the window is mapped but before
+    the page paints — comes from GTK, not Chromium, and is bright white by
+    default. That makes every seam around it obvious against the black either
+    side.
+
+    No Chromium flag reaches it: --default-background-color and
+    --cast-app-background-color both govern the page area and were verified in
+    the running process on sn09 with no effect on this surface.
+    """
+    assert "GTK_THEME=Adwaita:dark" in SCRIPT
+    assert ".config/gtk-3.0/gtk.css" in SCRIPT
+    assert "background-color: #000000" in SCRIPT

--- a/tests/fleet_device/test_deployment3_greengrass_script.py
+++ b/tests/fleet_device/test_deployment3_greengrass_script.py
@@ -114,3 +114,14 @@ def test_rc_xml_validated_before_reboot():
 def test_rc_xml_edit_is_idempotent():
     # Re-running deployment3 must not stack duplicate rules into rc.xml.
     assert "grep -q 'aquila-kiosk-no-decor'" in SCRIPT
+
+
+def test_kiosk_window_mapped_fullscreen():
+    """
+    Without this, Chromium's window is mapped small and then resized up, and the
+    growth is visible on screen — the "quadrant fill" on #428, which was mistaken
+    for a slow repaint until frame-by-frame capture on sn09 showed a part-sized
+    decorated window rather than a partially painted one.
+    """
+    assert "<fullscreen>yes</fullscreen>" in SCRIPT
+    assert "<maximized>yes</maximized>" in SCRIPT

--- a/tests/fleet_device/test_deployment3_greengrass_script.py
+++ b/tests/fleet_device/test_deployment3_greengrass_script.py
@@ -79,3 +79,38 @@ def test_retains_deployment2_device_build():
     # Everything else from deployment2 is kept (spot-check across phases).
     for marker in ("I2C", "Tailscale", "aquila-cert-renew", "security.sh", "Plymouth"):
         assert marker in SCRIPT, f"deployment3 dropped a shared step: {marker}"
+
+
+# --- Openbox window decorations, #428 ----------------------------------------
+# Openbox decorates every window by default and --kiosk does not survive a window
+# being re-mapped, so Chromium's window briefly wears a title bar reading
+# "Untitled — Chromium" at startup. Verified on sn03.
+
+def test_disables_window_decorations():
+    assert "aquila-kiosk-no-decor" in SCRIPT
+    assert "<decor>no</decor>" in SCRIPT
+
+
+def test_rc_xml_copied_from_distro_not_written_from_scratch():
+    # Openbox needs a complete rc.xml; hand-writing one would drop every other
+    # distro default (theme, keybinds, mouse behaviour).
+    assert "cp /etc/xdg/openbox/rc.xml" in SCRIPT
+
+
+def test_rc_xml_rule_inserted_inside_applications_block():
+    # A second top-level <applications> element is invalid and silently ignored,
+    # so the rule must go inside the existing one.
+    assert "s|</applications>|" in SCRIPT
+
+
+def test_rc_xml_validated_before_reboot():
+    # A malformed rc.xml leaves Openbox unable to start — blank screen on a
+    # device that may not be physically reachable. Validate and roll back.
+    assert "xml.etree.ElementTree" in SCRIPT
+    assert "restoring stock file" in SCRIPT
+    assert 'run_test "rc.xml is valid XML"' in SCRIPT
+
+
+def test_rc_xml_edit_is_idempotent():
+    # Re-running deployment3 must not stack duplicate rules into rc.xml.
+    assert "grep -q 'aquila-kiosk-no-decor'" in SCRIPT


### PR DESCRIPTION
Partial fix for #428 — removes the title bar. The white frame is still open there.

## The problem

At startup, before the Acorn splash paints, Chromium's window wears an Openbox title bar reading **"Untitled — Chromium"** across the top of the display.

`--kiosk` makes the window fullscreen and undecorated, but that state doesn't survive the window being re-mapped — it's re-applied *after* the window reappears, so there's a window of time where Openbox decorates it.

And nothing prevented that, because **we deployed no Openbox window rules at all** — no `rc.xml` anywhere in the repo, Phase 9b wrote only `autostart`, so Openbox ran stock defaults which decorate every window.

Worth noting the legacy WebKit kiosk guarded against this explicitly (`server_web/kiosk.py`, `set_decorated(False)`). The Chromium path relied on `--kiosk` alone and had no equivalent.

## The fix

A catch-all rule, since a kiosk never wants decoration on anything:

```xml
<!-- aquila-kiosk-no-decor: see #428 -->
<application class="*">
  <decor>no</decor>
</application>
```

**Verified on sn03** — title bar gone, kiosk otherwise unaffected.

## Three things about the implementation

**We now own a copy of `rc.xml`.** Openbox has no drop-in config directory; the only way to set a window rule is to own the whole file. That is precisely the "copied file drifts from upstream" pattern behind #424 and #426, both fixed this week. It's deliberate, and the copy carries a comment saying why it exists so the next person doesn't have to work it out.

**The result is XML-validated before it can reach a reboot.** A malformed `rc.xml` leaves Openbox unable to start — a blank screen on a device that may not be physically reachable. If validation fails the stock file is restored.

**The edit is idempotent.** Re-running deployment3 won't stack duplicate rules; a test enforces it.

## Tests

Five guard tests covering the rule, the copy-don't-hand-write choice, insertion inside the existing `<applications>` block (a second top-level one would be silently ignored), XML validation with rollback, and idempotency.

```
tests/fleet_device — 76 passed
bash -n scripts/deploy/deployment3_greengrass.sh — OK
```

The `sed` insertion was also run against a real `rc.xml` structure and the output confirmed to parse.

## Scope

Fixes the title bar only. Still open:

- **#428** — the white frame before the splash paints. Three theories ruled out and documented there (Chromium's blank page, the X root window, and hiding the window with `xdotool`). Plymouth is the proposed direction, since it's the one approach that doesn't require correctly identifying what the white is.
- **#431** — splash → app handoff, cross-origin renderer swap. Measured A/B on sn11.

`deployment2.sh` needs the same rule; it's a fork on `main`, out of scope here.

Fourth in a series with #419, #425 and #427, all off `feat/greengrass-migration`, all touching different phases.