### PR TITLE
fix(display): rotate at X startup; fix the logo jump via Chromium's initial window size (#437)

### DIFF
--- a/aquila_web/static/splash.html
+++ b/aquila_web/static/splash.html
@@ -13,7 +13,13 @@
       display: flex;
       flex-direction: column;
       align-items: center;
-      justify-content: center;
+      /* Anchored from the top rather than centred: centring positions this
+         block by its TOTAL height, so anything that resizes after first paint
+         (a font resolving, an element getting its real dimensions) moves the
+         logo. Measured on sn09 as a ~70px shift shortly after load. Anchoring
+         makes the logo's position depend only on the viewport. */
+      justify-content: flex-start;
+      padding-top: 25%;
       font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
       overflow: hidden;
     }

--- a/scripts/deploy/deployment3_greengrass.sh
+++ b/scripts/deploy/deployment3_greengrass.sh
@@ -297,11 +297,43 @@ phase_pass "LightDM configured for X11/Openbox autologin (Wayland compositor dis
 # ═══════════════════════════════════════════════════════════════════════════════
 phase_start 6 "Display and Touch configuration"
 
+# Rotate the panel at X startup rather than from the Openbox autostart.
+#
+# The panel is portrait but the display comes up landscape, and rotation used to
+# be applied by `xrandr --rotate right` from the session — after X, LightDM and
+# Chromium had already painted. Chromium therefore laid the splash out against a
+# landscape viewport, then re-laid it out when the geometry changed: measured on
+# sn10, the Acorn logo appeared high on the screen and visibly dropped into place.
+# The screen also filled in blocks rather than as one frame while the rotated
+# framebuffer was repainted.
+#
+# Setting it here means X is portrait from its first frame, so nothing re-layouts.
+# Verified on sn10: the logo jump is gone and the block fill is much reduced.
+#
+# Both connector names are written because the panel is not always on the same
+# one — sn10 reports HDMI-2 (kernel HDMI-A-2), and the autostart has always had to
+# auto-detect it. Xorg ignores a Monitor section whose Identifier matches no
+# output, so the unused one is harmless.
+mkdir -p /etc/X11/xorg.conf.d
+cat > /etc/X11/xorg.conf.d/99-rotate.conf <<'EOF'
+Section "Monitor"
+    Identifier "HDMI-1"
+    Option "Rotate" "right"
+EndSection
+
+Section "Monitor"
+    Identifier "HDMI-2"
+    Option "Rotate" "right"
+EndSection
+EOF
+
 # xrandr and xinput are called at runtime from Openbox autostart (Phase 9b).
 # This phase verifies the required tools are present on the host.
 run_test "xrandr binary present"  "which xrandr"
 run_test "xinput binary present"  "which xinput"
 run_test "unclutter present"      "which unclutter"
+run_test "X rotation config"      "test -f /etc/X11/xorg.conf.d/99-rotate.conf"
+run_test "rotation set to right"  "grep -q 'Option \"Rotate\" \"right\"' /etc/X11/xorg.conf.d/99-rotate.conf"
 
 # Disable the Raspberry Pi welcome wizard so it never appears on first boot
 rm -f /etc/xdg/autostart/piwiz.desktop
@@ -746,7 +778,10 @@ xset -dpms
 # Auto-detect connected HDMI output (handles HDMI-2, HDMI-A-2, etc.)
 HDMI_OUT=$(xrandr --query | grep -E "^HDMI.* connected" | head -1 | awk '{print $1}')
 if [ -n "$HDMI_OUT" ]; then
-    xrandr --output "$HDMI_OUT" --mode 1024x768 --rate 60 --rotate right
+    # No --rotate here: X is already portrait from /etc/X11/xorg.conf.d/99-rotate.conf
+    # (Phase 6). Rotating again in the session would undo it, and rotating late is
+    # what made the splash re-layout on screen in the first place.
+    xrandr --output "$HDMI_OUT" --mode 1024x768 --rate 60
 fi
 
 xinput set-prop "Focaltech Systems FT5926 MultiTouch" \

