### PR TITLE
fix(run_complete): guard profile resolution against non-object bodies + cap the read

### DIFF
--- a/aquila_web/main.py
+++ b/aquila_web/main.py
@@ -87,12 +87,29 @@ def resolve_profile_dir() -> Path:
     return LOCAL_PROFILE_DIR
 
 def _read_profile_at(path: Path) -> dict | None:
-    """Parse a profile file, or None if it is unreadable / not JSON."""
+    """Parse a profile file into its JSON-object body, or None.
+
+    Returns None — never raises — for a file that is missing, over the size cap,
+    unreadable, not JSON, or JSON that is not an object. Two guarantees every
+    caller leans on:
+
+      - The cap is checked against the on-disk size BEFORE the read, so a
+        pathological file is refused without being parsed into memory (#417).
+        Both the path lookup and the name scan read through here, so neither can
+        spike memory on a huge file.
+      - A non-object body (a list, a bare string/number) resolves to None, so
+        callers that do ``body.get(...)`` — labels, rox — never hit an
+        AttributeError on a non-dict. ``_find_profile`` therefore only ever
+        yields a dict.
+    """
     try:
+        if path.stat().st_size > MAX_PROFILE_JSON_BYTES:
+            return None
         with path.open() as f:
-            return json.load(f)
+            data = json.load(f)
     except Exception:
         return None
+    return data if isinstance(data, dict) else None
 
 
 def _profile_by_path(profile_dir: Path, profile_ref: str) -> tuple[Path, dict] | None:
@@ -135,15 +152,13 @@ def _find_profile(profile_name: str | None) -> tuple[Path, dict] | None:
     if direct is not None:
         return direct
     for path in profile_dir.rglob("*.json"):
-        try:
-            with path.open() as f:
-                data = json.load(f)
-            title = data.get("title", path.stem)
-            profile_title = data.get("name", title)
-            if profile_title == profile_name or path.stem == profile_name or path.name == profile_name:
-                return path, data
-        except Exception:
+        data = _read_profile_at(path)
+        if data is None:
             continue
+        title = data.get("title", path.stem)
+        profile_title = data.get("name", title)
+        if profile_title == profile_name or path.stem == profile_name or path.name == profile_name:
+            return path, data
     return None
 
 def _load_profile_labels(profile_name: str | None) -> dict:
@@ -163,33 +178,18 @@ def _load_profile_json(profile_name: str | None) -> dict | None:
     """The run's profile body, for the run_complete snapshot (#417).
 
     Returns the parsed object so the loader stores it as JSONB without
-    re-parsing. NEVER raises: a missing, unreadable, oversize, or malformed
-    profile logs a warning and yields None, because a completed run must still
-    reach the cloud. Older devices simply omit the field, so the cloud already
-    tolerates its absence.
+    re-parsing. NEVER raises: ``_find_profile`` already yields only a JSON object
+    within the size cap — a missing, unreadable, oversize, or non-object profile
+    resolves to None there — so a completed run always reaches the cloud. Older
+    devices simply omit the field, so the cloud already tolerates its absence.
     """
     if not profile_name:
         return None
     found = _find_profile(profile_name)
     if found is None:
-        logger.warning("No profile file found for %r; sending profile_json: null", profile_name)
+        logger.warning("No usable profile for %r; sending profile_json: null", profile_name)
         return None
