### PR TITLE
feat: emit duration_seconds on run_complete (#449)

### DIFF
--- a/aq_lib/state_requests.py
+++ b/aq_lib/state_requests.py
@@ -119,6 +119,7 @@ def emit_run_complete(
     results_path: str,
     run_timestamp: str | None = None,
     tube_names: list | None = None,
+    duration_seconds: float | None = None,
 ) -> None:
     url = f"{BACKEND_URL}/events/run_complete"
     payload = {"run_name": run_name, "profile": profile, "results_path": results_path}
@@ -126,6 +127,11 @@ def emit_run_complete(
         payload["run_timestamp"] = run_timestamp
     if tube_names is not None:
         payload["tube_names"] = tube_names
+    if duration_seconds is not None:
+        # How long the Run took (#449); read from fact_run.duration_seconds
+        # cloud-side. Omitted (not sent as null) when unknown, mirroring
+        # run_timestamp/tube_names above.
+        payload["duration_seconds"] = duration_seconds
     try:
         requests.post(url, json=payload, timeout=5)
     except requests.exceptions.RequestException as e:

--- a/aquila_web/main.py
+++ b/aquila_web/main.py
@@ -13,6 +13,7 @@ import logging
 from datetime import datetime
 import os
 import sys
+import time
 from pydantic import BaseModel
 from typing import Optional
 import json
@@ -668,6 +669,10 @@ async def _simulate_run(profile_name: str) -> None:
     start_time = datetime.now()
     # Canonical run_timestamp captured once at run start (#287).
     run_timestamp = _utc_now()
+    # Monotonic anchor for duration_seconds (#449): decoupled from run_timestamp
+    # (wall clock, used for run_id derivation) so a system clock adjustment
+    # mid-run can't skew the reported duration.
+    run_start_monotonic = time.monotonic()
     elapsed_time = 0
     timer_running = True
     current_item.screen = "running"
@@ -732,6 +737,7 @@ async def _simulate_run(profile_name: str) -> None:
     })
     _save_history(history)
     init_local_db()
+    duration_seconds = round(time.monotonic() - run_start_monotonic)
     enqueue_event(
         "run_complete",
         {
@@ -739,6 +745,7 @@ async def _simulate_run(profile_name: str) -> None:
             "profile": profile_name,
             "result": detected_summary,
             "run_timestamp": run_timestamp,
+            "duration_seconds": duration_seconds,
             "tube_names": _tube_names_by_well(),
             "calls": _calls_from_file(results_file),
         },
@@ -919,6 +926,10 @@ class _RunCompleteEventRequest(BaseModel):
     results_path: Optional[str] = None
     run_timestamp: Optional[str] = None
     tube_names: Optional[list] = None
+    # How long the Run took, in seconds -- captured device-side across the
+    # same bracket as run_timestamp (#449). Optional/None for legacy callers;
+    # the field is purely additive so there is no fallback computation here.
+    duration_seconds: Optional[float] = None
 
 
 @app.post("/events/run_complete")
@@ -938,6 +949,7 @@ async def events_run_complete(req: _RunCompleteEventRequest):
             "profile": req.profile,
             "result": result,
             "run_timestamp": run_timestamp,
+            "duration_seconds": req.duration_seconds,
             "tube_names": _tube_names_by_well(req.tube_names),
             "calls": _calls_from_file(results_file) if results_file else [],
         },

--- a/state_run_assay.py
+++ b/state_run_assay.py
@@ -174,6 +174,10 @@ class AssayInterface():
         # Shared by run_complete and the forthcoming optics_readings event so the
         # cloud derives the same run_id = uuid5(device_id : run_timestamp).
         self.run_timestamp = datetime.utcnow().isoformat(timespec="seconds") + "Z"
+        # Monotonic anchor for duration_seconds (#449): decoupled from
+        # run_timestamp (wall clock, used for run_id derivation) so an NTP/DST
+        # adjustment mid-run can't skew the reported duration.
+        self._run_start_monotonic = time.monotonic()
         # Optical read passes for the optics_readings completeness check (#288).
         # _planned_optics_passes is the profile's intended total (set once steps
         # are loaded, below); _optics_pass_count is the runtime fallback.
@@ -318,6 +322,7 @@ class AssayInterface():
                     self.run_name, profile_name, str(results_json),
                     run_timestamp=self.run_timestamp,
                     tube_names=tube_names,
+                    duration_seconds=round(time.monotonic() - self._run_start_monotonic),
                 )
                 # Capture the exact optics file just consumed onto the same
                 # outbox, sharing run_timestamp (#288).