--- a/scripts/deploy/deployment3_greengrass.sh
+++ b/scripts/deploy/deployment3_greengrass.sh
@@ -952,6 +952,13 @@ sleep 3
 # If kiosk_disabled flag exists, show desktop instead of kiosk.
 # Flag is in /tmp/ so it is cleared on reboot (kiosk relaunches normally).
 if [ ! -f /tmp/kiosk_disabled ]; then
+  # --window-size: open at panel size. Without it Chromium maps its window at
+  # its own default 748x561 and holds it ~1s before the WM fullscreens it —
+  # measured on sn09, on every one of five boots. The splash centres itself in
+  # the viewport, so a page painting during that second is laid out for a 561px
+  # window and its content shifts when the window grows to 1024. With the flag
+  # the intermediate size was 767x1023 across eight further boots.
+  #
   # GTK_THEME: Chromium's window background — the surface visible after the window
   # is mapped but before the page paints — comes from GTK, not from Chromium. It is
   # bright white by default, which makes every seam and flicker around it obvious
@@ -961,6 +968,8 @@ if [ ! -f /tmp/kiosk_disabled ]; then
   # theme does reach it. See ~/.config/gtk-3.0/gtk.css above for the black override.
   env GTK_THEME=Adwaita:dark chromium \
     --kiosk http://localhost:8080/splash \
+    --window-size=768,1024 \
+    --window-position=0,0 \
     --incognito \
     --noerrdialogs \
     --disable-infobars \

--- a/tests/fleet_device/test_deployment3_greengrass_script.py
+++ b/tests/fleet_device/test_deployment3_greengrass_script.py
@@ -79,3 +79,34 @@ def test_retains_deployment2_device_build():
     # Everything else from deployment2 is kept (spot-check across phases).
     for marker in ("I2C", "Tailscale", "aquila-cert-renew", "security.sh", "Plymouth"):
         assert marker in SCRIPT, f"deployment3 dropped a shared step: {marker}"
+
+
+# --- Display rotation at X startup -------------------------------------------
+# The panel is portrait, the display comes up landscape. Rotation used to be
+# applied by `xrandr --rotate right` from the Openbox autostart — after X,
+# LightDM and Chromium had painted — so Chromium laid the splash out against a
+# landscape viewport and re-laid it out when the geometry changed. Measured on
+# sn10: the Acorn logo appeared high and visibly dropped into place.
+
+def test_rotation_configured_at_x_startup():
+    assert "/etc/X11/xorg.conf.d/99-rotate.conf" in SCRIPT
+    assert 'Option "Rotate" "right"' in SCRIPT
+
+
+def test_rotation_covers_both_connectors():
+    # The panel is not always on the same connector — sn10 reports HDMI-2, and
+    # the autostart has always had to auto-detect it. Xorg ignores a Monitor
+    # section matching no output, so writing both is safe.
+    assert 'Identifier "HDMI-1"' in SCRIPT
+    assert 'Identifier "HDMI-2"' in SCRIPT
+
+
+def test_session_does_not_rotate_again():
+    # Rotating in the session would undo the X-level rotation, and rotating late
+    # is the original bug.
+    assert "--rotate right" not in SCRIPT.split("Section \"Monitor\"")[-1]
+    for line in SCRIPT.splitlines():
+        if line.strip().startswith("xrandr --output"):
+            assert "--rotate" not in line, (
+                f"session still rotates the display: {line.strip()}"
+            )

