### PR TITLE
feat(deployment2): add SKIP_TAILSCALE=1 to bypass Phase 12

### DIFF
--- a/scripts/deploy/deployment2.sh
+++ b/scripts/deploy/deployment2.sh
@@ -4,6 +4,7 @@
 # All values can be pre-set as env vars to skip prompts. Put them AFTER sudo so they
 # survive into the root shell (sudo strips the caller's environment by default):
 #   sudo DEVICE_HOSTNAME=sn04 IMAGE_TAG=prod GHCR_USER=... GHCR_TOKEN=... bash deployment2.sh
+# Set SKIP_TAILSCALE=1 to skip Phase 12 (Tailscale install, auth, and verification).
 set -euo pipefail
 
 # ── Preflight ─────────────────────────────────────────────────────────────────
@@ -984,28 +985,33 @@ phase_pass "kiosk-control installed and healthy"
 # ═══════════════════════════════════════════════════════════════════════════════
 phase_start 12 "Tailscale"
 
-if ! command -v tailscale >/dev/null 2>&1; then
-    curl -fsSL https://tailscale.com/install.sh | sh
-fi
-
-prompt_if_unset TAILSCALE_KEY \
-    "Enter Tailscale auth key (press Enter to authenticate interactively)"
-
-if [[ -n "${TAILSCALE_KEY:-}" ]]; then
-    tailscale up --ssh --authkey "${TAILSCALE_KEY}" --hostname "${DEVICE_HOSTNAME}"
+if [[ "${SKIP_TAILSCALE:-}" == "1" ]]; then
+    echo "  → SKIP_TAILSCALE=1 set — skipping Tailscale install, auth, and verification"
+    phase_pass "Tailscale skipped (SKIP_TAILSCALE=1)"
 else
-    tailscale up --ssh --hostname "${DEVICE_HOSTNAME}"
-    echo "  → Complete Tailscale authentication in your browser, then press Enter to continue."
-    read -r
+    if ! command -v tailscale >/dev/null 2>&1; then
+        curl -fsSL https://tailscale.com/install.sh | sh
+    fi
+
+    prompt_if_unset TAILSCALE_KEY \
+        "Enter Tailscale auth key (press Enter to authenticate interactively)"
+
+    if [[ -n "${TAILSCALE_KEY:-}" ]]; then
+        tailscale up --ssh --authkey "${TAILSCALE_KEY}" --hostname "${DEVICE_HOSTNAME}"
+    else
+        tailscale up --ssh --hostname "${DEVICE_HOSTNAME}"
+        echo "  → Complete Tailscale authentication in your browser, then press Enter to continue."
+        read -r
+    fi
+
+    run_test "tailscale installed"     "which tailscale"
+    run_test "tailscaled active"       "systemctl is-active tailscaled | grep -q active"
+    run_test "device authenticated"    "tailscale status | grep -q ${DEVICE_HOSTNAME}"
+    run_test "Tailscale IPs assigned"  \
+        "tailscale status --json | python3 -c \"import sys,json; d=json.load(sys.stdin); assert d.get('TailscaleIPs')\""
+
+    phase_pass "Tailscale active, device authenticated as ${DEVICE_HOSTNAME}"
 fi
-
-run_test "tailscale installed"     "which tailscale"
-run_test "tailscaled active"       "systemctl is-active tailscaled | grep -q active"
-run_test "device authenticated"    "tailscale status | grep -q ${DEVICE_HOSTNAME}"
-run_test "Tailscale IPs assigned"  \
-    "tailscale status --json | python3 -c \"import sys,json; d=json.load(sys.stdin); assert d.get('TailscaleIPs')\""
-
-phase_pass "Tailscale active, device authenticated as ${DEVICE_HOSTNAME}"
 
 # ═══════════════════════════════════════════════════════════════════════════════
 # Phase 13 — Grafana Alloy

--- a/tests/fleet_device/test_deployment2_script.py
+++ b/tests/fleet_device/test_deployment2_script.py
@@ -34,6 +34,19 @@ def test_security_script_downloaded() -> None:
     assert "security.sh" in SCRIPT
 
 
+# --- Tailscale skip flag (Phase 12) ------------------------------------------
+# SKIP_TAILSCALE=1 bypasses Phase 12 so a device can be provisioned without
+# joining the tailnet (or when interactive Tailscale auth is failing).
+
+def test_tailscale_skip_flag_guards_phase_12() -> None:
+    assert 'SKIP_TAILSCALE:-' in SCRIPT
+    assert "Tailscale skipped (SKIP_TAILSCALE=1)" in SCRIPT
+
+
+def test_tailscale_skip_documented_in_usage() -> None:
+    assert "SKIP_TAILSCALE=1" in SCRIPT
+
+
 # --- Fleet DNS forwarder (dnsmasq), #314 -------------------------------------
 # Container DNS freezes to the resolver captured at network-creation time; a
 # dnsmasq forwarder on the docker bridge gateway lets containers follow the


### PR DESCRIPTION
## What
Add a `SKIP_TAILSCALE=1` env flag to `deployment2.sh` that bypasses **Phase 12 (Tailscale)** — install, auth, and verification.

## Why
Phase 12's `device authenticated` check (`tailscale status | grep -q $DEVICE_HOSTNAME`) hard-fails the entire run under `set -euo pipefail` (via `run_test` → `phase_fail` → `exit 1`) whenever the device hasn't joined the tailnet — e.g. interactive browser auth wasn't completed. That blocks Phases 13+ with no way past Tailscale. The confusing `✗ Phase 12 FAILED — device authenticated` message is the *name of the failing check*, not a success.

## How
- Wrap the Phase 12 body in `if [[ "${SKIP_TAILSCALE:-}" == "1" ]]; then … else … fi`; the skip branch prints a note and `phase_pass`es.
- Matches the script's existing "pre-set env vars to skip prompts" idiom; documented in the usage header.

Usage:
```
sudo SKIP_TAILSCALE=1 DEVICE_HOSTNAME=snXX bash deployment2.sh
```

## Tests
`bash -n` clean; `tests/fleet_device/test_deployment2_script.py` green (13 passed), including two new tests for the guard and the usage doc.

## Note
`deployment3_greengrass.sh` has the same Phase 12 block — happy to add the flag there too in a follow-up if wanted.