-    path, data = found
-    try:
-        size = path.stat().st_size
-    except OSError as e:
-        logger.warning("Could not stat profile %s: %s; sending profile_json: null", path, e)
-        return None
-    if size > MAX_PROFILE_JSON_BYTES:
-        logger.warning(
-            "Profile %s is %d bytes, over the %d-byte cap; sending profile_json: null",
-            path, size, MAX_PROFILE_JSON_BYTES,
-        )
-        return None
-    if not isinstance(data, dict):
-        logger.warning("Profile %s is not a JSON object; sending profile_json: null", path)
-        return None
-    return data
+    return found[1]
 
 def _resolve_profile_display_name(profile_ref: str | None) -> str:
     """Resolve a profile reference to its human-readable display name.

--- a/tests/unit/test_profile_json_event.py
+++ b/tests/unit/test_profile_json_event.py
@@ -241,3 +241,48 @@ class TestProfileResolutionStaysShared:
 
         assert web_main._profile_rox_unavailable("rox.json") is True
         assert web_main._profile_rox_unavailable("abba.json") is False
+
+    def test_non_object_body_does_not_crash_labels_or_rox(self, db_client):
+        """A valid-JSON-but-not-an-object profile must degrade, never raise.
+
+        Regression: the shared _find_profile handed the parsed body straight to
+        labels/rox, which do ``body.get(...)``. A list body -> ``list.get`` ->
+        AttributeError, raised from the run-processing path (main.py, right
+        before process_run) — so a malformed profile file could abort a run,
+        the opposite of "never fail a run over this". Both must fall back to
+        empty labels / rox False, exactly as profile_json falls back to None.
+        """
+        client, local_db, profile_dir = db_client
+        from aquila_web import main as web_main
+
+        _write_profile(profile_dir, "list.json", json.dumps([1, 2, 3]))
+
+        assert web_main._load_profile_labels("list.json") == {}
+        assert web_main._profile_rox_unavailable("list.json") is False
+        assert web_main._load_profile_json("list.json") is None
+
+    def test_oversize_profile_is_rejected_before_it_is_read(self, db_client, monkeypatch):
+        """The size cap must bound the READ, not just the payload.
+
+        The guard is on the on-disk size, so an over-cap file is refused before
+        json.load ever parses it into memory — otherwise the memory spike the
+        cap exists to prevent has already happened by the time we check.
+        """
+        client, local_db, profile_dir = db_client
+        from aquila_web import main as web_main
+
+        monkeypatch.setattr(web_main, "MAX_PROFILE_JSON_BYTES", 512)
+        _write_profile(
+            profile_dir, "huge.json", json.dumps(dict(_PROFILE_BODY, padding="x" * 2000))
+        )
+
+        loads: list[int] = []
+        real_load = json.load
+        monkeypatch.setattr(
+            web_main.json, "load", lambda f, *a, **k: (loads.append(1), real_load(f, *a, **k))[1]
+        )
+
+        # Call the resolver directly so no unrelated request-path json.load can
+        # muddy the assertion.
+        assert web_main._load_profile_json("huge.json") is None
+        assert loads == [], "an over-cap profile must be rejected before json.load reads it"


### PR DESCRIPTION
Follow-up on #439 (feat: attach `profile_json` on `run_complete`, issue #417), addressing two review findings. **Targets the feature branch** so it lands before #439 merges to main.

Both fixes centralize on one idea: make `_read_profile_at` the single, safe reader, so `_find_profile` can only ever return a dict within the size cap — and all three callers (`_load_profile_labels`, `_profile_rox_unavailable`, `_load_profile_json`) are safe by construction.

## 🟠 Non-object profile body could crash a run (regression)

The shared `_find_profile` returned `(path, data)` where `data` was whatever `json.load` produced — possibly a list or scalar. `_load_profile_json` guarded that with `isinstance(data, dict)`, but the two sibling callers did `body.get(...)` directly:

```python
labels = found[1].get("labels")                       # list.get -> AttributeError
return bool(found[1].get("rox_unavailable", False))   # same
```

Those two run in the post-run processing path (`main.py`, right before `_analysis.process_run`), **not** behind a `try/except` — so a valid-JSON-but-not-an-object profile file would raise and abort the run. Before the refactor, the name-scan swallowed non-objects via `try/except: continue` and degraded to `{}`/`False`; the refactor accidentally routed the crash-prone direct-path result through the same helper. This is the opposite of the feature's own "never fail a run over this" rule.

**Fix:** `_read_profile_at` now returns only dict bodies (non-object → `None`), so `_find_profile` only ever yields a dict.

## 🟡 The 256 KB cap didn't bound the read it exists to bound

`MAX_PROFILE_JSON_BYTES` was checked in `_load_profile_json` *after* `_find_profile` had already `json.load`-ed the entire file into memory — so the memory spike the cap is meant to prevent had already happened. **Fix:** the cap is now checked against the on-disk size (`path.stat()`) **before** the read, in `_read_profile_at`, so both the direct-path lookup and the name scan are bounded.

`_load_profile_json` drops its now-redundant size/`isinstance` re-checks (both guaranteed upstream).

## Tests
- `test_non_object_body_does_not_crash_labels_or_rox` — a list body → labels `{}`, rox `False`, `profile_json` `None`, never `AttributeError`.
- `test_oversize_profile_is_rejected_before_it_is_read` — spies on `json.load` to assert an over-cap file is refused before it is parsed.
- All existing profile/run tests still green (`103 passed` across the profile-resolution + `run_complete` suites).

Part of #417.

🤖 Generated with [Claude Code](https://claude.com/claude-code)