--- a/tests/unit/test_run_complete_event.py
+++ b/tests/unit/test_run_complete_event.py
@@ -7,6 +7,7 @@ Behaviors tested:
   3. Event payload includes a non-empty result field
   4. state_requests.emit_run_complete() posts to the correct endpoint
 """
+import asyncio
 import sys
 from pathlib import Path
 from unittest.mock import MagicMock
@@ -151,6 +152,160 @@ class TestRunCompleteEndpoint:
             "3": "Tube 3",
             "4": "Tube 4",
         }
+
+
+class TestRunCompleteDuration:
+    """run_complete carries the Run's duration (#449), so
+    v_homing_sample_correlated stops treating every Run as still-in-progress
+    and Samples can be told apart as in-Run or idle."""
+
+    def test_payload_carries_supplied_duration_seconds(self, db_client):
+        client, local_db = db_client
+        client.post("/events/run_complete", json={
+            "run_name": "Run 1",
+            "profile": "basic_pcr.json",
+            "results_path": str(DETECTED_RESULTS),
+            "duration_seconds": 842,
+        })
+        payload = local_db.get_pending_events()[0]["payload"]
+        assert payload["duration_seconds"] == 842
+
+    def test_payload_defaults_duration_seconds_to_none_when_omitted(self, db_client):
+        client, local_db = db_client
+        client.post("/events/run_complete", json={
+            "run_name": "Run 1",
+            "profile": "basic_pcr.json",
+            "results_path": str(DETECTED_RESULTS),
+        })
+        payload = local_db.get_pending_events()[0]["payload"]
+        assert payload.get("duration_seconds") is None
+
+    def test_existing_fields_and_run_timestamp_unchanged(self, db_client):
+        # Acceptance criterion: existing fields and run_timestamp must be
+        # unaffected -- run_id is derived cloud-side from device_id +
+        # run_timestamp and must not shift.
+        client, local_db = db_client
+        client.post("/events/run_complete", json={
+            "run_name": "Run 1",
+            "profile": "basic_pcr.json",
+            "results_path": str(DETECTED_RESULTS),
+            "run_timestamp": "2026-07-02T14:03:11Z",
+        })
+        payload = local_db.get_pending_events()[0]["payload"]
+        assert payload["run_timestamp"] == "2026-07-02T14:03:11Z"
+        assert payload["run_name"] == "Run 1"
+        assert payload["profile"] == "basic_pcr.json"
+
+
+class TestEmitRunCompleteForwardsDurationSeconds:
+    """state_requests.emit_run_complete() forwards duration_seconds (#449)."""
+
+    def test_forwards_duration_seconds_when_supplied(self, monkeypatch):
+        import aq_lib.state_requests as sr
+
+        calls = []
+
+        class _FakeResponse:
+            status_code = 200
+
+        def fake_post(url, json=None, timeout=None):
+            calls.append({"url": url, "json": json})
+            return _FakeResponse()
+
+        monkeypatch.setattr("aq_lib.state_requests.requests.post", fake_post)
+        sr.emit_run_complete(
+            "Run 1", "basic_pcr.json", "/logs/results/run1.json",
+            duration_seconds=123,
+        )
+        assert calls[0]["json"]["duration_seconds"] == 123
+
+    def test_omits_duration_seconds_when_not_supplied(self, monkeypatch):
+        import aq_lib.state_requests as sr
+
+        calls = []
+
+        class _FakeResponse:
+            status_code = 200
+
+        def fake_post(url, json=None, timeout=None):
+            calls.append({"url": url, "json": json})
+            return _FakeResponse()
+
+        monkeypatch.setattr("aq_lib.state_requests.requests.post", fake_post)
+        sr.emit_run_complete("Run 1", "basic_pcr.json", "/logs/results/run1.json")
+        assert "duration_seconds" not in calls[0]["json"]
+
+
+class TestSimulatedRunEmitsSameFields:
+    """The simulated-run path (aquila_web.main._simulate_run) must stamp
+    duration_seconds onto run_complete the same way the real
+    /events/run_complete path does (#449 acceptance criterion).
+
+    Isolated from the real repo tree: RESULTS_DIR/PLOTS_DIR/HISTORY_PATH and
+    the local DB are all monkeypatched to tmp_path, and process_run (the real
+    curve analysis) is stubbed out with a fixture results file so this test
+    doesn't depend on optics-log parsing correctness -- that's covered
+    elsewhere.
+    """
+
+    @pytest.mark.asyncio
+    async def test_simulated_run_payload_has_duration(self, tmp_path, monkeypatch):
+        from aquila_web import local_db, main as web_main
+
+        db_path = tmp_path / "sim_events.db"
+        monkeypatch.setenv("AQ_LOCAL_DB_PATH", str(db_path))
+        local_db.init_local_db()
+
+        monkeypatch.setattr(web_main, "RESULTS_DIR", tmp_path / "results")
+        monkeypatch.setattr(web_main, "PLOTS_DIR", tmp_path / "plots")
+        monkeypatch.setattr(web_main, "HISTORY_PATH", tmp_path / "history.json")
+        monkeypatch.setattr(web_main, "SIM_RUN_SECONDS", 0)
+        # _simulate_run only checks that the optics path exists before handing it
+        # to process_run (stubbed below), so a minimal file in tmp_path is enough.
+        # Deliberately not a repo fixture: this test must not depend on a large
+        # sample log being present in the tree.
+        optics_stub = tmp_path / "optics.log"
+        optics_stub.write_text("# Starting optics log\n")
+        monkeypatch.setattr(web_main, "dev_optics_path", str(optics_stub))
+
+        # Results written inline rather than copied from tests/fixtures/results/:
+        # that directory is covered by the broad `results/` .gitignore rule, so
+        # those fixtures exist only on a developer machine and this test would
+        # fail on a clean clone.
+        _RESULTS_JSON = (
+            '{"1": {"1": "Detected", "2": "Detected", "3": "Detected", "4": "Detected"},'
+            ' "2": {"1": "Detected", "2": "Detected", "3": "Detected", "4": "Detected"},'
+            ' "cq": {"1": {"1": 22.34, "2": 23.10, "3": 24.05, "4": 22.88},'
+            ' "2": {"1": 21.50, "2": 21.92, "3": 22.41, "4": 21.77}}}'
+        )
+
+        def _fake_process_run(optics_path, results_filename, plot_path, labels=None, rox_unavailable=False):
+            dest = web_main.RESULTS_DIR / results_filename
+            dest.parent.mkdir(parents=True, exist_ok=True)
+            dest.write_text(_RESULTS_JSON)
+
+        monkeypatch.setattr(web_main._analysis, "process_run", _fake_process_run)
+        monkeypatch.setattr(web_main, "build_optics_readings", lambda *a, **k: None)
+
+        task = asyncio.create_task(web_main._simulate_run("basic_pcr.json"))
+        try:
+            for _ in range(100):
+                events = local_db.get_pending_events()
+                if any(e["event_type"] == "run_complete" for e in events):
+                    break
+                await asyncio.sleep(0.05)
+            else:
+                pytest.fail("run_complete event was not enqueued in time")
+
+            payload = next(
+                e for e in local_db.get_pending_events() if e["event_type"] == "run_complete"
+            )["payload"]
+            assert payload["duration_seconds"] is not None
+            assert payload["duration_seconds"] >= 0
+        finally:
+            # _simulate_run blocks on run_complete_ack -- let it finish cleanly.
+            web_main.run_complete_ack = True
+            await asyncio.wait_for(task, timeout=5)
 
 
 class TestEmitRunComplete:


### PR DESCRIPTION
Closes #449.

## What this does

`fact_run.duration_seconds` has existed in the Warehouse since the first fact migration and the loader reads it — but no Device code ever sent it, so it is NULL for every real Run.

That is not cosmetic. `v_homing_sample_correlated` labels a Homing Sample `idle` whenever its Run has no known end, so **every Homing Sample in the Warehouse is currently labelled idle** — plainly wrong, since the drawer homes at the start and end of every Run. Anyone reading homing health data today sees "no homing occurred during Runs" with no way to tell that is an artifact rather than a finding.

No Warehouse change is needed: the column and the loader already accept it, and the view starts working on its own once Devices report.

## Design notes

- **Not the on-screen stopwatch.** `start_time` / `elapsed_time` / `timer_running` are shared mutable UI state that other endpoints may reset (e.g. on abort), so the Run's recorded duration would depend on nobody else writing to it. This takes an independent `time.monotonic()` reading at Run start and again at completion.
- **Monotonic, not a wall-clock difference against `run_timestamp`**, so an NTP or DST adjustment mid-Run cannot skew it — and so the value used for *identity* (`run_timestamp`, which derives `run_id`) stays separate from the value used for *measurement*.
- **No SQLite migration**: the outbox stores the payload as a JSON blob, so this is purely additive. `run_timestamp` and all existing fields are unchanged, so `run_id` derivation is unaffected.
- Omitted rather than sent as null when unknown, mirroring `run_timestamp` / `tube_names`.

## Known gap, flagged for a decision

The duration covers **Run start through teardown**, not the assay alone — the emit site is in the `finally` block, after hardware deinit and the drawer opens, which can take 30–90s when the drawer has to re-home. That is the right window for Homing correlation (drawer homing happens there); it would be the wrong window for a future lid heater summary. Left as-is pending an explicit decision rather than changed silently.

## Testing

17 tests pass in `tests/unit/test_run_complete_event.py`. Written test-first.

The full suite was not run: it deletes `profiles/*.json` as a side effect, so only targeted files were exercised.

The simulated-run test builds its own optics stub and results JSON in `tmp_path` rather than reading `tests/fixtures/results/`, which is covered by the broad `results/` rule in `.gitignore` — those fixtures exist only on a developer machine, so any test reading them fails on a clean clone.

**Not covered by tests:** the real-device emit site in `state_run_assay.py`, which imports `RPi.GPIO` and cannot be exercised off-device. Verified by inspection only — the same treatment `run_timestamp` already gets in that file. First real proof comes from a device run.

## Relationship to #447

#447 (build identity) touches the same payload dict but is independent and targets a different base — it depends on `_BUILD_IDENTITY`, which exists only on `fix/rotate-display-at-x-startup`. Whichever merges second needs a trivial rebase. Neither blocks the other.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
