### PR TITLE
epic: clean startup — remove the visible artifacts before the app appears

### DIFF
--- a/aquila_web/static/splash.html
+++ b/aquila_web/static/splash.html
@@ -124,13 +124,13 @@
     const MAX_WAIT = 120;
 
     function poll() {
-      fetch('http://localhost:8090/health', { cache: 'no-store' })
+      fetch('/health', { cache: 'no-store' })
         .then(r => {
           if (r.ok) {
             statusEl.textContent = 'Ready';
             bar.style.transition = 'width 0.4s ease';
             setBar(100);
-            setTimeout(() => { window.location.href = 'http://localhost:8090'; }, 450);
+            setTimeout(() => { window.location.href = '/'; }, 450);
           } else { retry(); }
         })
         .catch(() => retry());

--- a/docker/nginx.conf
+++ b/docker/nginx.conf
@@ -5,8 +5,35 @@ server {
     root /usr/share/nginx/html;
     index index.html;
 
+    # Docker's embedded DNS. Every proxy_pass below resolves through a variable
+    # so the lookup happens per request, not at startup: nginx must come up and
+    # stay up while aquila-backend does not exist yet, which is the whole point
+    # of the boot splash. A literal upstream name is resolved once at startup
+    # and takes nginx down with it — the failure that killed aquila-ui on sn01
+    # (see tests/fleet_device/test_nginx_config.py).
+    resolver 127.0.0.11 valid=10s ipv6=off;
+
+    # The kiosk opens this address and never navigates away from it (#431).
+    # Backend up   -> proxied through, the app is served.
+    # Backend down -> nginx cannot connect, and @splash serves the boot splash.
+    #
+    # Same origin either way, so handing off from splash to app reuses Chromium's
+    # warm renderer instead of swapping processes. Measured on sn11: served from
+    # this origin the handoff is seamless; from file:// it visibly blanks.
     location = / {
-        try_files /index.html =404;
+        set $aq_backend http://aquila-backend:8090;
+        proxy_pass         $aq_backend;
+        error_page         502 503 504 = @splash;
+        proxy_http_version 1.1;
+        proxy_set_header   Host $host;
+        proxy_set_header   X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_connect_timeout 2s;
+    }
+
+    # Served from the UI image's own copy of aquila_web/static/ — the same file
+    # the repo ships. Nothing needs to install it on the host.
+    location @splash {
+        try_files /splash.html =404;
     }
 
     location = /ready {
@@ -45,8 +72,13 @@ server {
         proxy_connect_timeout 5s;
     }
 
+    # Everything else — API calls, /health, websockets — goes to the backend.
+    # Variable upstream for the same reason as above: a literal name here meant
+    # nginx refused to start whenever the backend container was absent, so the
+    # UI died alongside the thing it was meant to survive.
     location / {
-        proxy_pass http://aquila-backend:8090;
+        set $aq_backend_all http://aquila-backend:8090;
+        proxy_pass $aq_backend_all;
         proxy_http_version 1.1;
         proxy_set_header Upgrade $http_upgrade;
         proxy_set_header Connection "upgrade";

--- a/docker/nginx.conf
+++ b/docker/nginx.conf
@@ -12,6 +12,12 @@ server {
     # and takes nginx down with it — the failure that killed aquila-ui on sn01
     # (see tests/fleet_device/test_nginx_config.py).
     resolver 127.0.0.11 valid=10s ipv6=off;
+    # While the backend container does not exist its name does not resolve. The
+    # default 30s resolver timeout and 60s proxy timeouts made every splash
+    # health poll hang for a full minute — measured on sn10: 504 in 60.03s — so
+    # the splash sat there long past the app being ready. Fail fast instead, and
+    # let the page poll at the once-a-second rate it was written for.
+    resolver_timeout 2s;
 
     # The kiosk opens this address and never navigates away from it (#431).
     # Backend up   -> proxied through, the app is served.
@@ -48,8 +54,16 @@ server {
         try_files /complete.html =404;
     }
 
+    # The app's HTML references its assets relatively (href="static/styles.css"),
+    # which resolves to /static/… — but Dockerfile.ui copies aquila_web/static/
+    # INTO the document root, so the files sit at the top level and there is no
+    # static/ subdirectory. `alias` maps the URL prefix onto the flat directory.
+    # try_files is deliberately absent: combined with alias it resolves $uri
+    # against the aliased path and yields /usr/share/nginx/html/static/… again.
+    # Measured on sn10 before this: /static/styles.css returned 404 and the app
+    # rendered unstyled.
     location /static/ {
-        try_files $uri =404;
+        alias /usr/share/nginx/html/;
     }
 
     # The UI image's own baked identity (#351). This MUST be served locally: the
@@ -79,6 +93,11 @@ server {
     location / {
         set $aq_backend_all http://aquila-backend:8090;
         proxy_pass $aq_backend_all;
+        # Bounded so /health fails fast while the backend is still starting —
+        # the splash polls once a second and must not be blocked for 60s.
+        proxy_connect_timeout 2s;
+        proxy_send_timeout    10s;
+        proxy_read_timeout    60s;
         proxy_http_version 1.1;
         proxy_set_header Upgrade $http_upgrade;
         proxy_set_header Connection "upgrade";

--- a/docker/nginx.conf
+++ b/docker/nginx.conf
@@ -40,6 +40,13 @@ server {
     # the repo ships. Nothing needs to install it on the host.
     location @splash {
         try_files /splash.html =404;
+        # / serves two different documents depending on whether the backend is
+        # up, so the transient one must never be cached. Without this the browser
+        # is entitled to re-serve the splash from cache when the page navigates
+        # back to / after the app is ready, and the kiosk sits on the splash long
+        # after it should have moved on.
+        add_header Cache-Control "no-store, no-cache, must-revalidate" always;
+        expires -1;
     }
 
     location = /ready {

--- a/fleet-config/greengrass-compose.yaml
+++ b/fleet-config/greengrass-compose.yaml
@@ -135,7 +135,11 @@ services:
     env_file: ${DEVICE_ENV_FILE:-/opt/aquila/config/device.env}
     container_name: aquila-ui
     ports:
-      - "8080:80"
+      # 8080 belongs to host nginx, which is the kiosk's front door (#431):
+      # it must answer within a second of boot, and this container does not
+      # exist for the first ~40s. Publishing both here would leave the two
+      # fighting for the port and the stack failing to start.
+      - "8082:80"
     extra_hosts:
       - "host.docker.internal:host-gateway"
     restart: unless-stopped

--- a/scripts/deploy/deployment3_greengrass.sh
+++ b/scripts/deploy/deployment3_greengrass.sh
@@ -729,6 +729,28 @@ phase_start "9b" "Chromium Kiosk (Openbox autostart)"
 rm -f "${PI_HOME}/.config/autostart/chromium-kiosk.desktop"
 rm -f "${PI_HOME}/.config/labwc/autostart"
 
+# Neutralise the SYSTEM-WIDE Openbox autostart. Openbox runs /etc/xdg/openbox/
+# autostart BEFORE the per-user file written below, and both run — the user file
+# does not replace it. deployment1.sh wrote the legacy kiosk there, so any device
+# provisioned before this phase existed starts two browsers, not one.
+#
+# Measured on sn03: `python3 /home/pi/kiosk.py` (WebKit) and the Chromium kiosk
+# both running. kiosk.py loads http://localhost:8090 directly with no retry and
+# no error handling, so before the backend is listening it paints WebKit's default
+# error page ("Error receiving data: Connection reset by peer") over the splash.
+# The same file also ran `xrandr --rotate left` against this phase's `--rotate
+# right`, and `unclutter`, which the user autostart below deliberately avoids.
+#
+# Overwritten rather than deleted: openbox ships this path as a dpkg conffile, so
+# a removed file can come back on package upgrade while a modified one is kept.
+if [[ -f /etc/xdg/openbox/autostart ]]; then
+    cat > /etc/xdg/openbox/autostart <<'EOF'
+# Intentionally empty — the Aquila kiosk launches from the per-user autostart at
+# ~/.config/openbox/autostart. Openbox runs this system-wide file first and runs
+# BOTH, so anything added here starts in addition to the kiosk, not instead of it.
+EOF
+fi
+
 # Install boot splash page
 curl -fsSL \
     -H "Authorization: token ${GHCR_TOKEN}" \
@@ -805,6 +827,10 @@ run_test "xrandr auto-detect present"  "grep -q 'HDMI_OUT' ${AUTOSTART}"
 run_test "xinput transform present"    "grep -q 'Coordinate Transformation Matrix' ${AUTOSTART}"
 run_test "no stale Wayland .desktop"   "test ! -f ${PI_HOME}/.config/autostart/chromium-kiosk.desktop"
 run_test "correct file ownership"      "stat -c '%U' ${AUTOSTART} | grep -q pi"
+run_test "no legacy kiosk.py launch"   "! grep -q kiosk.py /etc/xdg/openbox/autostart 2>/dev/null"
+run_test "no system-wide unclutter"    "! grep -q '^unclutter' /etc/xdg/openbox/autostart 2>/dev/null"
+run_test "no system-wide xrandr"       "! grep -q '^xrandr' /etc/xdg/openbox/autostart 2>/dev/null"
+run_test "one kiosk launcher only"     "! grep -q 'chromium' /etc/xdg/openbox/autostart 2>/dev/null"
 
 phase_pass "Openbox autostart configured — X11 kiosk with rotation and touch mapping"
 

--- a/scripts/deploy/deployment3_greengrass.sh
+++ b/scripts/deploy/deployment3_greengrass.sh
@@ -292,6 +292,17 @@ rm -f /etc/nginx/sites-enabled/default
 # new config would never load. Restart explicitly. (Cost an hour on sn09.)
 nginx -t
 systemctl enable nginx
+
+# On a re-run, a previous deployment's aquila-ui may still be publishing :8080
+# and nginx cannot bind — `bind() to 0.0.0.0:8080 failed (98: Address already in
+# use)`, observed on sn09. The compose file below moves that container to :8082,
+# but the running one predates it, so stop it here. Phase 10 recreates the stack
+# from the updated file.
+if ss -lnt 2>/dev/null | grep -q ':8080' && command -v docker &>/dev/null; then
+    echo "  ℹ :8080 already held — stopping aquila-ui (it moves to :8082)"
+    docker stop aquila-ui &>/dev/null || true
+fi
+
 systemctl restart nginx
 
 run_test "nginx installed"        "command -v nginx"

--- a/scripts/deploy/deployment3_greengrass.sh
+++ b/scripts/deploy/deployment3_greengrass.sh
@@ -1159,6 +1159,70 @@ run_test "acorn theme is default"       "plymouth-set-default-theme | grep -q ac
 phase_pass "Plymouth Acorn theme installed (takes effect on next reboot)"
 
 # ═══════════════════════════════════════════════════════════════════════════════
+# Phase 14c — Bootloader Setup Screen (EEPROM)
+# ═══════════════════════════════════════════════════════════════════════════════
+phase_start "14c" "Bootloader Setup Screen (EEPROM)"
+
+# Boards with a newer factory bootloader ship NET_INSTALL_AT_POWER_ON=1, which
+# paints a "Configure this Raspberry Pi 4 Model B" panel over the whole display
+# on every cold boot. The bootloader draws it before the kernel loads, so the
+# suppression in Phases 6, 14 and 14b (piwiz, cmdline, Plymouth) all runs far too
+# late to hide it. NET_INSTALL_ENABLED=0 additionally skips the USB enumeration
+# the network-install keyboard probe performs, saving ~1s of boot.
+#
+# Applied to every device, not just affected ones: Phase 1 runs `apt-get upgrade`,
+# which can pull a newer rpi-eeprom and update the bootloader on an older board —
+# so a device that does not show the screen today can inherit the new defaults
+# from this very script. Setting the keys explicitly pins the behaviour instead
+# of depending on whichever bootloader the board happens to carry.
+#
+# This config lives in the on-board SPI EEPROM, NOT on the SD card: it survives
+# reimaging and is not undone by --revert. rpi-eeprom-config --apply does not
+# write the chip directly; it stages pieeprom.upd + recovery.bin on the boot
+# partition and the ROM programs the EEPROM during the next reboot. A power cut
+# in that window needs physical recovery, so the write is skipped entirely
+# whenever the config already matches — re-running this script never reflashes.
+
+EEPROM_CONF_CURRENT="/tmp/aquila-eeprom-current.conf"
+EEPROM_CONF_DESIRED="/tmp/aquila-eeprom-desired.conf"
+
+if ! command -v rpi-eeprom-config &>/dev/null; then
+    echo "  ⚠ rpi-eeprom-config not present — skipping (no Pi bootloader EEPROM)"
+    phase_pass "bootloader EEPROM not applicable on this hardware"
+elif ! rpi-eeprom-config > "${EEPROM_CONF_CURRENT}" 2>/dev/null \
+        || [[ ! -s "${EEPROM_CONF_CURRENT}" ]]; then
+    echo "  ⚠ could not read EEPROM config — skipping rather than writing blind"
+    phase_pass "bootloader EEPROM left untouched (config unreadable)"
+else
+    # Desired state: drop both keys wherever they sit, then pin network install
+    # off at the end. Deterministic ordering keeps this diff-stable on re-runs.
+    grep -v -E '^(NET_INSTALL_AT_POWER_ON|NET_INSTALL_ENABLED)=' \
+        "${EEPROM_CONF_CURRENT}" > "${EEPROM_CONF_DESIRED}" || true
+    echo "NET_INSTALL_ENABLED=0" >> "${EEPROM_CONF_DESIRED}"
+
+    if diff -q "${EEPROM_CONF_CURRENT}" "${EEPROM_CONF_DESIRED}" &>/dev/null; then
+        echo "  ✓ EEPROM config already correct — no update staged"
+    else
+        if rpi-eeprom-config --apply "${EEPROM_CONF_DESIRED}" &>/dev/null; then
+            echo "  ✓ EEPROM update staged — the ROM flashes it on the next reboot"
+            echo "    previous config: /var/lib/raspberrypi/bootloader/backup/"
+        else
+            phase_fail "rpi-eeprom-config --apply failed"
+        fi
+    fi
+
+    # Assert against the staged config, not the live chip: rpi-eeprom-config
+    # reads the CURRENT EEPROM, which still holds the old values until the
+    # flashing reboot, so asserting there would fail on an affected device.
+    run_test "power-on setup screen off" \
+        "! grep -q '^NET_INSTALL_AT_POWER_ON' ${EEPROM_CONF_DESIRED}"
+    run_test "network install disabled" \
+        "grep -q '^NET_INSTALL_ENABLED=0' ${EEPROM_CONF_DESIRED}"
+
+    phase_pass "bootloader setup screen suppressed (takes effect after reboot)"
+fi
+
+# ═══════════════════════════════════════════════════════════════════════════════
 # Phase 15 — Download Security Script
 # ═══════════════════════════════════════════════════════════════════════════════
 phase_start 15 "Download Security Script"

--- a/scripts/deploy/deployment3_greengrass.sh
+++ b/scripts/deploy/deployment3_greengrass.sh
@@ -1170,11 +1170,13 @@ phase_start "14c" "Bootloader Setup Screen (EEPROM)"
 # late to hide it. NET_INSTALL_ENABLED=0 additionally skips the USB enumeration
 # the network-install keyboard probe performs, saving ~1s of boot.
 #
-# Applied to every device, not just affected ones: Phase 1 runs `apt-get upgrade`,
-# which can pull a newer rpi-eeprom and update the bootloader on an older board —
-# so a device that does not show the screen today can inherit the new defaults
-# from this very script. Setting the keys explicitly pins the behaviour instead
-# of depending on whichever bootloader the board happens to carry.
+# Applied to every device, not just affected ones: `rpi-eeprom-config --apply`
+# updates the bootloader to the LATEST available image, not only its config.
+# Measured on sn01 and sn03 — both jumped from a 2025 bootloader to 2026/01/09
+# (d76c4603) when this ran. Newer bootloaders are precisely the ones that default
+# the setup screen on, so an old board that is fine today can inherit the problem
+# from this very phase. Writing the key in the same operation pins the behaviour
+# rather than leaving it to whichever bootloader the board ends up carrying.
 #
 # This config lives in the on-board SPI EEPROM, NOT on the SD card: it survives
 # reimaging and is not undone by --revert. rpi-eeprom-config --apply does not

--- a/scripts/deploy/deployment3_greengrass.sh
+++ b/scripts/deploy/deployment3_greengrass.sh
@@ -226,6 +226,83 @@ systemctl restart dnsmasq
 phase_pass "dnsmasq forwarder installed on 172.18.0.1"
 
 # ═══════════════════════════════════════════════════════════════════════════════
+# Phase 3d — Kiosk web front door (host nginx)
+# ═══════════════════════════════════════════════════════════════════════════════
+phase_start "3d" "Kiosk web front door (host nginx)"
+
+# The kiosk opens http://localhost:8080/ and never navigates away (#431), so that
+# address must answer from the first seconds of boot. This runs on the HOST, not
+# in Docker, for one measured reason: the compose stack takes ~30-40s to come up
+# (sn09: aquila-stack.service 18:00:14 -> 18:00:44), while Chromium launches ~8s
+# after boot. A containerised front door is not listening when the kiosk asks —
+# the device shows ERR_CONNECTION_REFUSED, or, if made to wait, a black screen
+# for the whole 40s with no splash at all. Both were observed on sn09.
+#
+# Host nginx starts in under a second, so:
+#   backend down (early boot) -> serves /opt/aquila/splash.html
+#   backend up                -> proxies through, the app is served
+#
+# Same origin either way, so the splash -> app handoff reuses Chromium's warm
+# renderer instead of swapping processes (measured A/B on sn11: same-origin is
+# seamless, file:// visibly blanks). It also means the kiosk no longer needs
+# --disable-web-security, which a file:// page required to poll /health.
+DEBIAN_FRONTEND=noninteractive apt-get install -y nginx
+
+cat > /etc/nginx/conf.d/aquila-kiosk.conf <<'EOF'
+server {
+    listen 8080;
+    root /opt/aquila;
+
+    # The kiosk's only URL. Backend up -> the app; backend absent -> the splash.
+    location = / {
+        proxy_pass http://127.0.0.1:8090;
+        error_page 502 503 504 = @splash;
+        # Bounded so the splash's once-a-second health poll is never blocked by a
+        # backend that simply has not started yet.
+        proxy_connect_timeout 2s;
+        proxy_set_header Host $host;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    }
+
+    # / serves two different documents depending on whether the backend is up, so
+    # the transient one must never be cached — otherwise the browser may re-serve
+    # the splash from cache after the app is ready and sit there indefinitely.
+    location @splash {
+        try_files /splash.html =404;
+        add_header Cache-Control "no-store, no-cache, must-revalidate" always;
+        expires -1;
+    }
+
+    location / {
+        proxy_pass http://127.0.0.1:8090;
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection "upgrade";
+        proxy_set_header Host $host;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    }
+}
+EOF
+
+# Debian's packaged default site also listens on :80 and is not wanted here.
+rm -f /etc/nginx/sites-enabled/default
+
+# The package starts nginx on install, before this config exists, and
+# `systemctl enable --now` does nothing to an already-running service — so the
+# new config would never load. Restart explicitly. (Cost an hour on sn09.)
+nginx -t
+systemctl enable nginx
+systemctl restart nginx
+
+run_test "nginx installed"        "command -v nginx"
+run_test "nginx config valid"     "nginx -t"
+run_test "nginx enabled"          "systemctl is-enabled nginx | grep -q enabled"
+run_test "nginx listening on 8080" "ss -lnt | grep -q ':8080'"
+# The splash file itself is installed in Phase 9b; serving it is asserted there.
+
+phase_pass "host nginx serving the kiosk front door on :8080"
+
+# ═══════════════════════════════════════════════════════════════════════════════
 # Phase 4 — Autologin (X11/Openbox)
 # ═══════════════════════════════════════════════════════════════════════════════
 phase_start 4 "Autologin (X11/Openbox)"
@@ -729,11 +806,13 @@ phase_start "9b" "Chromium Kiosk (Openbox autostart)"
 rm -f "${PI_HOME}/.config/autostart/chromium-kiosk.desktop"
 rm -f "${PI_HOME}/.config/labwc/autostart"
 
-# The boot splash is no longer installed on the host (#431). It ships inside the
-# UI image — Dockerfile.ui copies aquila_web/static/ into nginx's document root —
-# and nginx serves it on :8080 whenever the backend is not answering. Keeping a
-# second copy on the host would be one more file drifting from the repo, which is
-# how #424 and #426 happened.
+# Install the boot splash. Host nginx (Phase 3d) serves this file whenever the
+# backend is not answering, so it must live on the host filesystem — it is the
+# only thing available in the first seconds of boot.
+curl -fsSL \
+    -H "Authorization: token ${GHCR_TOKEN}" \
+    "${RAW_REPO_URL}/aquila_web/static/splash.html" \
+    -o /opt/aquila/splash.html
 
 mkdir -p "${PI_HOME}/.config/openbox"
 
@@ -795,6 +874,9 @@ AUTOSTART="${PI_HOME}/.config/openbox/autostart"
 run_test "openbox autostart exists"    "test -f ${AUTOSTART}"
 run_test "kiosk loads nginx origin"    "grep -q 'kiosk http://localhost:8080/' ${AUTOSTART}"
 run_test "no file:// splash"           "! grep -q 'file:///opt/aquila/splash.html' ${AUTOSTART}"
+run_test "splash installed on host"    "test -f /opt/aquila/splash.html"
+run_test "splash is same-origin"       "! grep -q 'localhost:8090' /opt/aquila/splash.html"
+run_test "front door answers"          "curl -sf -o /dev/null http://localhost:8080/"
 run_test "web security not disabled"   "! grep -q 'disable-web-security' ${AUTOSTART}"
 run_test "no file access override"     "! grep -q 'allow-file-access-from-files' ${AUTOSTART}"
 run_test "kiosk flag check present"    "grep -q 'kiosk_disabled' ${AUTOSTART}"

--- a/scripts/deploy/deployment3_greengrass.sh
+++ b/scripts/deploy/deployment3_greengrass.sh
@@ -798,13 +798,21 @@ EOF
 # this explicitly (server_web/kiosk.py, set_decorated(False)); the Chromium path
 # relies on --kiosk alone and had no equivalent until now.
 #
+# The rule also forces the window fullscreen at map time. Without it Chromium's
+# window is mapped small and then resized up to fullscreen, and you watch it grow
+# — this is the "quadrant fill" reported on #428, which was mistaken for a slow
+# repaint for some time. Frame-by-frame capture on sn09 showed a part-sized,
+# decorated window rather than a partially painted one. Mapping it fullscreen
+# removes the intermediate sizes entirely.
+#
 # A kiosk never wants decoration on anything, so the rule is unconditional.
 # Openbox has no drop-in config directory — the only way to set a window rule is
 # to own a copy of rc.xml, which is why this copies the distro file rather than
 # patching it in place. That is the same "copied file drifts from upstream"
 # pattern that caused #424 and #426, so it is deliberate and documented here.
 #
-# Verified on sn03: title bar gone, kiosk otherwise unaffected.
+# Verified on sn03 (title bar gone) and sn09 (window arrives fullscreen; the
+# growing fill is gone). Kiosk otherwise unaffected on both.
 OPENBOX_RC="${PI_HOME}/.config/openbox/rc.xml"
 if [[ ! -f "${OPENBOX_RC}" && -f /etc/xdg/openbox/rc.xml ]]; then
     cp /etc/xdg/openbox/rc.xml "${OPENBOX_RC}"
@@ -812,7 +820,7 @@ fi
 if [[ -f "${OPENBOX_RC}" ]] && ! grep -q 'aquila-kiosk-no-decor' "${OPENBOX_RC}"; then
     # Insert inside the existing <applications> block; a second top-level
     # <applications> element would be invalid and silently ignored.
-    sed -i 's|</applications>|  <!-- aquila-kiosk-no-decor: see #428 -->\n  <application class="*">\n    <decor>no</decor>\n  </application>\n</applications>|' "${OPENBOX_RC}"
+    sed -i 's|</applications>|  <!-- aquila-kiosk-no-decor: see #428 -->\n  <application class="*">\n    <decor>no</decor>\n    <maximized>yes</maximized>\n    <fullscreen>yes</fullscreen>\n  </application>\n</applications>|' "${OPENBOX_RC}"
     # A malformed rc.xml leaves Openbox with no window manager, so validate
     # before letting it reach a reboot. Restore the stock file if we broke it.
     if ! python3 -c "import xml.etree.ElementTree as ET; ET.parse('${OPENBOX_RC}')" 2>/dev/null; then

--- a/scripts/deploy/deployment3_greengrass.sh
+++ b/scripts/deploy/deployment3_greengrass.sh
@@ -729,11 +729,11 @@ phase_start "9b" "Chromium Kiosk (Openbox autostart)"
 rm -f "${PI_HOME}/.config/autostart/chromium-kiosk.desktop"
 rm -f "${PI_HOME}/.config/labwc/autostart"
 
-# Install boot splash page
-curl -fsSL \
-    -H "Authorization: token ${GHCR_TOKEN}" \
-    "${RAW_REPO_URL}/aquila_web/static/splash.html" \
-    -o /opt/aquila/splash.html
+# The boot splash is no longer installed on the host (#431). It ships inside the
+# UI image — Dockerfile.ui copies aquila_web/static/ into nginx's document root —
+# and nginx serves it on :8080 whenever the backend is not answering. Keeping a
+# second copy on the host would be one more file drifting from the repo, which is
+# how #424 and #426 happened.
 
 mkdir -p "${PI_HOME}/.config/openbox"
 
@@ -767,7 +767,7 @@ sleep 3
 # Flag is in /tmp/ so it is cleared on reboot (kiosk relaunches normally).
 if [ ! -f /tmp/kiosk_disabled ]; then
   chromium \
-    --kiosk file:///opt/aquila/splash.html \
+    --kiosk http://localhost:8080/ \
     --incognito \
     --noerrdialogs \
     --disable-infobars \
@@ -781,8 +781,6 @@ if [ ! -f /tmp/kiosk_disabled ]; then
     --enable-gpu-rasterization \
     --use-angle=gles \
     --ozone-platform=x11 \
-    --disable-web-security \
-    --allow-file-access-from-files \
     --user-data-dir=/tmp/chromium-kiosk \
     --disk-cache-size=0 \
     --start-maximized \
@@ -795,8 +793,10 @@ chown -R pi:pi "${PI_HOME}/.config/openbox"
 
 AUTOSTART="${PI_HOME}/.config/openbox/autostart"
 run_test "openbox autostart exists"    "test -f ${AUTOSTART}"
-run_test "splash page installed"       "test -f /opt/aquila/splash.html"
-run_test "kiosk loads splash"          "grep -q 'splash.html' ${AUTOSTART}"
+run_test "kiosk loads nginx origin"    "grep -q 'kiosk http://localhost:8080/' ${AUTOSTART}"
+run_test "no file:// splash"           "! grep -q 'file:///opt/aquila/splash.html' ${AUTOSTART}"
+run_test "web security not disabled"   "! grep -q 'disable-web-security' ${AUTOSTART}"
+run_test "no file access override"     "! grep -q 'allow-file-access-from-files' ${AUTOSTART}"
 run_test "kiosk flag check present"    "grep -q 'kiosk_disabled' ${AUTOSTART}"
 run_test "X11 platform flag"           "grep -q 'ozone-platform=x11' ${AUTOSTART}"
 run_test "user-data-dir flag present"  "grep -q 'user-data-dir' ${AUTOSTART}"

--- a/scripts/deploy/deployment3_greengrass.sh
+++ b/scripts/deploy/deployment3_greengrass.sh
@@ -791,10 +791,43 @@ if [ ! -f /tmp/kiosk_disabled ]; then
 fi
 EOF
 
+# Openbox decorates every window by default, and --kiosk does not survive a
+# window being re-mapped: at startup Chromium's window appears briefly before it
+# is fullscreened, and Openbox paints a title bar reading "Untitled — Chromium"
+# across the top of the display (#428). The legacy WebKit kiosk guarded against
+# this explicitly (server_web/kiosk.py, set_decorated(False)); the Chromium path
+# relies on --kiosk alone and had no equivalent until now.
+#
+# A kiosk never wants decoration on anything, so the rule is unconditional.
+# Openbox has no drop-in config directory — the only way to set a window rule is
+# to own a copy of rc.xml, which is why this copies the distro file rather than
+# patching it in place. That is the same "copied file drifts from upstream"
+# pattern that caused #424 and #426, so it is deliberate and documented here.
+#
+# Verified on sn03: title bar gone, kiosk otherwise unaffected.
+OPENBOX_RC="${PI_HOME}/.config/openbox/rc.xml"
+if [[ ! -f "${OPENBOX_RC}" && -f /etc/xdg/openbox/rc.xml ]]; then
+    cp /etc/xdg/openbox/rc.xml "${OPENBOX_RC}"
+fi
+if [[ -f "${OPENBOX_RC}" ]] && ! grep -q 'aquila-kiosk-no-decor' "${OPENBOX_RC}"; then
+    # Insert inside the existing <applications> block; a second top-level
+    # <applications> element would be invalid and silently ignored.
+    sed -i 's|</applications>|  <!-- aquila-kiosk-no-decor: see #428 -->\n  <application class="*">\n    <decor>no</decor>\n  </application>\n</applications>|' "${OPENBOX_RC}"
+    # A malformed rc.xml leaves Openbox with no window manager, so validate
+    # before letting it reach a reboot. Restore the stock file if we broke it.
+    if ! python3 -c "import xml.etree.ElementTree as ET; ET.parse('${OPENBOX_RC}')" 2>/dev/null; then
+        echo "  ✗ rc.xml failed XML validation — restoring stock file"
+        cp /etc/xdg/openbox/rc.xml "${OPENBOX_RC}"
+    fi
+fi
+
 chown -R pi:pi "${PI_HOME}/.config/openbox"
 
 AUTOSTART="${PI_HOME}/.config/openbox/autostart"
 run_test "openbox autostart exists"    "test -f ${AUTOSTART}"
+run_test "openbox rc.xml exists"       "test -f ${OPENBOX_RC}"
+run_test "window decorations disabled" "grep -q 'aquila-kiosk-no-decor' ${OPENBOX_RC}"
+run_test "rc.xml is valid XML"         "python3 -c \"import xml.etree.ElementTree as ET; ET.parse('${OPENBOX_RC}')\""
 run_test "splash page installed"       "test -f /opt/aquila/splash.html"
 run_test "kiosk loads splash"          "grep -q 'splash.html' ${AUTOSTART}"
 run_test "kiosk flag check present"    "grep -q 'kiosk_disabled' ${AUTOSTART}"

--- a/scripts/deploy/deployment3_greengrass.sh
+++ b/scripts/deploy/deployment3_greengrass.sh
@@ -766,7 +766,14 @@ sleep 3
 # If kiosk_disabled flag exists, show desktop instead of kiosk.
 # Flag is in /tmp/ so it is cleared on reboot (kiosk relaunches normally).
 if [ ! -f /tmp/kiosk_disabled ]; then
-  chromium \
+  # GTK_THEME: Chromium's window background — the surface visible after the window
+  # is mapped but before the page paints — comes from GTK, not from Chromium. It is
+  # bright white by default, which makes every seam and flicker around it obvious
+  # against the black either side. No Chromium flag reaches it:
+  # --default-background-color and --cast-app-background-color both govern the PAGE
+  # area and were verified in the running process on sn09 with no effect. A dark GTK
+  # theme does reach it. See ~/.config/gtk-3.0/gtk.css above for the black override.
+  env GTK_THEME=Adwaita:dark chromium \
     --kiosk file:///opt/aquila/splash.html \
     --incognito \
     --noerrdialogs \
@@ -830,6 +837,19 @@ if [[ -f "${OPENBOX_RC}" ]] && ! grep -q 'aquila-kiosk-no-decor' "${OPENBOX_RC}"
 fi
 
 chown -R pi:pi "${PI_HOME}/.config/openbox"
+
+# Paint Chromium's window background black rather than the theme's dark grey, so
+# the empty window is indistinguishable from the black on either side of it and
+# the seams between frames have nothing to show. GTK_THEME=Adwaita:dark on the
+# launch line (Phase 9b) selects a dark theme; this pins the exact colour.
+mkdir -p "${PI_HOME}/.config/gtk-3.0"
+cat > "${PI_HOME}/.config/gtk-3.0/gtk.css" <<'EOF'
+/* Kiosk: the browser window background before any page paints (#428). */
+window, .background, decoration {
+    background-color: #000000;
+}
+EOF
+chown -R pi:pi "${PI_HOME}/.config/gtk-3.0"
 
 AUTOSTART="${PI_HOME}/.config/openbox/autostart"
 run_test "openbox autostart exists"    "test -f ${AUTOSTART}"

--- a/scripts/deploy/deployment3_greengrass.sh
+++ b/scripts/deploy/deployment3_greengrass.sh
@@ -281,12 +281,39 @@ Section "ServerFlags"
 EndSection
 EOF
 
+# Tear down the legacy console-autologin path from deployment1.sh: an agetty
+# --autologin override on tty1 plus `startx` in ~/.bash_profile (server_web/
+# .bash_profile). LightDM owns autologin now, but the two are not mutually
+# exclusive — a device provisioned before Phase 4 existed carries both, and
+# nothing here previously removed the old one.
+#
+# Left in place, agetty logs in on tty1 and prints the login banner, the Debian
+# MOTD and the X.Org version block to the display before LightDM takes the
+# screen, and ~/.bash_profile races LightDM to start a second X on VT1.
+# Measured on sn03: removing both cleared the text entirely, kiosk unaffected.
+rm -rf /etc/systemd/system/getty@tty1.service.d
+systemctl daemon-reload
+
+# Rewrite rather than filter: deleting only the startx line leaves an empty
+# `if ... then / fi`, which is a bash syntax error on every login shell.
+if [[ -f "${PI_HOME}/.bash_profile" ]] && grep -q startx "${PI_HOME}/.bash_profile"; then
+    cat > "${PI_HOME}/.bash_profile" <<'EOF'
+if [ -f ~/.bashrc ]; then
+   . ~/.bashrc
+fi
+EOF
+    chown pi:pi "${PI_HOME}/.bash_profile"
+fi
+
 run_test "autologin.conf exists"           "test -f /etc/lightdm/lightdm.conf.d/autologin.conf"
 run_test "autologin-user=pi"               "grep -q 'autologin-user=pi' /etc/lightdm/lightdm.conf.d/autologin.conf"
 run_test "autologin-session=openbox"       "grep -q 'autologin-session=openbox' /etc/lightdm/lightdm.conf.d/autologin.conf"
 run_test "main lightdm.conf not rpd-labwc" "! grep -q 'autologin-session=rpd-labwc' /etc/lightdm/lightdm.conf"
 run_test "cursor disabled (-nocursor)"     "grep -q 'X -nocursor' /etc/lightdm/lightdm.conf.d/autologin.conf"
 run_test "lightdm enabled"                 "systemctl is-enabled lightdm | grep -q enabled"
+run_test "no console autologin override"   "! test -d /etc/systemd/system/getty@tty1.service.d"
+run_test "no startx in .bash_profile"      "! grep -q startx ${PI_HOME}/.bash_profile 2>/dev/null"
+run_test ".bash_profile is valid bash"     "test ! -f ${PI_HOME}/.bash_profile || bash -n ${PI_HOME}/.bash_profile"
 run_test "xorg.conf has AutoAddGPU off"    "grep -q 'AutoAddGPU' /etc/X11/xorg.conf"
 run_test "fbdev not installed"            "! dpkg -l xserver-xorg-video-fbdev 2>/dev/null | grep -q '^ii'"
 

--- a/scripts/deploy/deployment3_greengrass.sh
+++ b/scripts/deploy/deployment3_greengrass.sh
@@ -267,6 +267,18 @@ server {
     # / serves two different documents depending on whether the backend is up, so
     # the transient one must never be cached — otherwise the browser may re-serve
     # the splash from cache after the app is ready and sit there indefinitely.
+    # The kiosk opens this, not /, so the splash is shown on EVERY boot rather
+    # than only when the backend happens to be slow. Two reasons: the Acorn
+    # branding should be consistent, and going straight from black to a
+    # fully-rendered app is a harsher change than black -> splash -> app. The
+    # page navigates to / once /health answers, which is same-origin, so
+    # Chromium keeps its warm renderer.
+    location = /splash {
+        try_files /splash.html =404;
+        add_header Cache-Control "no-store, no-cache, must-revalidate" always;
+        expires -1;
+    }
+
     location @splash {
         try_files /splash.html =404;
         add_header Cache-Control "no-store, no-cache, must-revalidate" always;
@@ -857,7 +869,7 @@ sleep 3
 # Flag is in /tmp/ so it is cleared on reboot (kiosk relaunches normally).
 if [ ! -f /tmp/kiosk_disabled ]; then
   chromium \
-    --kiosk http://localhost:8080/ \
+    --kiosk http://localhost:8080/splash \
     --incognito \
     --noerrdialogs \
     --disable-infobars \
@@ -883,7 +895,7 @@ chown -R pi:pi "${PI_HOME}/.config/openbox"
 
 AUTOSTART="${PI_HOME}/.config/openbox/autostart"
 run_test "openbox autostart exists"    "test -f ${AUTOSTART}"
-run_test "kiosk loads nginx origin"    "grep -q 'kiosk http://localhost:8080/' ${AUTOSTART}"
+run_test "kiosk loads splash path"     "grep -q 'kiosk http://localhost:8080/splash' ${AUTOSTART}"
 run_test "no file:// splash"           "! grep -q 'file:///opt/aquila/splash.html' ${AUTOSTART}"
 run_test "splash installed on host"    "test -f /opt/aquila/splash.html"
 run_test "splash is same-origin"       "! grep -q 'localhost:8090' /opt/aquila/splash.html"

--- a/tests/fleet_device/test_deployment3_greengrass_script.py
+++ b/tests/fleet_device/test_deployment3_greengrass_script.py
@@ -79,3 +79,33 @@ def test_retains_deployment2_device_build():
     # Everything else from deployment2 is kept (spot-check across phases).
     for marker in ("I2C", "Tailscale", "aquila-cert-renew", "security.sh", "Plymouth"):
         assert marker in SCRIPT, f"deployment3 dropped a shared step: {marker}"
+
+
+# --- Legacy console autologin teardown ---------------------------------------
+# deployment1.sh set up console autologin (agetty --autologin on tty1) plus
+# `startx` in ~/.bash_profile. Phase 4 configures LightDM autologin but never
+# removed the old path, so devices provisioned before it carried both: agetty
+# printed the login banner, MOTD and X.Org block on the display before LightDM
+# took the screen, and .bash_profile raced it to start a second X on VT1.
+# Confirmed on sn03.
+
+def test_removes_legacy_console_autologin_override():
+    assert "rm -rf /etc/systemd/system/getty@tty1.service.d" in SCRIPT
+    assert "systemctl daemon-reload" in SCRIPT
+
+
+def test_removes_startx_from_bash_profile():
+    assert "grep -q startx" in SCRIPT
+
+
+def test_bash_profile_rewritten_not_filtered():
+    # Deleting only the startx line leaves `if ... then / fi` with an empty body,
+    # which is a bash syntax error on every login shell. Must rewrite the file.
+    assert "sed -i '/startx/d'" not in SCRIPT
+    assert "grep -v startx" not in SCRIPT
+
+
+def test_console_autologin_teardown_is_asserted():
+    assert 'run_test "no console autologin override"' in SCRIPT
+    assert 'run_test "no startx in .bash_profile"' in SCRIPT
+    assert 'run_test ".bash_profile is valid bash"' in SCRIPT

--- a/tests/fleet_device/test_deployment3_greengrass_script.py
+++ b/tests/fleet_device/test_deployment3_greengrass_script.py
@@ -125,3 +125,19 @@ def test_kiosk_window_mapped_fullscreen():
     """
     assert "<fullscreen>yes</fullscreen>" in SCRIPT
     assert "<maximized>yes</maximized>" in SCRIPT
+
+
+def test_kiosk_window_background_is_dark():
+    """
+    Chromium's window background — visible after the window is mapped but before
+    the page paints — comes from GTK, not Chromium, and is bright white by
+    default. That makes every seam around it obvious against the black either
+    side.
+
+    No Chromium flag reaches it: --default-background-color and
+    --cast-app-background-color both govern the page area and were verified in
+    the running process on sn09 with no effect on this surface.
+    """
+    assert "GTK_THEME=Adwaita:dark" in SCRIPT
+    assert ".config/gtk-3.0/gtk.css" in SCRIPT
+    assert "background-color: #000000" in SCRIPT

--- a/tests/fleet_device/test_deployment3_greengrass_script.py
+++ b/tests/fleet_device/test_deployment3_greengrass_script.py
@@ -79,3 +79,33 @@ def test_retains_deployment2_device_build():
     # Everything else from deployment2 is kept (spot-check across phases).
     for marker in ("I2C", "Tailscale", "aquila-cert-renew", "security.sh", "Plymouth"):
         assert marker in SCRIPT, f"deployment3 dropped a shared step: {marker}"
+
+
+# --- Legacy system-wide Openbox autostart teardown ---------------------------
+# Openbox runs /etc/xdg/openbox/autostart BEFORE the per-user file and runs BOTH.
+# deployment1.sh put the legacy WebKit kiosk (kiosk.py) there, so devices
+# provisioned before Phase 9b existed start two browsers. kiosk.py loads
+# localhost:8090 with no retry, painting WebKit's default error page over the
+# splash before the backend is listening. Confirmed on sn03.
+
+def test_neutralises_system_wide_openbox_autostart():
+    assert "/etc/xdg/openbox/autostart" in SCRIPT
+
+
+def test_system_autostart_overwritten_not_deleted():
+    # openbox ships this path as a dpkg conffile: a deleted file can return on
+    # package upgrade, a modified one is kept.
+    assert "rm -f /etc/xdg/openbox/autostart" not in SCRIPT
+    assert "rm -rf /etc/xdg/openbox" not in SCRIPT
+
+
+def test_legacy_kiosk_launchers_asserted_gone():
+    assert 'run_test "no legacy kiosk.py launch"' in SCRIPT
+    assert 'run_test "one kiosk launcher only"' in SCRIPT
+
+
+def test_legacy_rotation_and_unclutter_asserted_gone():
+    # The legacy file also ran `xrandr --rotate left` against this phase's
+    # `--rotate right`, and unclutter, which Phase 9b deliberately avoids.
+    assert 'run_test "no system-wide unclutter"' in SCRIPT
+    assert 'run_test "no system-wide xrandr"' in SCRIPT

--- a/tests/fleet_device/test_deployment3_greengrass_script.py
+++ b/tests/fleet_device/test_deployment3_greengrass_script.py
@@ -79,3 +79,39 @@ def test_retains_deployment2_device_build():
     # Everything else from deployment2 is kept (spot-check across phases).
     for marker in ("I2C", "Tailscale", "aquila-cert-renew", "security.sh", "Plymouth"):
         assert marker in SCRIPT, f"deployment3 dropped a shared step: {marker}"
+
+
+# --- Bootloader setup screen (EEPROM), #418 ----------------------------------
+# Newer factory bootloaders ship NET_INSTALL_AT_POWER_ON=1, which paints a
+# "Configure this Raspberry Pi" panel over the display on every cold boot. The
+# bootloader draws it pre-kernel, so the piwiz/cmdline/Plymouth suppression in
+# Phases 6, 14 and 14b all run too late to hide it.
+
+def test_disables_power_on_network_install_ui():
+    # Both keys are stripped, then network install is pinned off.
+    assert "NET_INSTALL_AT_POWER_ON" in SCRIPT
+    assert "NET_INSTALL_ENABLED=0" in SCRIPT
+    assert "rpi-eeprom-config --apply" in SCRIPT
+
+
+def test_eeprom_write_is_skipped_when_already_correct():
+    # The risk is the flash, not the setting: a power cut mid-write needs
+    # physical recovery. Re-running deployment3 must not reflash a correct chip.
+    assert "diff -q" in SCRIPT
+    assert "already correct" in SCRIPT
+
+
+def test_eeprom_phase_degrades_instead_of_writing_blind():
+    # No rpi-eeprom-config, or an unreadable config, must skip the phase rather
+    # than apply a config built from nothing.
+    assert "command -v rpi-eeprom-config" in SCRIPT
+    assert "writing blind" in SCRIPT
+
+
+def test_eeprom_asserts_against_staged_config_not_live_chip():
+    # rpi-eeprom-config reads the CURRENT EEPROM, which still holds the old
+    # values until the flashing reboot — asserting there fails on an affected
+    # device. The run_tests must check the staged file instead.
+    assert "EEPROM_CONF_DESIRED" in SCRIPT
+    assert 'run_test "power-on setup screen off"' in SCRIPT
+    assert 'run_test "network install disabled"' in SCRIPT

--- a/tests/fleet_device/test_deployment3_greengrass_script.py
+++ b/tests/fleet_device/test_deployment3_greengrass_script.py
@@ -79,3 +79,37 @@ def test_retains_deployment2_device_build():
     # Everything else from deployment2 is kept (spot-check across phases).
     for marker in ("I2C", "Tailscale", "aquila-cert-renew", "security.sh", "Plymouth"):
         assert marker in SCRIPT, f"deployment3 dropped a shared step: {marker}"
+
+
+# --- Same-origin splash via nginx, #431 --------------------------------------
+# The splash used to load from file:// and redirect to http://localhost:8090.
+# That crosses an origin boundary, so Chromium discards the renderer it just
+# warmed up and builds a second one for the app — the visible blank between
+# splash and app. Measured A/B on sn11: same-origin is seamless, file:// is not.
+
+def test_kiosk_opens_the_nginx_origin():
+    assert "--kiosk http://localhost:8080/" in SCRIPT
+
+
+def test_no_file_url_splash():
+    # The kiosk must not open the splash as a local file — that is the origin
+    # boundary this change removes.
+    assert "file:///opt/aquila/splash.html" not in SCRIPT.replace(
+        "! grep -q 'file:///opt/aquila/splash.html'", ""
+    )
+
+
+def test_splash_not_installed_on_host():
+    # It ships in the UI image (Dockerfile.ui copies aquila_web/static/), so a
+    # host copy would be a second file drifting from the repo — how #424 and
+    # #426 happened.
+    assert "-o /opt/aquila/splash.html" not in SCRIPT
+
+
+def test_web_security_no_longer_disabled():
+    # A file:// page fetching http://localhost:8090/health is cross-origin, so
+    # the old splash only worked because Chromium ran with web security off, on
+    # a device holding device certificates. Same-origin needs neither flag.
+    launch = SCRIPT.split("chromium \\")[1] if "chromium \\" in SCRIPT else ""
+    assert "--disable-web-security" not in launch
+    assert "--allow-file-access-from-files" not in launch

--- a/tests/fleet_device/test_deployment3_greengrass_script.py
+++ b/tests/fleet_device/test_deployment3_greengrass_script.py
@@ -114,3 +114,14 @@ def test_rc_xml_validated_before_reboot():
 def test_rc_xml_edit_is_idempotent():
     # Re-running deployment3 must not stack duplicate rules into rc.xml.
     assert "grep -q 'aquila-kiosk-no-decor'" in SCRIPT
+
+
+def test_kiosk_window_mapped_fullscreen():
+    """
+    Without this, Chromium's window is mapped small and then resized up, and the
+    growth is visible on screen — the "quadrant fill" on #428, which was mistaken
+    for a slow repaint until frame-by-frame capture on sn09 showed a part-sized
+    decorated window rather than a partially painted one.
+    """
+    assert "<fullscreen>yes</fullscreen>" in SCRIPT
+    assert "<maximized>yes</maximized>" in SCRIPT

--- a/tests/fleet_device/test_deployment3_greengrass_script.py
+++ b/tests/fleet_device/test_deployment3_greengrass_script.py
@@ -99,11 +99,10 @@ def test_no_file_url_splash():
     )
 
 
-def test_splash_not_installed_on_host():
-    # It ships in the UI image (Dockerfile.ui copies aquila_web/static/), so a
-    # host copy would be a second file drifting from the repo — how #424 and
-    # #426 happened.
-    assert "-o /opt/aquila/splash.html" not in SCRIPT
+def test_splash_installed_on_host_for_nginx():
+    # Host nginx serves the splash in the first seconds of boot, before Docker
+    # exists, so the file must be on the host filesystem.
+    assert "-o /opt/aquila/splash.html" in SCRIPT
 
 
 def test_web_security_no_longer_disabled():
@@ -113,3 +112,42 @@ def test_web_security_no_longer_disabled():
     launch = SCRIPT.split("chromium \\")[1] if "chromium \\" in SCRIPT else ""
     assert "--disable-web-security" not in launch
     assert "--allow-file-access-from-files" not in launch
+
+
+# --- Host nginx front door, #431 ---------------------------------------------
+# The kiosk opens http://localhost:8080/ and never navigates away, so that
+# address must answer from the first seconds of boot. Measured on sn09: the
+# compose stack takes ~30-40s while Chromium launches at ~8s, so a containerised
+# front door is not listening when the kiosk asks.
+
+def test_nginx_runs_on_the_host_not_in_docker():
+    assert "apt-get install -y nginx" in SCRIPT
+    assert "/etc/nginx/conf.d/aquila-kiosk.conf" in SCRIPT
+    assert "systemctl enable nginx" in SCRIPT
+
+
+def test_nginx_restarted_not_just_enabled():
+    # The package starts nginx on install, before the config exists, and
+    # `enable --now` does nothing to a running service — so the config would
+    # never load. Cost an hour on sn09.
+    assert "systemctl restart nginx" in SCRIPT
+
+
+def test_nginx_proxies_to_backend_on_loopback():
+    # Host-side, so the backend is reached via its published host port, not a
+    # Docker service name.
+    assert "proxy_pass http://127.0.0.1:8090" in SCRIPT
+
+
+def test_nginx_falls_back_to_splash():
+    assert "error_page 502 503 504 = @splash" in SCRIPT
+    assert "location @splash" in SCRIPT
+    assert "no-store" in SCRIPT
+
+
+def test_ui_container_does_not_claim_8080():
+    # Host nginx owns 8080; both publishing it would leave them fighting for the
+    # port and the stack failing to start.
+    compose = Path("fleet-config/greengrass-compose.yaml").read_text()
+    assert '"8080:80"' not in compose
+    assert '"8082:80"' in compose

--- a/tests/fleet_device/test_deployment3_greengrass_script.py
+++ b/tests/fleet_device/test_deployment3_greengrass_script.py
@@ -151,3 +151,14 @@ def test_ui_container_does_not_claim_8080():
     compose = Path("fleet-config/greengrass-compose.yaml").read_text()
     assert '"8080:80"' not in compose
     assert '"8082:80"' in compose
+
+
+def test_nginx_phase_frees_port_8080_on_rerun():
+    """
+    On a re-run, a previous deployment's aquila-ui may still be publishing :8080,
+    and nginx fails with `bind() to 0.0.0.0:8080 failed (98: Address already in
+    use)` — observed on sn09. The compose file moves that container to :8082, but
+    the already-running one predates it.
+    """
+    assert "docker stop aquila-ui" in SCRIPT
+    assert "Address already in use" in SCRIPT or ":8080 already held" in SCRIPT

--- a/tests/fleet_device/test_deployment3_greengrass_script.py
+++ b/tests/fleet_device/test_deployment3_greengrass_script.py
@@ -79,3 +79,38 @@ def test_retains_deployment2_device_build():
     # Everything else from deployment2 is kept (spot-check across phases).
     for marker in ("I2C", "Tailscale", "aquila-cert-renew", "security.sh", "Plymouth"):
         assert marker in SCRIPT, f"deployment3 dropped a shared step: {marker}"
+
+
+# --- Openbox window decorations, #428 ----------------------------------------
+# Openbox decorates every window by default and --kiosk does not survive a window
+# being re-mapped, so Chromium's window briefly wears a title bar reading
+# "Untitled — Chromium" at startup. Verified on sn03.
+
+def test_disables_window_decorations():
+    assert "aquila-kiosk-no-decor" in SCRIPT
+    assert "<decor>no</decor>" in SCRIPT
+
+
+def test_rc_xml_copied_from_distro_not_written_from_scratch():
+    # Openbox needs a complete rc.xml; hand-writing one would drop every other
+    # distro default (theme, keybinds, mouse behaviour).
+    assert "cp /etc/xdg/openbox/rc.xml" in SCRIPT
+
+
+def test_rc_xml_rule_inserted_inside_applications_block():
+    # A second top-level <applications> element is invalid and silently ignored,
+    # so the rule must go inside the existing one.
+    assert "s|</applications>|" in SCRIPT
+
+
+def test_rc_xml_validated_before_reboot():
+    # A malformed rc.xml leaves Openbox unable to start — blank screen on a
+    # device that may not be physically reachable. Validate and roll back.
+    assert "xml.etree.ElementTree" in SCRIPT
+    assert "restoring stock file" in SCRIPT
+    assert 'run_test "rc.xml is valid XML"' in SCRIPT
+
+
+def test_rc_xml_edit_is_idempotent():
+    # Re-running deployment3 must not stack duplicate rules into rc.xml.
+    assert "grep -q 'aquila-kiosk-no-decor'" in SCRIPT

--- a/tests/fleet_device/test_deployment3_greengrass_script.py
+++ b/tests/fleet_device/test_deployment3_greengrass_script.py
@@ -87,8 +87,14 @@ def test_retains_deployment2_device_build():
 # warmed up and builds a second one for the app — the visible blank between
 # splash and app. Measured A/B on sn11: same-origin is seamless, file:// is not.
 
-def test_kiosk_opens_the_nginx_origin():
-    assert "--kiosk http://localhost:8080/" in SCRIPT
+def test_kiosk_opens_the_splash_path():
+    # /splash always serves the splash; / would serve the app directly whenever
+    # the backend happens to be up, skipping the splash entirely.
+    assert "--kiosk http://localhost:8080/splash" in SCRIPT
+
+
+def test_splash_path_always_serves_the_splash():
+    assert "location = /splash" in SCRIPT
 
 
 def test_no_file_url_splash():

--- a/tests/fleet_device/test_nginx_config.py
+++ b/tests/fleet_device/test_nginx_config.py
@@ -152,3 +152,46 @@ def test_no_hardcoded_host_ips():
         f"nginx.conf contains hardcoded Docker bridge IPs: {matches}. "
         "Use container service names or host.docker.internal with a resolver."
     )
+
+
+def test_static_prefix_maps_to_flat_document_root():
+    """
+    The app references its assets relatively (href="static/styles.css"), which
+    resolves to /static/… — but Dockerfile.ui copies aquila_web/static/ INTO the
+    document root, so the files are at the top level with no static/ subdir.
+
+    Serving that prefix with a plain root+try_files looks for
+    /usr/share/nginx/html/static/styles.css, which does not exist: measured on
+    sn10, /static/styles.css returned 404 and the app rendered unstyled.
+
+    try_files must NOT be combined with alias here — it resolves $uri against the
+    aliased path and reintroduces the same wrong directory.
+    """
+    conf = _read_conf()
+    blocks = [b for b in _location_blocks(conf) if b.lstrip().startswith("location /static/")]
+    assert blocks, "no location /static/ block found"
+    block = blocks[0]
+    assert "alias /usr/share/nginx/html/" in block, (
+        "/static/ must alias the flat document root, not use root+try_files"
+    )
+    assert "try_files" not in block, (
+        "try_files with alias resolves against the aliased path and breaks it"
+    )
+
+
+def test_backend_failure_is_fast():
+    """
+    While the backend container does not exist its name does not resolve. With
+    nginx's defaults (30s resolver, 60s proxy) every splash health poll hung for
+    a full minute — measured on sn10: 504 in 60.03s — so the splash stayed up
+    long after the app was ready.
+
+    The splash polls once a second and must not be blocked for longer than that
+    by a backend which is simply not up yet.
+    """
+    conf = _read_conf()
+    assert "resolver_timeout" in conf, (
+        "resolver_timeout must be set — the 30s default stalls every poll while "
+        "the backend container is absent"
+    )
+    assert "proxy_connect_timeout" in conf

--- a/tests/fleet_device/test_nginx_config.py
+++ b/tests/fleet_device/test_nginx_config.py
@@ -87,15 +87,57 @@ def test_no_bare_host_docker_internal_in_proxy_pass():
 
 def test_backend_upstream_uses_container_name():
     """
-    The main backend proxy_pass must use the Docker service name
-    (aquila-backend), not localhost or a host IP. Container-to-container
-    traffic must go via the Docker network.
+    The backend upstream must be the Docker service name (aquila-backend), not
+    localhost or a host IP. Container-to-container traffic goes via the Docker
+    network.
+
+    The name now appears in a `set $aq_backend http://aquila-backend:8090`
+    directive rather than inline in proxy_pass, so nginx resolves it per request
+    instead of at startup (#431). The container-name requirement is unchanged —
+    only where the name is written has moved.
     """
     conf = _read_conf()
-    assert "proxy_pass http://aquila-backend:" in conf, (
-        "Main backend proxy_pass should use the container name 'aquila-backend', "
+    assert "http://aquila-backend:8090" in conf, (
+        "Backend upstream should use the container name 'aquila-backend', "
         "not localhost or a hardcoded IP."
     )
+    assert "proxy_pass http://localhost" not in conf
+    assert "proxy_pass http://127.0.0.1" not in conf
+
+
+def test_backend_upstream_resolved_per_request():
+    """
+    Every proxy_pass to aquila-backend must go through a variable, so the name is
+    resolved at request time. A literal upstream is resolved once at startup and
+    nginx refuses to start if the backend container does not exist yet — which is
+    exactly the state during boot, and the whole point of the splash fallback.
+
+    Same failure mode that took down aquila-ui on sn01, previously only guarded
+    for host.docker.internal.
+    """
+    conf = _read_conf()
+    for line in conf.splitlines():
+        line = line.strip()
+        if line.startswith("proxy_pass") and "aquila-backend" in line:
+            assert "$" in line, (
+                "proxy_pass to aquila-backend must use a variable so the name is "
+                f"resolved per request, not at startup:\n  {line}"
+            )
+
+
+def test_root_falls_back_to_splash_when_backend_is_down():
+    """
+    The kiosk opens / and never navigates away (#431). While the backend is
+    starting nginx cannot connect, and that must serve the boot splash rather
+    than an error page — otherwise the device shows a connection failure for the
+    several seconds the app takes to come up.
+    """
+    conf = _read_conf()
+    assert "error_page" in conf and "@splash" in conf, (
+        "location = / must fall back to @splash on upstream failure"
+    )
+    assert "location @splash" in conf
+    assert "/splash.html" in conf
 
 
 def test_no_hardcoded_host_ips():

--- a/tests/fleet_device/test_nginx_config.py
+++ b/tests/fleet_device/test_nginx_config.py
@@ -21,21 +21,28 @@ def _read_conf() -> str:
 
 
 def _location_blocks(conf: str) -> list[str]:
-    """Extract each location { ... } block as a string."""
+    """
+    Extract each location { ... } block as a string.
+
+    The opening brace on the `location` line must be counted, otherwise depth
+    starts at 0 and the first body line closes the block — which silently
+    truncated every block to one line and let tests pass while inspecting almost
+    nothing.
+    """
     blocks = []
     depth = 0
     current: list[str] = []
     inside = False
     for line in conf.splitlines():
-        if re.match(r"\s*location\s+", line):
+        if not inside and re.match(r"\s*location\s+", line):
             inside = True
-            depth = 0
             current = [line]
+            depth = line.count("{") - line.count("}")
             continue
         if inside:
             current.append(line)
             depth += line.count("{") - line.count("}")
-            if depth <= 0 and "{" in "\n".join(current):
+            if depth <= 0:
                 blocks.append("\n".join(current))
                 inside = False
                 current = []
@@ -195,3 +202,18 @@ def test_backend_failure_is_fast():
         "the backend container is absent"
     )
     assert "proxy_connect_timeout" in conf
+
+
+def test_splash_fallback_is_not_cacheable():
+    """
+    / serves two different documents depending on whether the backend is up. The
+    transient one must carry no-store, or the browser may re-serve the splash
+    from cache when the page navigates back to / after the app is ready — leaving
+    the kiosk on the splash long after it should have moved on.
+    """
+    conf = _read_conf()
+    blocks = [b for b in _location_blocks(conf) if b.lstrip().startswith("location @splash")]
+    assert blocks, "no location @splash block found"
+    assert "no-store" in blocks[0], (
+        "@splash must send Cache-Control: no-store — one URL, two documents"
+    )


### PR DESCRIPTION
Removes the visible artifacts between power-on and the app appearing. Five child PRs, all merged into this branch, all verified on hardware.

## What a customer saw before

- A **"Configure this Raspberry Pi 4 Model B"** panel with QR codes filling the screen on every cold power-on, before anything of ours appeared. — #419
- **Walls of Linux text** scrolling past: a login banner, the Debian licence paragraph, the X.Org version block. — #425
- A white page reading **"Error receiving data: Connection reset by peer"** sitting on screen before the app loaded. — #427
- A grey **"Untitled — Chromium" title bar** flashing across the top, and the window visibly **growing from a narrow strip** to full screen. — #435
- The empty browser window flashing **bright white** against the black around it, making every seam and flicker obvious. — #435
- On a fast boot the loading screen **never appearing at all**, so the screen jumped from black straight to a fully-rendered app. — #436
- The switch from the loading screen to the app **blanking out** instead of changing cleanly. — #436

## What changed

| Area | Change |
|---|---|
| Bootloader EEPROM | `NET_INSTALL_ENABLED=0`, guarded so the chip is only written when the config actually differs |
| Legacy console autologin | torn down (`agetty` override + `~/.bash_profile` with `startx`) |
| Legacy system-wide Openbox autostart | neutralised — it was starting a **second** browser |
| Openbox window rules | no decoration, mapped fullscreen, black window background |
| Kiosk web front door | **host** nginx on :8080 serving the splash and proxying to the backend |
| Chromium flags | `--disable-web-security` and `--allow-file-access-from-files` removed |

## Beyond the cosmetic

**`--disable-web-security` is gone.** The `file://` splash could only poll `/health` because Chromium ran with web security disabled browser-wide — on a device holding device certificates and talking to AWS IoT. Serving the splash same-origin removes the need.

**Two browsers were running on older devices.** `/etc/xdg/openbox/autostart` still launched the legacy WebKit kiosk alongside Chromium. That file was also rotating the display against the current setting and running `unclutter`, which the current autostart deliberately avoids — so the cursor behaviour `specs/hardware/mouse-cursor-removal.md` was written to fix had never actually been fixed on those units.

**A latent nginx crash.** `proxy_pass` to a literal `aquila-backend` is resolved once at startup, so nginx refuses to start when the container is absent — the failure that took down aquila-ui on sn01. The existing test guarded this for `host.docker.internal` only.

## Verification

Applied and observed on **sn01, sn03, sn09, sn10, sn11, sn12**, not only asserted in tests. Several defects were found *only* by applying changes to a device:

- The container-based front door loses a startup race — passed on sn10/sn11 by luck, failed on sn09. **Per-boot, not per-device.**
- Serving the splash same-origin requires the relative-URL `splash.html` in the same change, or the device sits on the splash forever.
- nginx must be `restart`ed, not `enable --now`'d — the package starts it before the config exists.
- On a re-run, the old `aquila-ui` still holds :8080 and nginx cannot bind.

`bash -n` clean, `tests/fleet_device` — **106 passed**. Generated nginx config validated against real nginx.

## Deliberately not included

**#438 (display rotation)** stays open. The fix is confirmed applied at the X level — `(**) modeset(0): Option "Rotate" "right"` in `Xorg.0.log` — but the logo jump was still observed afterwards. The symptom is intermittent and we have no baseline rate, so there is no way yet to tell a fix from a lucky boot. Data collection is in progress.

## Known limits, documented not hidden

- **A dark frame remains** at the Chromium handover. Seven approaches ruled out with evidence in #428, including Plymouth `--retain-splash`, X `-background none`/`-nr`, kernel-level rotation, and three Chromium background flags — five of them verified live in the running process, not just written to config.
- **Residual tearing.** This modesetting build has no `TearFree` support (no property in `xrandr --props`, no mention in the X log). The black window background removes the contrast that made it visible.
- **The panel is briefly unlit** during the handover, and a lit black screen can never match an unlit one. That is a hardware limit, not a config gap.
- **Two nginx configs** now exist. Tracked in #444 — consolidation looks like a net deletion, blocked on rehoming the #351 `version.json` check.
- **The app still takes 30–40s to start.** Host nginx made that wait *visible* rather than shorter. It is now by far the largest thing in the boot — every artifact above lasts under a second — and deserves its own issue.
