### PR TITLE
fix(greengrass): pin greengrassDataPlaneEndpoint so deployments can't wedge

### DIFF
--- a/scripts/deploy/deployment3_greengrass.sh
+++ b/scripts/deploy/deployment3_greengrass.sh
@@ -695,6 +695,12 @@ services:
       iotRoleAlias: "${GG_ROLE_ALIAS}"
       iotDataEndpoint: "${GG_IOT_DATA_ENDPOINT}"
       iotCredEndpoint: "${GG_IOT_CRED_ENDPOINT}"
+      # Pin the Greengrass data-plane to the account's IoT data endpoint. Left
+      # empty the nucleus SDK defaults to the shared greengrass-ats.iot.<region>
+      # endpoint, which completes mTLS then closes with no HTTP response for this
+      # device -- wedging every deployment at ListThingGroupsForCoreDevice
+      # (#442). Same host as iotDataEndpoint, data-plane port 8443.
+      greengrassDataPlaneEndpoint: "${GG_IOT_DATA_ENDPOINT}"
 EOF
 
 java -Droot="${GG_ROOT}" -Dlog.store=FILE \
@@ -746,6 +752,7 @@ run_test "greengrass ordered after kiosk" "systemctl show -p After greengrass.se
 run_test "greengrass service installed"   "test -f /etc/systemd/system/greengrass.service"
 run_test "provisioned with device cert"   "grep -q 'device.crt' /opt/aquila/config/greengrass-config.yaml"
 run_test "role alias configured"          "grep -q '${GG_ROLE_ALIAS}' /opt/aquila/config/greengrass-config.yaml"
+run_test "data-plane endpoint pinned"     "grep -q 'greengrassDataPlaneEndpoint: \"${GG_IOT_DATA_ENDPOINT}\"' /opt/aquila/config/greengrass-config.yaml"
 run_test "ggc_user in docker group"       "id -nG ggc_user | grep -qw docker"
 run_test "device.env readable by ggc_group" "test \"\$(stat -c '%G' /opt/aquila/config/device.env)\" = ggc_group"
 run_test "device.env perms 0640 (ggc_user can read)" "test \"\$(stat -c '%a' /opt/aquila/config/device.env)\" = 640"

--- a/tests/fleet_device/test_deployment3_greengrass_script.py
+++ b/tests/fleet_device/test_deployment3_greengrass_script.py
@@ -10,6 +10,7 @@ image delivery and updates.
 Run with:
     pytest tests/fleet_device/test_deployment3_greengrass_script.py -v
 """
+import re
 from pathlib import Path
 
 SCRIPT = Path("scripts/deploy/deployment3_greengrass.sh").read_text()
@@ -40,6 +41,22 @@ def test_configures_iot_endpoints():
     # endpoints — the Pi has no AWS creds to look them up itself.
     assert "iotDataEndpoint" in SCRIPT
     assert "iotCredEndpoint" in SCRIPT
+
+
+def test_pins_greengrass_dataplane_endpoint_to_account_endpoint():
+    # Manual provisioning must pin the Greengrass data-plane endpoint to the
+    # account's IoT data endpoint. Left unset, the nucleus SDK defaults to the
+    # shared greengrass-ats.iot.<region>.amazonaws.com endpoint, which completes
+    # mTLS then refuses this device (closes with no HTTP response) -- so every
+    # deployment wedges at ListThingGroupsForCoreDevice, IN_PROGRESS forever
+    # (#442; regressed by a re-provision that regenerated nucleus config).
+    data_ep = re.search(r'iotDataEndpoint:\s*"([^"]+)"', SCRIPT)
+    dp_ep = re.search(r'greengrassDataPlaneEndpoint:\s*"([^"]*)"', SCRIPT)
+    assert dp_ep is not None, "greengrassDataPlaneEndpoint is not set in the nucleus config"
+    assert dp_ep.group(1), "greengrassDataPlaneEndpoint must not be empty (empty => greengrass-ats default)"
+    assert data_ep is not None and dp_ep.group(1) == data_ep.group(1), (
+        "greengrassDataPlaneEndpoint must be pinned to the same account endpoint as iotDataEndpoint"
+    )
 
 
 def test_watchtower_ota_path_removed():


### PR DESCRIPTION
## What

Pin `greengrassDataPlaneEndpoint` in the deployment3 Greengrass nucleus config so a provisioned device can't fall back to the shared `greengrass-ats` data-plane endpoint.

## Why

The config heredoc wrote `iotDataEndpoint`/`iotCredEndpoint` but omitted `greengrassDataPlaneEndpoint`. Left unset, the nucleus SDK defaults to `greengrass-ats.iot.<region>.amazonaws.com:8443`, which **completes the mTLS handshake with the device cert and then closes the connection with zero HTTP bytes on every request path**. That fails step 1 of every deployment (`ListThingGroupsForCoreDevice`, in `DefaultDeploymentTask.getNonTargetGroupToRootPackagesMap`), so the IoT job hangs `IN_PROGRESS` forever and **all new deployments to that device silently stop**.

The account IoT data endpoint (same host as `iotDataEndpoint`) serves the identical call over the same cert and returns HTTP 200 — only the shared `greengrass-ats` endpoint refuses it. Verified against a live device.

## Change

- `scripts/deploy/deployment3_greengrass.sh`: `greengrassDataPlaneEndpoint: "${GG_IOT_DATA_ENDPOINT}"` in the nucleus config heredoc + a `run_test` smoke check that the generated config contains it.
- `tests/fleet_device/test_deployment3_greengrass_script.py`: test that the data-plane endpoint is pinned to the same account endpoint as `iotDataEndpoint` — fails on both an omitted **and** an empty value.

## Test

- `pytest tests/fleet_device/` → 72 passed
- `bash -n` clean; rendered the config heredoc and confirmed valid YAML with `greengrassDataPlaneEndpoint == iotDataEndpoint`.

Part of #442

🤖 Generated with [Claude Code](https://claude.com/claude-code)
