### PR TITLE
fix(greengrass): self-heal device.env perms so the component can't get bricked

### DIFF
--- a/scripts/deploy/deployment3_greengrass.sh
+++ b/scripts/deploy/deployment3_greengrass.sh
@@ -705,11 +705,26 @@ java -Droot="${GG_ROOT}" -Dlog.store=FILE \
     --provision false
 
 # The component runs as ggc_user, which must (a) reach the Docker socket to run
-# the compose stack and (b) read the root-owned device.env the compose injects.
-# Without these the component goes BROKEN ("permission denied ... docker.sock").
+# the compose stack and (b) read the root-owned device.env the compose injects as
+# its env_file. Without these the component goes BROKEN ("permission denied").
 usermod -aG docker ggc_user
 chgrp ggc_group /opt/aquila/config/device.env && chmod 640 /opt/aquila/config/device.env
 chmod o+rx /opt/aquila /opt/aquila/config
+
+# ...but a one-time chmod is fragile: re-enrolment (enroll_device.py) and cert
+# renewal rewrite files under /opt/aquila/config and can leave device.env at
+# root:root 0600, which silently re-breaks the component (ggc_user can no longer
+# read the compose env_file) -- and a plain reboot does NOT heal it. Install a
+# tmpfiles.d rule so systemd re-asserts the correct group+mode on every boot; a
+# rewrite then self-heals on the next restart instead of bricking the app.
+cat > /etc/tmpfiles.d/aquila-device-env.conf <<'EOF'
+# Keep the compose env_file readable by the Greengrass component user: ggc_user is
+# in ggc_group, so 0640 root:ggc_group lets the component read it while the file
+# stays owner-write-only. Re-applied on every boot so a re-enrolment/renewal that
+# resets it to 0600 can't leave the component BROKEN.
+z /opt/aquila/config/device.env 0640 root ggc_group -
+EOF
+systemd-tmpfiles --create /etc/tmpfiles.d/aquila-device-env.conf 2>/dev/null || true
 
 # Let the kiosk reach the screen before the nucleus starts its heavy first-boot
 # work (JRE, JITP registration, ~497 MB image pull). The installer registers
@@ -733,6 +748,8 @@ run_test "provisioned with device cert"   "grep -q 'device.crt' /opt/aquila/conf
 run_test "role alias configured"          "grep -q '${GG_ROLE_ALIAS}' /opt/aquila/config/greengrass-config.yaml"
 run_test "ggc_user in docker group"       "id -nG ggc_user | grep -qw docker"
 run_test "device.env readable by ggc_group" "test \"\$(stat -c '%G' /opt/aquila/config/device.env)\" = ggc_group"
+run_test "device.env perms 0640 (ggc_user can read)" "test \"\$(stat -c '%a' /opt/aquila/config/device.env)\" = 640"
+run_test "device.env perms self-heal on boot" "grep -q '/opt/aquila/config/device.env 0640 root ggc_group' /etc/tmpfiles.d/aquila-device-env.conf"
 
 phase_pass "Greengrass nucleus installed + provisioned; ggc_user granted Docker + config access (JITP -> ${GG_THING_GROUP})"
 


### PR DESCRIPTION
## Problem

`com.acorn.sentri` runs `docker compose` as **ggc_user**, which must read `/opt/aquila/config/device.env` (the compose `env_file`). Provisioning sets it `0640 root:ggc_group` so ggc_user (in ggc_group) can read it — but that's a **one-time chmod**.

Re-enrolment (`enroll_device.py`) and cert renewal rewrite files under `/opt/aquila/config` and can leave `device.env` at `root:root 0600`. When that happens:
- `docker compose` (as ggc_user) fails with `open /opt/aquila/config/device.env: permission denied`
- the component goes **BROKEN** → no containers → the app never comes up → **device stuck on the splash screen**
- **a reboot does not heal it** — nothing re-applies the perms.

Observed live on sn01 after a re-enrol: device.env came back `0600`, the component looped BROKEN, and rebooting didn't fix it.

## Fix

Install a `tmpfiles.d` rule so systemd **re-asserts `0640 root:ggc_group` on every boot**:

```
z /opt/aquila/config/device.env 0640 root ggc_group -
```

So a re-enrolment/renewal that resets device.env to `0600` **self-heals on the next restart** instead of bricking the device. The file stays owner-write-only; group-read is exactly what the (ggc_group) component user needs.

Keeps the existing inline `chgrp/chmod` for the immediate provision, and adds tests for the `0640` mode and the tmpfiles.d rule.

## Testing

- `bash -n` clean.
- New `run_test`s assert device.env is `0640` and the self-heal rule is installed.
- Verified the manual equivalent on sn01: `chmod 640` → ggc_user can read → Greengrass re-runs the component → all three containers healthy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)