--- a/tests/fleet_device/test_deployment3_greengrass_script.py
+++ b/tests/fleet_device/test_deployment3_greengrass_script.py
@@ -352,3 +352,16 @@ def test_nginx_phase_frees_port_8080_on_rerun():
     """
     assert "docker stop aquila-ui" in SCRIPT
     assert "Address already in use" in SCRIPT or ":8080 already held" in SCRIPT
+
+
+def test_kiosk_window_opens_at_panel_size():
+    """
+    Without this Chromium maps its window at its own default 748x561 and holds
+    it ~1s before the WM fullscreens it — measured on sn09 on every one of five
+    boots. The splash centres itself in the viewport, so a page painting during
+    that second is laid out for a 561px-tall window and its content shifts when
+    the window grows to 1024. That is the logo jump (#437), intermittent only
+    because the page does not always paint before the resize.
+    """
+    assert "--window-size=768,1024" in SCRIPT
+    assert "--window-position=0,0" in SCRIPT


### PR DESCRIPTION
Closes #437. Two separate things, both about the boot display — and the second one corrects what this PR originally claimed.

## 1. Rotate the panel at X startup, not from the session

The panel is portrait, the display comes up landscape, and rotation was applied by `xrandr --rotate right` from the **Openbox autostart** — from inside the session, after X, LightDM and Chromium had started painting.

Rotating in `/etc/X11/xorg.conf.d/99-rotate.conf` means X is portrait from its first frame. Confirmed applied on sn09:

```
$ grep -i rotate /var/log/Xorg.0.log
[    20.294] (**) modeset(0): Option "Rotate" "right"
```

Both connector names are written — the panel is not always on the same one (sn09 and sn10 report HDMI-2), which is why the autostart has always had to auto-detect it. Xorg ignores a Monitor section matching no output.

Touch was verified after the change; the autostart's `Coordinate Transformation Matrix` still maps correctly.

## 2. The logo jump — and a correction

**This PR originally claimed late rotation caused the logo jump. It does not.** Rotation was confirmed applied at the X level and the jump still occurred.

Frame-by-frame geometry logging on sn09 found the real cause. Every boot showed:

```
10x10     ← Chromium's internal window
748x561   ← the kiosk window, mapped small, held ~1s
768x1024  ← finally fullscreen
```

| Boot | at 748×561 | → 768×1024 | duration |
|---|---|---|---|
| 14:48 | 14:49:09.7 | 14:49:10.8 | 1.09s |
| 15:38 | 15:41:02.5 | 15:41:03.6 | 1.07s |
| 15:41 | 15:42:34.4 | 15:42:35.7 | 1.26s |
| 15:47 | 15:48:52.2 | 15:48:53.1 | 0.87s |
| 15:50 | 15:51:54.8 | 15:51:55.8 | 0.97s |

The splash centres itself in the viewport, so a page painting during that second is laid out for a 561px-tall window and its content drops when the window grows to 1024.

**This also explains the intermittency**, which nothing else did. The small window happens on *every* boot; the jump only appears when the page paints before the resize rather than after. That is why the symptom came and went on identical configurations and why single-boot observations were worthless.

`--window-size=768,1024 --window-position=0,0` reduced the intermediate stage to `767x1023` across **eight consecutive boots** — a one-pixel change instead of a 463-pixel one.

**A residual ~70px shift remained**, inside the page rather than the window. Centring positions the block by its total height, so anything resizing after first paint moves the logo. Anchoring from the top with `padding-top` makes the position depend only on the viewport, so no late reflow can move it. That fixes the class of problem without identifying which element resized — several candidates were checked and none confirmed.

## Why the rotation change stays

Applying rotation before anything paints is correct regardless of the jump, and the previous ordering was a genuine hazard — the session rotating after Chromium had painted is the kind of thing that produces exactly this class of bug. It just was not the cause here.

## Not isolated

Whether the rotation change *also* contributes to the jump is unknown: both were applied throughout testing on sn09, and the isolation run was not completed. This PR claims only what the geometry data shows.

## Verification

- Rotation applied at X level, confirmed in `Xorg.0.log`, touch correct.
- `--window-size`: eight consecutive boots, no `748x561` stage.
- Splash anchoring: verified visually on sn09; position adjusted to 25% to match the previous centred placement.
- `bash -n` clean, `tests/fleet_device` — 110 passed.

One thing worth flagging for reviewers: an earlier revision of this commit placed the explanatory comment *inside* the backslash-continued `chromium` invocation. `bash -n` passes on that, but it silently truncates the command and turns the following flags into a separate command. The comment now sits above the launch. Worth watching for in review — a passing syntax check does not catch it.
