### PR TITLE
1b — Run provenance: stamp canonical profile hash into run_complete

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -41,8 +41,12 @@ A named PCR assay profile — a JSON file in `profiles/` that defines thermal st
 **Profile**
 The operator-facing name for a Protocol. The Run screen labels the protocol picker "Profile," and protocols are stored on-disk as `profiles/*.json`. "Profile" is the correct term at the UI and on-disk-artifact layer; "Protocol" is the canonical analytics/domain term for the same thing. There is no case where a Profile is not a Protocol — they are the same concept named for two audiences.
 
+**Managed Profile** / **Local Profile**
+The two profile classes after `acorn-fleet` ADR-0002. **Managed** profiles are team-pushed, S3-backed, delivered per-device via the IoT Profiles Shadow, and always read-only on the device — they replace the old **bundled** profiles and are **no longer baked into the image**. **Local** profiles are authored on-device and editable. On-disk this is `profiles/managed/` (formerly `profiles/bundled/`) vs `profiles/local/`.
+_Avoid_: "bundled" (stale — profiles no longer ship in the image); assuming a rebuild is needed to change a device's profiles (it is not — edit its shadow).
+
 **Run**
-A single execution of a Protocol on a Sentri, producing results for up to 4 Wells. A Run has a start time, end time, and status (completed, aborted). A Run is the unit of event emission — one `run_complete` event per Run.
+A single execution of a Protocol on a Sentri, producing results for up to 4 Wells. A Run has a start time, end time, and status (completed, aborted). A Run is the unit of event emission — one `run_complete` event per Run. The `run_complete` event records `{profile name, canonical content sha256}` so the exact recipe is reconstructable from versioned S3 (ADR-0002).
 
 ### Profile Authoring
 

--- a/aq_lib/profile_hash.py
+++ b/aq_lib/profile_hash.py
@@ -1,0 +1,25 @@
+"""Run-provenance fingerprint for a Profile.
+
+``canonical_profile_hash`` produces a stable content fingerprint of a whole
+Profile document, stamped into the ``run_complete`` event so a Run's exact
+recipe is reconstructable even after the Profile is later changed
+(issue #456 / acorn-fleet ADR-0002).
+
+Canonicalization (sorted keys, compact separators) makes the fingerprint
+immune to formatting/key-order noise while still changing on any real content
+change. The ``canon-v1:`` tag records which canonicalization scheme produced the
+digest, so a future revision stays distinguishable from old records.
+"""
+import hashlib
+import json
+
+_SCHEME = "canon-v1"
+
+
+def canonical_profile_hash(profile: dict) -> str:
+    """Return ``canon-v1:sha256:<hex>`` for a Profile document."""
+    canonical = json.dumps(
+        profile, sort_keys=True, separators=(",", ":"), ensure_ascii=False
+    )
+    digest = hashlib.sha256(canonical.encode("utf-8")).hexdigest()
+    return f"{_SCHEME}:sha256:{digest}"

--- a/aq_lib/state_requests.py
+++ b/aq_lib/state_requests.py
@@ -119,6 +119,7 @@ def emit_run_complete(
     results_path: str,
     run_timestamp: str | None = None,
     tube_names: list | None = None,
+    profile_sha256: str | None = None,
 ) -> None:
     url = f"{BACKEND_URL}/events/run_complete"
     payload = {"run_name": run_name, "profile": profile, "results_path": results_path}
