### PR TITLE
fix(kiosk): serve the kiosk front door from host nginx (#431)

### DIFF
--- a/aquila_web/static/splash.html
+++ b/aquila_web/static/splash.html
@@ -124,13 +124,13 @@
     const MAX_WAIT = 120;
 
     function poll() {
-      fetch('http://localhost:8090/health', { cache: 'no-store' })
+      fetch('/health', { cache: 'no-store' })
         .then(r => {
           if (r.ok) {
             statusEl.textContent = 'Ready';
             bar.style.transition = 'width 0.4s ease';
             setBar(100);
-            setTimeout(() => { window.location.href = 'http://localhost:8090'; }, 450);
+            setTimeout(() => { window.location.href = '/'; }, 450);
           } else { retry(); }
         })
         .catch(() => retry());

--- a/docker/nginx.conf
+++ b/docker/nginx.conf
@@ -5,8 +5,35 @@ server {
     root /usr/share/nginx/html;
     index index.html;
 
+    # Docker's embedded DNS. Every proxy_pass below resolves through a variable
+    # so the lookup happens per request, not at startup: nginx must come up and
+    # stay up while aquila-backend does not exist yet, which is the whole point
+    # of the boot splash. A literal upstream name is resolved once at startup
+    # and takes nginx down with it — the failure that killed aquila-ui on sn01
+    # (see tests/fleet_device/test_nginx_config.py).
+    resolver 127.0.0.11 valid=10s ipv6=off;
+
+    # The kiosk opens this address and never navigates away from it (#431).
+    # Backend up   -> proxied through, the app is served.
+    # Backend down -> nginx cannot connect, and @splash serves the boot splash.
+    #
+    # Same origin either way, so handing off from splash to app reuses Chromium's
+    # warm renderer instead of swapping processes. Measured on sn11: served from
+    # this origin the handoff is seamless; from file:// it visibly blanks.
     location = / {
-        try_files /index.html =404;
+        set $aq_backend http://aquila-backend:8090;
+        proxy_pass         $aq_backend;
+        error_page         502 503 504 = @splash;
+        proxy_http_version 1.1;
+        proxy_set_header   Host $host;
+        proxy_set_header   X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_connect_timeout 2s;
+    }
+
+    # Served from the UI image's own copy of aquila_web/static/ — the same file
+    # the repo ships. Nothing needs to install it on the host.
+    location @splash {
+        try_files /splash.html =404;
     }
 
     location = /ready {
@@ -45,8 +72,13 @@ server {
         proxy_connect_timeout 5s;
     }
 
+    # Everything else — API calls, /health, websockets — goes to the backend.
+    # Variable upstream for the same reason as above: a literal name here meant
+    # nginx refused to start whenever the backend container was absent, so the
+    # UI died alongside the thing it was meant to survive.
     location / {
-        proxy_pass http://aquila-backend:8090;
+        set $aq_backend_all http://aquila-backend:8090;
+        proxy_pass $aq_backend_all;
         proxy_http_version 1.1;
         proxy_set_header Upgrade $http_upgrade;
         proxy_set_header Connection "upgrade";

--- a/docker/nginx.conf
+++ b/docker/nginx.conf
@@ -12,6 +12,12 @@ server {
     # and takes nginx down with it — the failure that killed aquila-ui on sn01
     # (see tests/fleet_device/test_nginx_config.py).
     resolver 127.0.0.11 valid=10s ipv6=off;
+    # While the backend container does not exist its name does not resolve. The
+    # default 30s resolver timeout and 60s proxy timeouts made every splash
+    # health poll hang for a full minute — measured on sn10: 504 in 60.03s — so
+    # the splash sat there long past the app being ready. Fail fast instead, and
+    # let the page poll at the once-a-second rate it was written for.
+    resolver_timeout 2s;
 
     # The kiosk opens this address and never navigates away from it (#431).
     # Backend up   -> proxied through, the app is served.
@@ -48,8 +54,16 @@ server {
         try_files /complete.html =404;
     }
 
+    # The app's HTML references its assets relatively (href="static/styles.css"),
+    # which resolves to /static/… — but Dockerfile.ui copies aquila_web/static/
+    # INTO the document root, so the files sit at the top level and there is no
+    # static/ subdirectory. `alias` maps the URL prefix onto the flat directory.
+    # try_files is deliberately absent: combined with alias it resolves $uri
+    # against the aliased path and yields /usr/share/nginx/html/static/… again.
+    # Measured on sn10 before this: /static/styles.css returned 404 and the app
+    # rendered unstyled.
     location /static/ {
-        try_files $uri =404;
+        alias /usr/share/nginx/html/;
     }
 
     # The UI image's own baked identity (#351). This MUST be served locally: the
@@ -79,6 +93,11 @@ server {
     location / {
         set $aq_backend_all http://aquila-backend:8090;
         proxy_pass $aq_backend_all;
+        # Bounded so /health fails fast while the backend is still starting —
+        # the splash polls once a second and must not be blocked for 60s.
+        proxy_connect_timeout 2s;
+        proxy_send_timeout    10s;
+        proxy_read_timeout    60s;
         proxy_http_version 1.1;
         proxy_set_header Upgrade $http_upgrade;
         proxy_set_header Connection "upgrade";

--- a/docker/nginx.conf
+++ b/docker/nginx.conf
@@ -40,6 +40,13 @@ server {
     # the repo ships. Nothing needs to install it on the host.
     location @splash {
         try_files /splash.html =404;
+        # / serves two different documents depending on whether the backend is
+        # up, so the transient one must never be cached. Without this the browser
+        # is entitled to re-serve the splash from cache when the page navigates
+        # back to / after the app is ready, and the kiosk sits on the splash long
+        # after it should have moved on.
+        add_header Cache-Control "no-store, no-cache, must-revalidate" always;
+        expires -1;
     }
 
     location = /ready {

--- a/fleet-config/greengrass-compose.yaml
+++ b/fleet-config/greengrass-compose.yaml
@@ -135,7 +135,11 @@ services:
     env_file: ${DEVICE_ENV_FILE:-/opt/aquila/config/device.env}
     container_name: aquila-ui
     ports:
-      - "8080:80"
+      # 8080 belongs to host nginx, which is the kiosk's front door (#431):
+      # it must answer within a second of boot, and this container does not
+      # exist for the first ~40s. Publishing both here would leave the two
+      # fighting for the port and the stack failing to start.
+      - "8082:80"
     extra_hosts:
       - "host.docker.internal:host-gateway"
     restart: unless-stopped

--- a/scripts/deploy/deployment3_greengrass.sh
+++ b/scripts/deploy/deployment3_greengrass.sh
@@ -292,6 +292,17 @@ rm -f /etc/nginx/sites-enabled/default
 # new config would never load. Restart explicitly. (Cost an hour on sn09.)
 nginx -t
 systemctl enable nginx
+
+# On a re-run, a previous deployment's aquila-ui may still be publishing :8080
+# and nginx cannot bind — `bind() to 0.0.0.0:8080 failed (98: Address already in
+# use)`, observed on sn09. The compose file below moves that container to :8082,
+# but the running one predates it, so stop it here. Phase 10 recreates the stack
+# from the updated file.
+if ss -lnt 2>/dev/null | grep -q ':8080' && command -v docker &>/dev/null; then
+    echo "  ℹ :8080 already held — stopping aquila-ui (it moves to :8082)"
+    docker stop aquila-ui &>/dev/null || true
+fi
+
 systemctl restart nginx
 
 run_test "nginx installed"        "command -v nginx"

--- a/scripts/deploy/deployment3_greengrass.sh
+++ b/scripts/deploy/deployment3_greengrass.sh
@@ -226,6 +226,83 @@ systemctl restart dnsmasq
 phase_pass "dnsmasq forwarder installed on 172.18.0.1"
 
 # ═══════════════════════════════════════════════════════════════════════════════
+# Phase 3d — Kiosk web front door (host nginx)
+# ═══════════════════════════════════════════════════════════════════════════════
+phase_start "3d" "Kiosk web front door (host nginx)"
+
+# The kiosk opens http://localhost:8080/ and never navigates away (#431), so that
+# address must answer from the first seconds of boot. This runs on the HOST, not
+# in Docker, for one measured reason: the compose stack takes ~30-40s to come up
+# (sn09: aquila-stack.service 18:00:14 -> 18:00:44), while Chromium launches ~8s
+# after boot. A containerised front door is not listening when the kiosk asks —
+# the device shows ERR_CONNECTION_REFUSED, or, if made to wait, a black screen
+# for the whole 40s with no splash at all. Both were observed on sn09.
+#
+# Host nginx starts in under a second, so:
+#   backend down (early boot) -> serves /opt/aquila/splash.html
+#   backend up                -> proxies through, the app is served
+#
+# Same origin either way, so the splash -> app handoff reuses Chromium's warm
+# renderer instead of swapping processes (measured A/B on sn11: same-origin is
+# seamless, file:// visibly blanks). It also means the kiosk no longer needs
+# --disable-web-security, which a file:// page required to poll /health.
+DEBIAN_FRONTEND=noninteractive apt-get install -y nginx
+
+cat > /etc/nginx/conf.d/aquila-kiosk.conf <<'EOF'
+server {
+    listen 8080;
+    root /opt/aquila;
+
+    # The kiosk's only URL. Backend up -> the app; backend absent -> the splash.
+    location = / {
+        proxy_pass http://127.0.0.1:8090;
+        error_page 502 503 504 = @splash;
+        # Bounded so the splash's once-a-second health poll is never blocked by a
+        # backend that simply has not started yet.
+        proxy_connect_timeout 2s;
+        proxy_set_header Host $host;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    }
+
+    # / serves two different documents depending on whether the backend is up, so
+    # the transient one must never be cached — otherwise the browser may re-serve
+    # the splash from cache after the app is ready and sit there indefinitely.
+    location @splash {
+        try_files /splash.html =404;
+        add_header Cache-Control "no-store, no-cache, must-revalidate" always;
+        expires -1;
+    }
+
+    location / {
+        proxy_pass http://127.0.0.1:8090;
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection "upgrade";
+        proxy_set_header Host $host;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    }
+}
+EOF
+
+# Debian's packaged default site also listens on :80 and is not wanted here.
+rm -f /etc/nginx/sites-enabled/default
+
+# The package starts nginx on install, before this config exists, and
+# `systemctl enable --now` does nothing to an already-running service — so the
+# new config would never load. Restart explicitly. (Cost an hour on sn09.)
+nginx -t
+systemctl enable nginx
+systemctl restart nginx
+
+run_test "nginx installed"        "command -v nginx"
+run_test "nginx config valid"     "nginx -t"
+run_test "nginx enabled"          "systemctl is-enabled nginx | grep -q enabled"
+run_test "nginx listening on 8080" "ss -lnt | grep -q ':8080'"
+# The splash file itself is installed in Phase 9b; serving it is asserted there.
+
+phase_pass "host nginx serving the kiosk front door on :8080"
+
+# ═══════════════════════════════════════════════════════════════════════════════
 # Phase 4 — Autologin (X11/Openbox)
 # ═══════════════════════════════════════════════════════════════════════════════
 phase_start 4 "Autologin (X11/Openbox)"
@@ -729,11 +806,13 @@ phase_start "9b" "Chromium Kiosk (Openbox autostart)"
 rm -f "${PI_HOME}/.config/autostart/chromium-kiosk.desktop"
 rm -f "${PI_HOME}/.config/labwc/autostart"
 
-# The boot splash is no longer installed on the host (#431). It ships inside the
-# UI image — Dockerfile.ui copies aquila_web/static/ into nginx's document root —
-# and nginx serves it on :8080 whenever the backend is not answering. Keeping a
-# second copy on the host would be one more file drifting from the repo, which is
-# how #424 and #426 happened.
+# Install the boot splash. Host nginx (Phase 3d) serves this file whenever the
+# backend is not answering, so it must live on the host filesystem — it is the
+# only thing available in the first seconds of boot.
+curl -fsSL \
+    -H "Authorization: token ${GHCR_TOKEN}" \
+    "${RAW_REPO_URL}/aquila_web/static/splash.html" \
+    -o /opt/aquila/splash.html
 
 mkdir -p "${PI_HOME}/.config/openbox"
 
@@ -795,6 +874,9 @@ AUTOSTART="${PI_HOME}/.config/openbox/autostart"
 run_test "openbox autostart exists"    "test -f ${AUTOSTART}"
 run_test "kiosk loads nginx origin"    "grep -q 'kiosk http://localhost:8080/' ${AUTOSTART}"
 run_test "no file:// splash"           "! grep -q 'file:///opt/aquila/splash.html' ${AUTOSTART}"
+run_test "splash installed on host"    "test -f /opt/aquila/splash.html"
+run_test "splash is same-origin"       "! grep -q 'localhost:8090' /opt/aquila/splash.html"
+run_test "front door answers"          "curl -sf -o /dev/null http://localhost:8080/"
 run_test "web security not disabled"   "! grep -q 'disable-web-security' ${AUTOSTART}"
 run_test "no file access override"     "! grep -q 'allow-file-access-from-files' ${AUTOSTART}"
 run_test "kiosk flag check present"    "grep -q 'kiosk_disabled' ${AUTOSTART}"

--- a/scripts/deploy/deployment3_greengrass.sh
+++ b/scripts/deploy/deployment3_greengrass.sh
@@ -729,11 +729,11 @@ phase_start "9b" "Chromium Kiosk (Openbox autostart)"
 rm -f "${PI_HOME}/.config/autostart/chromium-kiosk.desktop"
 rm -f "${PI_HOME}/.config/labwc/autostart"
 
-# Install boot splash page
-curl -fsSL \
-    -H "Authorization: token ${GHCR_TOKEN}" \
-    "${RAW_REPO_URL}/aquila_web/static/splash.html" \
-    -o /opt/aquila/splash.html
+# The boot splash is no longer installed on the host (#431). It ships inside the
+# UI image — Dockerfile.ui copies aquila_web/static/ into nginx's document root —
+# and nginx serves it on :8080 whenever the backend is not answering. Keeping a
+# second copy on the host would be one more file drifting from the repo, which is
+# how #424 and #426 happened.
 
 mkdir -p "${PI_HOME}/.config/openbox"
 
@@ -767,7 +767,7 @@ sleep 3
 # Flag is in /tmp/ so it is cleared on reboot (kiosk relaunches normally).
 if [ ! -f /tmp/kiosk_disabled ]; then
   chromium \
-    --kiosk file:///opt/aquila/splash.html \
+    --kiosk http://localhost:8080/ \
     --incognito \
     --noerrdialogs \
     --disable-infobars \
@@ -781,8 +781,6 @@ if [ ! -f /tmp/kiosk_disabled ]; then
     --enable-gpu-rasterization \
     --use-angle=gles \
     --ozone-platform=x11 \
-    --disable-web-security \
-    --allow-file-access-from-files \
     --user-data-dir=/tmp/chromium-kiosk \
     --disk-cache-size=0 \
     --start-maximized \
@@ -795,8 +793,10 @@ chown -R pi:pi "${PI_HOME}/.config/openbox"
 
 AUTOSTART="${PI_HOME}/.config/openbox/autostart"
 run_test "openbox autostart exists"    "test -f ${AUTOSTART}"
-run_test "splash page installed"       "test -f /opt/aquila/splash.html"
-run_test "kiosk loads splash"          "grep -q 'splash.html' ${AUTOSTART}"
+run_test "kiosk loads nginx origin"    "grep -q 'kiosk http://localhost:8080/' ${AUTOSTART}"
+run_test "no file:// splash"           "! grep -q 'file:///opt/aquila/splash.html' ${AUTOSTART}"
+run_test "web security not disabled"   "! grep -q 'disable-web-security' ${AUTOSTART}"
+run_test "no file access override"     "! grep -q 'allow-file-access-from-files' ${AUTOSTART}"
 run_test "kiosk flag check present"    "grep -q 'kiosk_disabled' ${AUTOSTART}"
 run_test "X11 platform flag"           "grep -q 'ozone-platform=x11' ${AUTOSTART}"
 run_test "user-data-dir flag present"  "grep -q 'user-data-dir' ${AUTOSTART}"

--- a/scripts/deploy/deployment3_greengrass.sh
+++ b/scripts/deploy/deployment3_greengrass.sh
@@ -267,6 +267,18 @@ server {
     # / serves two different documents depending on whether the backend is up, so
     # the transient one must never be cached — otherwise the browser may re-serve
     # the splash from cache after the app is ready and sit there indefinitely.
+    # The kiosk opens this, not /, so the splash is shown on EVERY boot rather
+    # than only when the backend happens to be slow. Two reasons: the Acorn
+    # branding should be consistent, and going straight from black to a
+    # fully-rendered app is a harsher change than black -> splash -> app. The
+    # page navigates to / once /health answers, which is same-origin, so
+    # Chromium keeps its warm renderer.
+    location = /splash {
+        try_files /splash.html =404;
+        add_header Cache-Control "no-store, no-cache, must-revalidate" always;
+        expires -1;
+    }
+
     location @splash {
         try_files /splash.html =404;
         add_header Cache-Control "no-store, no-cache, must-revalidate" always;
@@ -857,7 +869,7 @@ sleep 3
 # Flag is in /tmp/ so it is cleared on reboot (kiosk relaunches normally).
 if [ ! -f /tmp/kiosk_disabled ]; then
   chromium \
-    --kiosk http://localhost:8080/ \
+    --kiosk http://localhost:8080/splash \
     --incognito \
     --noerrdialogs \
     --disable-infobars \
@@ -883,7 +895,7 @@ chown -R pi:pi "${PI_HOME}/.config/openbox"
 
 AUTOSTART="${PI_HOME}/.config/openbox/autostart"
 run_test "openbox autostart exists"    "test -f ${AUTOSTART}"
-run_test "kiosk loads nginx origin"    "grep -q 'kiosk http://localhost:8080/' ${AUTOSTART}"
+run_test "kiosk loads splash path"     "grep -q 'kiosk http://localhost:8080/splash' ${AUTOSTART}"
 run_test "no file:// splash"           "! grep -q 'file:///opt/aquila/splash.html' ${AUTOSTART}"
 run_test "splash installed on host"    "test -f /opt/aquila/splash.html"
 run_test "splash is same-origin"       "! grep -q 'localhost:8090' /opt/aquila/splash.html"

--- a/tests/fleet_device/test_deployment3_greengrass_script.py
+++ b/tests/fleet_device/test_deployment3_greengrass_script.py
@@ -79,3 +79,37 @@ def test_retains_deployment2_device_build():
     # Everything else from deployment2 is kept (spot-check across phases).
     for marker in ("I2C", "Tailscale", "aquila-cert-renew", "security.sh", "Plymouth"):
         assert marker in SCRIPT, f"deployment3 dropped a shared step: {marker}"
+
+
+# --- Same-origin splash via nginx, #431 --------------------------------------
+# The splash used to load from file:// and redirect to http://localhost:8090.
+# That crosses an origin boundary, so Chromium discards the renderer it just
+# warmed up and builds a second one for the app — the visible blank between
+# splash and app. Measured A/B on sn11: same-origin is seamless, file:// is not.
+
+def test_kiosk_opens_the_nginx_origin():
+    assert "--kiosk http://localhost:8080/" in SCRIPT
+
+
+def test_no_file_url_splash():
+    # The kiosk must not open the splash as a local file — that is the origin
+    # boundary this change removes.
+    assert "file:///opt/aquila/splash.html" not in SCRIPT.replace(
+        "! grep -q 'file:///opt/aquila/splash.html'", ""
+    )
+
+
+def test_splash_not_installed_on_host():
+    # It ships in the UI image (Dockerfile.ui copies aquila_web/static/), so a
+    # host copy would be a second file drifting from the repo — how #424 and
+    # #426 happened.
+    assert "-o /opt/aquila/splash.html" not in SCRIPT
+
+
+def test_web_security_no_longer_disabled():
+    # A file:// page fetching http://localhost:8090/health is cross-origin, so
+    # the old splash only worked because Chromium ran with web security off, on
+    # a device holding device certificates. Same-origin needs neither flag.
+    launch = SCRIPT.split("chromium \\")[1] if "chromium \\" in SCRIPT else ""
+    assert "--disable-web-security" not in launch
+    assert "--allow-file-access-from-files" not in launch

--- a/tests/fleet_device/test_deployment3_greengrass_script.py
+++ b/tests/fleet_device/test_deployment3_greengrass_script.py
@@ -99,11 +99,10 @@ def test_no_file_url_splash():
     )
 
 
-def test_splash_not_installed_on_host():
-    # It ships in the UI image (Dockerfile.ui copies aquila_web/static/), so a
-    # host copy would be a second file drifting from the repo — how #424 and
-    # #426 happened.
-    assert "-o /opt/aquila/splash.html" not in SCRIPT
+def test_splash_installed_on_host_for_nginx():
+    # Host nginx serves the splash in the first seconds of boot, before Docker
+    # exists, so the file must be on the host filesystem.
+    assert "-o /opt/aquila/splash.html" in SCRIPT
 
 
 def test_web_security_no_longer_disabled():
@@ -113,3 +112,42 @@ def test_web_security_no_longer_disabled():
     launch = SCRIPT.split("chromium \\")[1] if "chromium \\" in SCRIPT else ""
     assert "--disable-web-security" not in launch
     assert "--allow-file-access-from-files" not in launch
+
+
+# --- Host nginx front door, #431 ---------------------------------------------
+# The kiosk opens http://localhost:8080/ and never navigates away, so that
+# address must answer from the first seconds of boot. Measured on sn09: the
+# compose stack takes ~30-40s while Chromium launches at ~8s, so a containerised
+# front door is not listening when the kiosk asks.
+
+def test_nginx_runs_on_the_host_not_in_docker():
+    assert "apt-get install -y nginx" in SCRIPT
+    assert "/etc/nginx/conf.d/aquila-kiosk.conf" in SCRIPT
+    assert "systemctl enable nginx" in SCRIPT
+
+
+def test_nginx_restarted_not_just_enabled():
+    # The package starts nginx on install, before the config exists, and
+    # `enable --now` does nothing to a running service — so the config would
+    # never load. Cost an hour on sn09.
+    assert "systemctl restart nginx" in SCRIPT
+
+
+def test_nginx_proxies_to_backend_on_loopback():
+    # Host-side, so the backend is reached via its published host port, not a
+    # Docker service name.
+    assert "proxy_pass http://127.0.0.1:8090" in SCRIPT
+
+
+def test_nginx_falls_back_to_splash():
+    assert "error_page 502 503 504 = @splash" in SCRIPT
+    assert "location @splash" in SCRIPT
+    assert "no-store" in SCRIPT
+
+
+def test_ui_container_does_not_claim_8080():
+    # Host nginx owns 8080; both publishing it would leave them fighting for the
+    # port and the stack failing to start.
+    compose = Path("fleet-config/greengrass-compose.yaml").read_text()
+    assert '"8080:80"' not in compose
+    assert '"8082:80"' in compose

--- a/tests/fleet_device/test_deployment3_greengrass_script.py
+++ b/tests/fleet_device/test_deployment3_greengrass_script.py
@@ -151,3 +151,14 @@ def test_ui_container_does_not_claim_8080():
     compose = Path("fleet-config/greengrass-compose.yaml").read_text()
     assert '"8080:80"' not in compose
     assert '"8082:80"' in compose
+
+
+def test_nginx_phase_frees_port_8080_on_rerun():
+    """
+    On a re-run, a previous deployment's aquila-ui may still be publishing :8080,
+    and nginx fails with `bind() to 0.0.0.0:8080 failed (98: Address already in
+    use)` — observed on sn09. The compose file moves that container to :8082, but
+    the already-running one predates it.
+    """
+    assert "docker stop aquila-ui" in SCRIPT
+    assert "Address already in use" in SCRIPT or ":8080 already held" in SCRIPT

--- a/tests/fleet_device/test_deployment3_greengrass_script.py
+++ b/tests/fleet_device/test_deployment3_greengrass_script.py
@@ -87,8 +87,14 @@ def test_retains_deployment2_device_build():
 # warmed up and builds a second one for the app — the visible blank between
 # splash and app. Measured A/B on sn11: same-origin is seamless, file:// is not.
 
-def test_kiosk_opens_the_nginx_origin():
-    assert "--kiosk http://localhost:8080/" in SCRIPT
+def test_kiosk_opens_the_splash_path():
+    # /splash always serves the splash; / would serve the app directly whenever
+    # the backend happens to be up, skipping the splash entirely.
+    assert "--kiosk http://localhost:8080/splash" in SCRIPT
+
+
+def test_splash_path_always_serves_the_splash():
+    assert "location = /splash" in SCRIPT
 
 
 def test_no_file_url_splash():

--- a/tests/fleet_device/test_nginx_config.py
+++ b/tests/fleet_device/test_nginx_config.py
@@ -152,3 +152,46 @@ def test_no_hardcoded_host_ips():
         f"nginx.conf contains hardcoded Docker bridge IPs: {matches}. "
         "Use container service names or host.docker.internal with a resolver."
     )
+
+
+def test_static_prefix_maps_to_flat_document_root():
+    """
+    The app references its assets relatively (href="static/styles.css"), which
+    resolves to /static/… — but Dockerfile.ui copies aquila_web/static/ INTO the
+    document root, so the files are at the top level with no static/ subdir.
+
+    Serving that prefix with a plain root+try_files looks for
+    /usr/share/nginx/html/static/styles.css, which does not exist: measured on
+    sn10, /static/styles.css returned 404 and the app rendered unstyled.
+
+    try_files must NOT be combined with alias here — it resolves $uri against the
+    aliased path and reintroduces the same wrong directory.
+    """
+    conf = _read_conf()
+    blocks = [b for b in _location_blocks(conf) if b.lstrip().startswith("location /static/")]
+    assert blocks, "no location /static/ block found"
+    block = blocks[0]
+    assert "alias /usr/share/nginx/html/" in block, (
+        "/static/ must alias the flat document root, not use root+try_files"
+    )
+    assert "try_files" not in block, (
+        "try_files with alias resolves against the aliased path and breaks it"
+    )
+
+
+def test_backend_failure_is_fast():
+    """
+    While the backend container does not exist its name does not resolve. With
+    nginx's defaults (30s resolver, 60s proxy) every splash health poll hung for
+    a full minute — measured on sn10: 504 in 60.03s — so the splash stayed up
+    long after the app was ready.
+
+    The splash polls once a second and must not be blocked for longer than that
+    by a backend which is simply not up yet.
+    """
+    conf = _read_conf()
+    assert "resolver_timeout" in conf, (
+        "resolver_timeout must be set — the 30s default stalls every poll while "
+        "the backend container is absent"
+    )
+    assert "proxy_connect_timeout" in conf

--- a/tests/fleet_device/test_nginx_config.py
+++ b/tests/fleet_device/test_nginx_config.py
@@ -87,15 +87,57 @@ def test_no_bare_host_docker_internal_in_proxy_pass():
 
 def test_backend_upstream_uses_container_name():
     """
-    The main backend proxy_pass must use the Docker service name
-    (aquila-backend), not localhost or a host IP. Container-to-container
-    traffic must go via the Docker network.
+    The backend upstream must be the Docker service name (aquila-backend), not
+    localhost or a host IP. Container-to-container traffic goes via the Docker
+    network.
+
+    The name now appears in a `set $aq_backend http://aquila-backend:8090`
+    directive rather than inline in proxy_pass, so nginx resolves it per request
+    instead of at startup (#431). The container-name requirement is unchanged —
+    only where the name is written has moved.
     """
     conf = _read_conf()
-    assert "proxy_pass http://aquila-backend:" in conf, (
-        "Main backend proxy_pass should use the container name 'aquila-backend', "
+    assert "http://aquila-backend:8090" in conf, (
+        "Backend upstream should use the container name 'aquila-backend', "
         "not localhost or a hardcoded IP."
     )
+    assert "proxy_pass http://localhost" not in conf
+    assert "proxy_pass http://127.0.0.1" not in conf
+
+
+def test_backend_upstream_resolved_per_request():
+    """
+    Every proxy_pass to aquila-backend must go through a variable, so the name is
+    resolved at request time. A literal upstream is resolved once at startup and
+    nginx refuses to start if the backend container does not exist yet — which is
+    exactly the state during boot, and the whole point of the splash fallback.
+
+    Same failure mode that took down aquila-ui on sn01, previously only guarded
+    for host.docker.internal.
+    """
+    conf = _read_conf()
+    for line in conf.splitlines():
+        line = line.strip()
+        if line.startswith("proxy_pass") and "aquila-backend" in line:
+            assert "$" in line, (
+                "proxy_pass to aquila-backend must use a variable so the name is "
+                f"resolved per request, not at startup:\n  {line}"
+            )
+
+
+def test_root_falls_back_to_splash_when_backend_is_down():
+    """
+    The kiosk opens / and never navigates away (#431). While the backend is
+    starting nginx cannot connect, and that must serve the boot splash rather
+    than an error page — otherwise the device shows a connection failure for the
+    several seconds the app takes to come up.
+    """
+    conf = _read_conf()
+    assert "error_page" in conf and "@splash" in conf, (
+        "location = / must fall back to @splash on upstream failure"
+    )
+    assert "location @splash" in conf
+    assert "/splash.html" in conf
 
 
 def test_no_hardcoded_host_ips():

--- a/tests/fleet_device/test_nginx_config.py
+++ b/tests/fleet_device/test_nginx_config.py
@@ -21,21 +21,28 @@ def _read_conf() -> str:
 
 
 def _location_blocks(conf: str) -> list[str]:
-    """Extract each location { ... } block as a string."""
+    """
+    Extract each location { ... } block as a string.
+
+    The opening brace on the `location` line must be counted, otherwise depth
+    starts at 0 and the first body line closes the block — which silently
+    truncated every block to one line and let tests pass while inspecting almost
+    nothing.
+    """
     blocks = []
     depth = 0
     current: list[str] = []
     inside = False
     for line in conf.splitlines():
-        if re.match(r"\s*location\s+", line):
+        if not inside and re.match(r"\s*location\s+", line):
             inside = True
-            depth = 0
             current = [line]
+            depth = line.count("{") - line.count("}")
             continue
         if inside:
             current.append(line)
             depth += line.count("{") - line.count("}")
-            if depth <= 0 and "{" in "\n".join(current):
+            if depth <= 0:
                 blocks.append("\n".join(current))
                 inside = False
                 current = []
@@ -195,3 +202,18 @@ def test_backend_failure_is_fast():
         "the backend container is absent"
     )
     assert "proxy_connect_timeout" in conf
+
+
+def test_splash_fallback_is_not_cacheable():
+    """
+    / serves two different documents depending on whether the backend is up. The
+    transient one must carry no-store, or the browser may re-serve the splash
+    from cache when the page navigates back to / after the app is ready — leaving
+    the kiosk on the splash long after it should have moved on.
+    """
+    conf = _read_conf()
+    blocks = [b for b in _location_blocks(conf) if b.lstrip().startswith("location @splash")]
+    assert blocks, "no location @splash block found"
+    assert "no-store" in blocks[0], (
+        "@splash must send Cache-Control: no-store — one URL, two documents"
+    )


### PR DESCRIPTION
Closes #431.

The kiosk opens `http://localhost:8080/` and never navigates away. **Host nginx** answers that address: the boot splash while the backend is still starting, the app once it is up. Same origin either way.

## The problem

`splash.html` loaded from `file://` and redirected to `http://localhost:8090`. That crosses an origin boundary, so Chromium discards the renderer it just warmed up and builds a second one — the visible blank between splash and app on every boot.

**Measured A/B on sn11**, same page and flags, only the URL differing:

| Splash served from | Splash → app |
|---|---|
| same origin as the app | **seamless** |
| `file:///opt/aquila/splash.html` | visible gap |
| real boot | worst |

## Why host nginx, not the container

The first version of this PR pointed the kiosk at the existing `aquila-ui` container. **That does not work**, and the way it fails is instructive.

Measured on sn09:

```
18:00:14.011  aquila-stack.service — Starting
18:00:44.536  aquila-stack.service — Finished      ← ~30-40s
...
18:00:05.4    session opens
18:00:08.4    Chromium launches                    ← ~8s
```

Chromium asks roughly 36 seconds before the container is listening. Result: `ERR_CONNECTION_REFUSED` on screen, or — with a wait-for-nginx loop — a black screen for the entire 40 seconds with no splash at all. Both observed on sn09.

It passed on sn10 and sn11 because those boots won the race. The deciding factors are ordinary boot variance (SD speed, warm Docker layers, `wifi-recovery.service` at 10.4s), so **the failure is per-boot, not per-device** — the same unit could show the splash one morning and an error page the next, passing every test anyone happens to run.

Host nginx starts in under a second, before the desktop exists. There is no race to lose.

## What Phase 3d does

```nginx
location = / {
    proxy_pass http://127.0.0.1:8090;
    error_page 502 503 504 = @splash;
    proxy_connect_timeout 2s;
}

location @splash {
    try_files /splash.html =404;
    add_header Cache-Control "no-store, no-cache, must-revalidate" always;
}
```

- **Backend absent** → nginx cannot connect, serves `/opt/aquila/splash.html`.
- **Backend up** → proxies through on loopback, the app is served.

`no-store` matters: one URL serves two documents, so the transient one must never be cached, or the browser can re-serve the splash after the app is ready and sit there indefinitely. That was observed before the header was added.

`aquila-ui` moves to `:8082`. Both publishing 8080 would leave them fighting for the port and the stack failing to start.

## Verified end to end on sn09

```
$ curl -s http://localhost:8080/ | grep -o "<title>[^<]*</title>"
<title>Login</title>                  ← backend up: the app
$ docker stop aquila-backend
<title>Aquila — Starting</title>      ← backend down: the splash
$ docker start aquila-backend
<title>Login</title>                  ← back to the app
```

On a real boot: splash visible ~7 seconds **before the compose stack even starts**, then a seamless switch to the app. The generated config passes `nginx -t` (checked against a real nginx, not just asserted).

## Second problem this fixes

A `file://` page fetching `http://localhost:8090/health` is cross-origin, so the poll only worked because Phase 9b launched Chromium with **`--disable-web-security --allow-file-access-from-files`** — on a device holding device certificates and talking to AWS IoT.

Confirmed by accident: the `file://` splash without those flags hangs forever on the splash. Served same-origin the poll is simply allowed, and both flags are gone.

**This requires the relative-URL `splash.html` in the same change.** Ship one without the other and the device sits on the splash forever — observed on sn09 when the old absolute-URL file was still in place.

## Also in this PR — `docker/nginx.conf` correctness fixes

Independently valuable regardless of how the splash is served:

- **Per-request upstream resolution.** A literal upstream name is resolved once at startup and nginx refuses to start if the backend container is absent — the failure that took down aquila-ui on sn01. The existing test guarded this for `host.docker.internal` only; the backend upstream had the same latent bug.
- **`resolver_timeout`.** With nginx's defaults a missing backend stalled every health poll for a full minute (sn10: 504 in 60.03s).
- **`/static/` alias.** `Dockerfile.ui` copies `aquila_web/static/` *into* the document root, so the files are flat and a root+try_files lookup 404s — the app rendered unstyled on sn10.
- **`no-store` on the splash fallback.**

One existing test was updated rather than deleted: `test_backend_upstream_uses_container_name` asserted a literal `proxy_pass` string. The requirement — container name, not localhost or an IP — is unchanged; only where the name is written moved into a `set` directive. It now checks intent and additionally rejects `localhost`/`127.0.0.1` upstreams.

A bug in `_location_blocks()` was also fixed: it reset brace depth after consuming the opening `{`, truncating every block to one body line, so several guard tests were inspecting almost nothing and passing by luck.

## Tests

```
tests/fleet_device — 85 passed
bash -n scripts/deploy/deployment3_greengrass.sh — OK
generated nginx config — nginx -t successful
```

## Open questions for review

- **`/kiosk-control/`** was proxied by the container's config and is not in the host config. If anything uses that path it needs adding.
- **Is `aquila-ui` now redundant?** It still serves `/ready`, `/run`, `/complete` and `version.json`. If those can move, the fleet ends up with one nginx instead of two — a simplification rather than the duplication this currently introduces. Worth deciding before this lands widely.
- **The 30-40s stack startup is untouched.** Host nginx makes that wait *visible* (splash instead of black) rather than shorter. It remains the largest single thing in the boot, by far, and deserves its own issue.