@@ -126,6 +127,8 @@ def emit_run_complete(
         payload["run_timestamp"] = run_timestamp
     if tube_names is not None:
         payload["tube_names"] = tube_names
+    if profile_sha256 is not None:
+        payload["profile_sha256"] = profile_sha256
     try:
         requests.post(url, json=payload, timeout=5)
     except requests.exceptions.RequestException as e:

--- a/aquila_web/main.py
+++ b/aquila_web/main.py
@@ -954,6 +954,7 @@ class _RunCompleteEventRequest(BaseModel):
     results_path: Optional[str] = None
     run_timestamp: Optional[str] = None
     tube_names: Optional[list] = None
+    profile_sha256: Optional[str] = None
 
 
 @app.post("/events/run_complete")
@@ -966,17 +967,20 @@ async def events_run_complete(req: _RunCompleteEventRequest):
     # optics_readings event derive the same run_id cloud-side. Fall back to
     # enqueue time only for legacy callers that don't send one.
     run_timestamp = req.run_timestamp or _utc_now()
-    event_id = enqueue_event(
-        "run_complete",
-        {
-            "run_name": req.run_name,
-            "profile": req.profile,
-            "result": result,
-            "run_timestamp": run_timestamp,
-            "tube_names": _tube_names_by_well(req.tube_names),
-            "calls": _calls_from_file(results_file) if results_file else [],
-        },
-    )
+    payload = {
+        "run_name": req.run_name,
+        "profile": req.profile,
+        "result": result,
+        "run_timestamp": run_timestamp,
+        "tube_names": _tube_names_by_well(req.tube_names),
+        "calls": _calls_from_file(results_file) if results_file else [],
+    }
+    # Run provenance (#456): the canonical content hash of the Profile that ran,
+    # so the recipe is reconstructable from versioned S3 even after the Profile
+    # is later changed. Absent for legacy/sim callers that don't send one.
+    if req.profile_sha256 is not None:
+        payload["profile_sha256"] = req.profile_sha256
+    event_id = enqueue_event("run_complete", payload)
     # Summary call_evidence rides alongside run_complete on the same run_id (#297).
     _emit_call_evidence(results_file, run_timestamp)
     return {"ok": True, "event_id": event_id}

--- a/docs/prd/per-device-profiles.md
+++ b/docs/prd/per-device-profiles.md
@@ -1,0 +1,134 @@
+# PRD: Per-device Profiles via Device Shadow + S3 (decouple Profiles from releases)
+
+**Status:** Ready for agent
+**Author:** Nicole Cornell
+**Date:** 2026-09-09
+**Issue:** AcornGenetics/aquilla-main#455
+**Related:** acorn-fleet ADR-0002 (per-device profiles via Device Shadow + S3), acorn-fleet ADR-0001 (fleet management via AWS IoT Greengrass), aquilla-main ADR-001 (hostname-keyed device config — superseded for profiles)
+**Glossary:** CONTEXT.md — **Managed Profile**, **Local Profile**; acorn-fleet CONTEXT.md — **Profiles Shadow**, **Profile Assignment**, **Ring**, **Component**, **Deployment**, **Run**
+
+## Problem Statement
+
+Today, when we want a specific Sentri to have a specific set of assay Profiles, we have to change files that are baked into the container image (`profiles/bundled/` plus the hostname-keyed maps `device_profiles.json` / `profile_groups.json`) and then ship a whole new release — publishing a new `com.acorn.sentri` Component version and deploying it through every Ring. Getting one device the profiles it needs means pushing an update to the entire fleet.
+
+This is painful in three ways:
+
+- **Profiles are welded to the release.** Changing which Profiles a device has, or the contents of a Profile, both require an image rebuild + Greengrass deployment. There is no way to change one device without a fleet-wide release.
+- **The per-device config is set but not remotely reachable.** It can only change through a rebuild, and every device ships every other device's config. The drift is already visible: `profile_groups.json` contains hand-faked per-device groups (`"sn04 brewery"`, `"sn10 brewery"`, …) and per-device Profile files (`ABBA_sn005.json`, `verification_profile_sn10.json`).
+- **No run-level provenance.** A completed Run records only the Profile *name*, not the exact recipe contents that produced the result.
+
+We want to put specific Profiles on a specific device, and change them (assignment and contents) remotely, **without** a release and **without** version drift — the Component version must stay identical across a Ring, with Profiles the only per-device difference, while Profiles remain reachable for the team to change when needed.
+
+## Solution
+
+Move Profiles off the container image and make each device's Profile set a per-Thing attachment delivered through `acorn-fleet`, per ADR-0002 (`acorn-fleet/docs/adr/0002-per-device-profiles-via-device-shadow.md`).
+
+- **Managed Profile** bodies live as objects in the existing S3 `ArtifactsBucket` (versioning enabled).
+- Each Sentri gets a named **Profiles Shadow** (`.../shadow/name/profiles`) whose `desired` state is a flat list of S3 keys — that device's **Profile Assignment**.
+- A new on-device **sync agent** (its own small Greengrass Component) reconciles the local `managed/` Profile directory against the Shadow + S3, and reports back what it actually has.
+- Assigning a Profile to a device is one `UpdateThingShadow` call and affects only that device. The `com.acorn.sentri` Component version stays identical across a Ring.
+- **Managed Profiles** are always read-only on the device; **Local Profiles** (authored on-device in the builder) remain editable. The per-device edit-lock flag is removed.
+- Every Run stamps `{Profile name, canonical content sha256}` into the `run_complete` event, so the exact recipe is reconstructable from versioned S3 — provenance survives even though Profiles are now mutable.
+
+From the team's perspective: upload a Profile JSON to S3 once, then add its key to a device's Shadow. It appears on that device, and only that device, with no release. Editing a Profile is a re-upload; the device picks it up on its own.
+
+## User Stories
+
+1. As an Acorn engineer, I want to assign a specific Profile to one Sentri with a single Shadow edit, so that I don't have to ship a release to the whole fleet to change one device.
+2. As an Acorn engineer, I want to change the *contents* of a Profile remotely, so that fixing a recipe doesn't require an image rebuild.
+3. As an Acorn engineer, I want the `com.acorn.sentri` Component version to stay identical across a Ring, so that Profiles are the only thing that differs between devices and I never introduce version drift.
+4. As an Acorn engineer, I want to attach a Profile to several named devices by editing each of their Shadows, so that I can roll a new assay to exactly the devices that should have it.
+5. As an Acorn engineer, I want to detach a Profile from a device by removing its key from the Shadow, so that a device stops offering a Profile it should no longer run.
+6. As an Acorn engineer, I want to upload a Profile body to S3 once and point many devices' Shadows at the same key, so that shared Profiles aren't duplicated per device.
+7. As an Acorn engineer, I want to assign Profiles with plain AWS CLI/console for now, so that we can ship this without first building a UI.
+8. As an Acorn engineer, I want to omit the sha256 in the Shadow and still have edits picked up, so that I don't have to compute and paste hashes by hand.
+9. As an Acorn engineer, I want the device to report back (in the Shadow's `reported`) which Profiles it actually has, so that I can confirm an assignment landed and spot drift via Fleet Indexing.
+10. As an on-device operator, I want Managed Profiles assigned to my Sentri to appear in the Profile picker, so that I can select and run them.
+11. As an on-device operator, I want Managed Profiles to be read-only, so that I can't accidentally alter a controlled assay recipe.
+12. As an on-device operator, I want to keep authoring and editing my own Local Profiles, so that on-device experimentation is unaffected by the new managed-delivery path.
+13. As an on-device operator, I want a Run I've already started to keep running unaffected if a Profile syncs mid-run, so that a remote change never interrupts an assay in progress.
+14. As an on-device operator, I want the device to keep running its last-known Profiles when it's offline, so that loss of connectivity never stops me from running assays.
+15. As an on-device operator, I want a device that has never synced (fresh or factory-reset, offline) to clearly show "No profiles available," so that I'm not misled into thinking it's broken versus simply unprovisioned.
+16. As an on-device operator, I want a newly assigned Profile to appear without any manual "apply" step, so that using it is frictionless.
+17. As an on-device operator, I want to select a Managed Profile and start a Run that executes its exact thermal steps, so that the new delivery path runs assays identically to before.
+18. As a quality/analytics user, I want each Run to record the exact Profile contents (by canonical hash) that produced it, so that I can prove which recipe generated a given result even after the Profile is later changed.
+19. As a quality/analytics user, I want the exact recipe reconstructable from S3 by the recorded hash, so that provenance lookups don't require the Profile body to be stored on the device or in every Run record.
+20. As a quality/analytics user, I want Runs that used a Local Profile to also be reconstructable, so that provenance has no gap for on-device-authored Profiles.
+21. As an Acorn engineer, I want an edit made in place (same S3 key, new contents) to be detected and re-pulled by the device, so that I can fix a Profile without renaming files.
+22. As an Acorn engineer, I want the sync to be resumable and idempotent, so that a partial or interrupted sync converges to the assigned set on the next run without manual cleanup.
+23. As an Acorn engineer, I want Local Profiles to be untouched by the sync agent, so that reconciling Managed Profiles never deletes or overwrites an operator's own work.
+24. As an Acorn engineer, I want to promote a Component release to a Ring without it resetting or requiring any change to Profile Assignments, so that release cadence and Profile management are fully independent.
+25. As a platform maintainer, I want the baked profile path (image COPY, entrypoint copy, hostname filter) removed once the new path is proven, so that there's a single source of truth for a device's Profiles.
+
+## Implementation Decisions
+
+**Delivery model (per ADR-0002).**
+- Managed Profile bodies are stored as objects in the S3 `ArtifactsBucket`; the device's Token Exchange Role already grants read.
+- Per-device assignment lives in a named Device Shadow `profiles` whose `desired.profiles` is a **flat list of `{ key }`** entries (sha256 optional). No group indirection.
+- A new device-side **sync agent** runs as its own small Greengrass Component. It reads `desired` (over Greengrass IPC / ShadowManager local cache), reconciles the local Managed directory against S3, and writes the applied set into `reported`.
+
+**On-device directory model.**
+- `profiles/bundled/` is renamed conceptually to **`managed/`**; the sync agent owns this directory. `profiles/local/` is unchanged and never touched by the agent.
+- The Profile listing endpoint continues to list whatever is in `managed/` + `local/`. The baked hostname filter (`resolve_device_profiles`) and the two config files (`device_profiles.json`, `profile_groups.json`) are removed.
+
+**Profile classes.**
+- **Managed Profiles**: team-pushed, S3-backed, delivered via the Shadow, **always read-only** on every device. Because they can't be edited on-device, their on-device bytes always equal S3.
+- **Local Profiles**: authored on-device, always editable, never in S3.
+- The per-device `profile_editing_disabled` flag is dropped; the lock is now a property of the class, not the device.
+
+**Reconcile behavior (functional core).**
+- Reconcile is a pure decision over `(desired keys, current managed-dir state, a fetch capability)` producing writes / deletes / reported state. IO (Shadow read, S3 fetch, file writes, S3 uploads) is injected, so behavior is testable without network or IPC.
+- Keys present in `desired` but missing/changed locally are fetched from S3; keys no longer in `desired` are deleted from `managed/`; `local/` is never considered.
+- **Edit detection**: in-place edits (same key, new contents) are detected via S3 object versioning (the object's version marker), not a hand-maintained hash. sha256 in the Shadow is advisory: if present and mismatched, the agent surfaces the mismatch in `reported` rather than silently dropping the Profile.
+- **Idempotent/resumable**: rerunning reconcile converges to the assigned set.
+
+**Offline / bootstrap.**
+- Managed bodies are cached persistently in the `/opt/aquila/profiles` volume; offline = keep running the last-synced set.
+- A device with an empty Managed cache that has never synced presents "No profiles available" (fail-closed). No baked fallback Profile set.
+
+**Run provenance.**
+- At Run start, compute a **canonical whole-document** hash of the loaded Profile: stable JSON serialization (sorted keys, fixed separators) then SHA-256, stored tagged as `canon-v1:sha256:…`. Computed once at load so it reflects the exact bytes that ran.
+- Thread `{ profile_name, profile_sha256 }` into the `run_complete` event; it flows through the existing local outbox → Sync → `acorn-analytics` pipeline. The event contract gains an optional `profile_sha256` field (legacy fallback when absent, mirroring how `run_timestamp` was added).
+- For Managed Profiles, `{name, sha}` + versioned S3 is sufficient to reconstruct the recipe. For **Local Profiles**, the device captures the Profile body up to the versioned S3 bucket by sha as part of the Run sync, so reconstruction is uniform across both classes.
+- Reconstruction of the exact recipe from S3 by sha is a read performed by `acorn-internal-app`/analytics consumers; the device stores only the reference.
+
+**acorn-fleet CDK deltas (dependency; see ADR-0002).**
+- Extend ShadowManager sync configuration to include `namedShadows: ['profiles']`.
+- Add `'profiles'` to `INDEXED_NAMED_SHADOWS` so assignments are queryable in Fleet Indexing.
+- Enable **versioning** on the `ArtifactsBucket`; ensure lifecycle rules do not expunge versions still referenced by Run records.
+- Per-Thing Shadow read/write is already covered by the existing device IoT policy and Token Exchange Role — no new policy expected.
+
+**Deferred.**
+- An `acorn-internal-app` "assign Profiles to device" UI (upload + assignment + who-has-what view) is a follow-up; v1 authoring is raw AWS CLI/console.
+
+## Testing Decisions
+
+Good tests here assert **external behavior at the highest honest seam** — what a device offers and runs, what the listing endpoint returns, what the `run_complete` event carries, and what the CDK template declares — never internal call sequences or IPC plumbing. IO is injected so tests need no network, no AWS, and no hardware.
+
+**Modules and seams to test (aquilla-main unless noted):**
+
+1. **Sync-agent reconcile (new unit seam, functional core).** Test `reconcile(desired_keys, current_managed_state, fetch) → {writes, deletes, reported}` with an injected fake fetcher and a temp directory. Cases: add a new key; detect an in-place edit (changed version) and re-pull; delete a key removed from `desired`; never touch `local/`; empty `desired` → empty managed set; unreadable Shadow → keep current cache (offline); advisory sha mismatch surfaces in `reported`; idempotent rerun. Prior art: the unit-test style in `unit_tests/` (e.g. `test_device_profile_filtering.py`, `test_enroll.py`).
+
+2. **Profile listing (existing contract seam).** `GET /profiles` lists `managed/` + `local/`, with Managed Profiles marked read-only. Prior art: `tests/contract/test_bundled_profiles.py`. The old per-device filtering / edit-lock tests (`tests/contract/test_profile_device_filtering.py`, `unit_tests/test_device_profile_filtering.py`, `unit_tests/test_profile_editing_lock.py`) are **retired or rewritten** — the baked hostname filter and per-device flag no longer exist; the new invariant is "Managed = always locked, no per-device filtering."
+
+3. **Run provenance (new unit seam + existing contract seam).** Unit-test the pure `canonical_profile_hash(json) → "canon-v1:sha256:…"` — same contents in any key order/formatting yield the same hash; any real content change changes it. Contract-test that `run_complete` carries `profile_sha256` for the selected Profile, with legacy fallback when absent. Prior art: `unit_tests/test_estimated_completion.py` / `test_profile_assembly.py` (pure logic), `tests/contract/test_history_endpoints.py` (run/event contract). Local-Profile capture-to-S3-by-sha is asserted at the emit seam with an injected uploader.
+
+4. **CDK template (existing seam, acorn-fleet).** Fine-grained template assertions: ShadowManager config includes `namedShadows: ['profiles']`; `INDEXED_NAMED_SHADOWS` includes `'profiles'`; `ArtifactsBucket` has versioning enabled. Prior art: `acorn-fleet/tests/deploy-stack.test.ts`, `registry-stack.test.ts`, `device-access-stack.test.ts`.
+
+5. **Managed Profile still runs (existing run seam, simulation mode) — the key regression guard.** Drive the real Run flow in `RUN_MODE` simulation against a Profile placed in `managed/` exactly as the sync agent would produce it (fixture reuses seam 1 output): the Profile appears in `GET /profiles`; it is selectable via `POST /profile/select`; editing it is rejected (Managed = locked); the Run loads that Profile's steps and executes to completion; and `run_complete` fires with `{name, canonical sha256}` matching that exact Profile. Prior art: `tests/contract/test_dev_update_simulation.py` and the `_simulate_run` path. This proves the new delivery path is listable → selectable → **runnable** → provenance-stamped, end to end.
+
+## Out of Scope
+
+- The `acorn-internal-app` UI for assigning Profiles / uploading bodies / viewing who-has-what (deferred; v1 is CLI/console).
+- Group / profile-group abstractions — v1 is a flat per-device key list. Groups can be added later without changing the device agent (it always receives a resolved list).
+- Content-addressed S3 keys (sha as filename) — rejected in favor of mutable keys + S3 versioning so operators need not compute hashes.
+- Any change to how a Run executes a selected Profile's steps (the thermal engine is unchanged).
+- Greengrass per-Thing *deployments* or `configurationUpdate.merge` for Profiles — rejected; Profiles are device state, not deployment state.
+- Migrating historical Runs to backfill `profile_sha256` (new events only; legacy rows keep name-only).
+
+## Further Notes
+
+- This PRD depends on the `acorn-fleet` CDK deltas landing (ShadowManager named-shadow sync, Fleet Indexing, S3 versioning). See `acorn-fleet/docs/adr/0002-per-device-profiles-via-device-shadow.md`.
+- Rollout is staged and reversible: build the sync agent, prove it on one device joined to the `sandbox` Ring alongside the still-baked Profiles, then cut over and remove the baked path (`docker/Dockerfile.api` `COPY profiles/bundled/`, the `cp -f` loop in `docker/entrypoint.sh`, and `device_profiles.json` / `profile_groups.json` + `resolve_device_profiles`).
+- Provenance is only as durable as S3 retention: versioning must stay enabled and lifecycle rules must not delete versions still referenced by Run records.
+- Terminology: "bundled" is retired in favor of **Managed Profile**; glossary updated in `acorn-fleet/CONTEXT.md` and `aquilla-main/CONTEXT.md`.

--- a/state_run_assay.py
+++ b/state_run_assay.py
@@ -21,6 +21,7 @@ from aq_lib.thermal_parser import thermal_parser
 from aq_lib.config_module import Config
 from aq_lib.utils import load_json
 from aq_lib.utils import LogFileName
+from aq_lib.profile_hash import canonical_profile_hash
 from aq_lib.utils import LOGGING_CONFIG
 from aq_curve.plot_utils import generate_optics_plot
 from aq_lib.regulate import lid_heater_worker
@@ -86,6 +87,7 @@ class AssayInterface():
         self.meer.setTd(4)
 
         self.thermal_profile = ""
+        self._profile_sha256 = None
 
     def executor( self ):
         logger.info( "Execution thread started." )
@@ -217,7 +219,14 @@ class AssayInterface():
         logger.info( "Optics log: %s", optics_log )
         logger.info("Optics log absolute: %s", Path(optics_log).resolve())
 
-        steps = load_json( self.thermal_profile )["steps"]
+        # Load the whole Profile document once at run start. Run provenance
+        # (#456): hash the exact bytes we run so the record binds to the recipe
+        # that produced the result, even if the Profile file is overwritten a
+        # moment later (e.g. a managed-profile sync). Captured once, like
+        # run_timestamp.
+        profile_doc = load_json( self.thermal_profile )
+        self._profile_sha256 = canonical_profile_hash( profile_doc )
+        steps = profile_doc["steps"]
         # Planned optical passes for the whole run, from the profile — so optics
         # expected_lines reflects the intended total even on an early abort (#288).
         self._planned_optics_passes = count_optics_passes(steps)
@@ -318,6 +327,7 @@ class AssayInterface():
                     self.run_name, profile_name, str(results_json),
                     run_timestamp=self.run_timestamp,
                     tube_names=tube_names,
+                    profile_sha256=self._profile_sha256,
                 )
                 # Capture the exact optics file just consumed onto the same
                 # outbox, sharing run_timestamp (#288).

--- a/tests/unit/test_run_complete_event.py
+++ b/tests/unit/test_run_complete_event.py
@@ -87,6 +87,33 @@ class TestRunCompleteEndpoint:
         payload = local_db.get_pending_events()[0]["payload"]
         assert payload.get("run_timestamp")
 
+    def test_payload_carries_supplied_profile_sha256(self, db_client):
+        # Run provenance (#456): the device sends the canonical content hash of
+        # the Profile it ran, so the recipe is reconstructable from versioned S3
+        # even after the Profile is later changed.
+        client, local_db = db_client
+        client.post("/events/run_complete", json={
+            "run_name": "Run 1",
+            "profile": "basic_pcr.json",
+            "results_path": str(DETECTED_RESULTS),
+            "profile_sha256": "canon-v1:sha256:" + "a" * 64,
+        })
+        payload = local_db.get_pending_events()[0]["payload"]
+        assert payload["profile_sha256"] == "canon-v1:sha256:" + "a" * 64
+
+    def test_payload_omits_profile_sha256_when_absent(self, db_client):
+        # Legacy callers (and sim) that don't send a hash still succeed; the
+        # field is simply absent rather than an error.
+        client, local_db = db_client
+        response = client.post("/events/run_complete", json={
+            "run_name": "Run 1",
+            "profile": "basic_pcr.json",
+            "results_path": str(DETECTED_RESULTS),
+        })
+        assert response.status_code == 200
+        payload = local_db.get_pending_events()[0]["payload"]
+        assert "profile_sha256" not in payload
+
     def test_event_payload_includes_non_empty_result(self, db_client):
         client, local_db = db_client
         client.post("/events/run_complete", json={
@@ -194,6 +221,41 @@ class TestEmitRunComplete:
             run_timestamp="2026-07-02T14:03:11Z",
         )
         assert calls[0]["json"]["run_timestamp"] == "2026-07-02T14:03:11Z"
+
+    def test_forwards_profile_sha256(self, monkeypatch):
+        import aq_lib.state_requests as sr
+
+        calls = []
+
+        class _FakeResponse:
+            status_code = 200
+
+        def fake_post(url, json=None, timeout=None):
+            calls.append({"url": url, "json": json})
+            return _FakeResponse()
+
+        monkeypatch.setattr("aq_lib.state_requests.requests.post", fake_post)
+        sr.emit_run_complete(
+            "Run 1", "basic_pcr.json", "/logs/results/run1.json",
+            profile_sha256="canon-v1:sha256:" + "a" * 64,
+        )
+        assert calls[0]["json"]["profile_sha256"] == "canon-v1:sha256:" + "a" * 64
+
+    def test_omits_profile_sha256_when_absent(self, monkeypatch):
+        import aq_lib.state_requests as sr
+
+        calls = []
+
+        class _FakeResponse:
+            status_code = 200
+
+        def fake_post(url, json=None, timeout=None):
+            calls.append({"url": url, "json": json})
+            return _FakeResponse()
+
+        monkeypatch.setattr("aq_lib.state_requests.requests.post", fake_post)
+        sr.emit_run_complete("Run 1", "basic_pcr.json", "/logs/results/run1.json")
+        assert "profile_sha256" not in calls[0]["json"]
 
     def test_forwards_tube_names_snapshot(self, monkeypatch):
         import aq_lib.state_requests as sr

--- a/unit_tests/test_profile_hash.py
+++ b/unit_tests/test_profile_hash.py
@@ -1,0 +1,45 @@
+"""
+Unit tests for aq_lib/profile_hash.py — canonical_profile_hash(profile) -> str.
+
+Pure logic, no hardware or network. Produces the run-provenance fingerprint
+stamped into the ``run_complete`` event so a Run's exact recipe is reconstructable
+even after the Profile is later changed (issue #456 / acorn-fleet ADR-0002).
+Marked ``unit``.
+"""
+import re
+
+import pytest
+
+from aq_lib.profile_hash import canonical_profile_hash
+
+pytestmark = pytest.mark.unit
+
+
+def _profile():
+    return {
+        "title": "Beer Spoilers - Bacteria",
+        "steps": [{"setpoint": 94, "duration": 240}],
+        "labels": {"fam": "FAM", "rox": "ROX"},
+    }
+
+
+def test_hash_is_canon_v1_sha256_tagged():
+    """The fingerprint is a canon-v1-tagged SHA-256 hex digest."""
+    digest = canonical_profile_hash(_profile())
+    assert re.fullmatch(r"canon-v1:sha256:[0-9a-f]{64}", digest)
+
+
+def test_hash_is_invariant_to_key_order():
+    """Reordering keys (e.g. an editor re-serialising) does not change the hash."""
+    a = {"title": "X", "steps": [{"setpoint": 94, "duration": 240}]}
+    b = {"steps": [{"duration": 240, "setpoint": 94}], "title": "X"}
+    assert canonical_profile_hash(a) == canonical_profile_hash(b)
+
+
+def test_hash_changes_when_any_field_changes():
+    """Any real content change — including outside ``steps`` — flips the hash."""
+    base = _profile()
+    changed_setpoint = {**base, "steps": [{"setpoint": 95, "duration": 240}]}
+    changed_label = {**base, "labels": {"fam": "FAM", "rox": "HEX"}}
+    assert canonical_profile_hash(base) != canonical_profile_hash(changed_setpoint)
+    assert canonical_profile_hash(base) != canonical_profile_hash(changed_label)


### PR DESCRIPTION
## What this does

Implements **1b — Run provenance** for the per-device profiles work (PRD #455, acorn-fleet ADR-0002). Each Run now records `{profile name, canonical content sha256}` so a Run's exact recipe is reconstructable from versioned S3 even after the Profile is later changed.

Built test-first (RED→GREEN per behavior).

### Behaviors covered
1. `aq_lib/profile_hash.canonical_profile_hash` — whole-document canonical SHA-256, tagged `canon-v1`; invariant to key order / formatting; changes on any real content change.
2. `emit_run_complete` forwards `profile_sha256` when given, omits when absent.
3. `POST /events/run_complete` enqueues `profile_sha256`; omission still succeeds (legacy/sim callers).

### Production wiring
`state_run_assay` computes the hash **once at run start** from the loaded bytes, so it binds to what actually ran even if the file is overwritten a moment later (e.g. a managed-profile sync).

### Also included (per request)
- `docs/prd/per-device-profiles.md` — the feature PRD.
- `CONTEXT.md` — glossary entries for **Managed / Local Profile** and the `run_complete` provenance note.

## Testing
- 7 new tests green (`unit_tests/test_profile_hash.py`, `tests/unit/test_run_complete_event.py`).
- Full non-e2e suite: **975→982 passing, 0 new failures**. The 51 failures present are pre-existing on the base branch (test-isolation leakage in the hardware + background_sync suites; e2e needs `playwright`) and are unrelated to this change.

The full-sim end-to-end assertion is intentionally **deferred to 3b**.

## Notes
- Targets `feat/greengrass-migration` as required.
- `Closes #456` — heads up: GitHub only auto-closes on merge to the **default** branch, so merging into `feat/greengrass-migration` will link but not auto-close the issue; close #456 manually or it closes when greengrass lands on main.

Closes #456

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012hUuWrV3xi3FCn7MyFCztf
