### PR TITLE
3b — Tracer bullet: deliver Managed Profiles via sync agent, list + run them

### DIFF
--- a/aquila_web/main.py
+++ b/aquila_web/main.py
@@ -4,6 +4,7 @@ from aquila_web.local_db import enqueue_event, init_local_db, _utc_now
 from aquila_web.optics_readings import build_optics_readings, count_data_lines
 from aq_curve.curve import ALGO_VERSION
 from aquila_web.profile_assembly import assemble_steps, validate_stages
+from aq_lib.profile_hash import canonical_profile_hash
 from fastapi.responses import FileResponse, RedirectResponse, JSONResponse
 from fastapi.staticfiles import StaticFiles
 from pathlib import Path
@@ -117,6 +118,39 @@ def _profile_rox_unavailable(profile_name: str | None) -> bool:
         except Exception:
             continue
     return False
+
+def _profile_sha256_for(profile_ref: str | None) -> "str | None":
+    """Canonical content hash of the Profile identified by ``profile_ref``.
+
+    Run provenance (#456/#457): the recipe recorded for a Run must be the exact
+    bytes of the Profile that ran. The simulate path has only the selected
+    reference, so it resolves the Profile — a relative-path id like
+    ``managed/X.json`` or a name/stem/filename — and hashes the whole document.
+    Returns None if unresolvable so the ``run_complete`` stamp is simply omitted
+    (legacy fallback), never raising into the run path.
+    """
+    if not profile_ref:
+        return None
+    profile_dir = resolve_profile_dir()
+    if not profile_dir.exists():
+        return None
+    candidate = profile_dir / profile_ref
+    if candidate.is_file():
+        try:
+            return canonical_profile_hash(json.loads(candidate.read_text()))
+        except Exception:
+            return None
+    for path in profile_dir.rglob("*.json"):
+        try:
+            data = json.loads(path.read_text())
+        except Exception:
+            continue
+        title = data.get("title", path.stem)
+        profile_title = data.get("name", title)
+        if profile_title == profile_ref or path.stem == profile_ref or path.name == profile_ref:
+            return canonical_profile_hash(data)
+    return None
+
 
 def _resolve_profile_display_name(profile_ref: str | None) -> str:
     """Resolve a profile reference to its human-readable display name.
@@ -732,17 +766,20 @@ async def _simulate_run(profile_name: str) -> None:
     })
     _save_history(history)
     init_local_db()
-    enqueue_event(
-        "run_complete",
-        {
-            "run_name": run_name,
-            "profile": profile_name,
-            "result": detected_summary,
-            "run_timestamp": run_timestamp,
-            "tube_names": _tube_names_by_well(),
-            "calls": _calls_from_file(results_file),
-        },
-    )
+    sim_payload = {
+        "run_name": run_name,
+        "profile": profile_name,
+        "result": detected_summary,
+        "run_timestamp": run_timestamp,
+        "tube_names": _tube_names_by_well(),
+        "calls": _calls_from_file(results_file),
+    }
+    # Run provenance (#456/#457): stamp the canonical hash of the exact Profile
+    # that ran (resolved from its selected reference), matching the hardware path.
+    sim_sha256 = _profile_sha256_for(profile_name)
+    if sim_sha256 is not None:
+        sim_payload["profile_sha256"] = sim_sha256
+    enqueue_event("run_complete", sim_payload)
 
     # Summary call_evidence rides alongside run_complete on the same run_id (#297).
     _emit_call_evidence(results_file, run_timestamp)
@@ -1582,12 +1619,18 @@ async def list_profiles():
     # Collect local filenames first for deduplication — local takes priority over bundled
     local_filenames: set[str] = {p.name for p in (profile_dir / "local").glob("*.json")} if (profile_dir / "local").exists() else set()
 
-    # local/ first, then bundled/, then anything flat (dev/legacy)
+    # local/ first, then managed/ + bundled/, then anything flat (dev/legacy)
     search_paths = []
     local_dir = profile_dir / "local"
+    managed_dir = profile_dir / "managed"
     bundled_dir = profile_dir / "bundled"
     if local_dir.exists():
         search_paths.extend(sorted(local_dir.glob("*.json")))
+    # Managed Profiles (ADR-0002): team-pushed, S3-backed, delivered per-device
+    # via the profiles shadow. Read-only like bundled, but not hostname-filtered
+    # (the shadow already scopes them to this device).
+    if managed_dir.exists():
+        search_paths.extend(sorted(managed_dir.glob("*.json")))
     if bundled_dir.exists():
         search_paths.extend(sorted(bundled_dir.glob("*.json")))
     # fallback: flat files not in either subdir (dev simulate or pre-migration)
@@ -1595,12 +1638,16 @@ async def list_profiles():
 
     for path in search_paths:
         is_bundled = "bundled" in path.parts
+        is_managed = "managed" in path.parts
+        # Managed and bundled are both read-only; local wins over both.
+        is_readonly = is_bundled or is_managed
 
-        # Deduplicate: skip bundled file if a local version exists with same filename
-        if is_bundled and path.name in local_filenames:
+        # Deduplicate: skip a read-only file if a local version exists
+        if is_readonly and path.name in local_filenames:
             continue
 
-        # Device allowlist: only filter bundled profiles
+        # Device allowlist filters only bundled profiles; managed profiles are
+        # already scoped to this device by its profiles shadow.
         if allowed is not None and is_bundled and path.name not in allowed:
             continue
 
@@ -1620,7 +1667,7 @@ async def list_profiles():
                 "id": str(path.relative_to(profile_dir)),
                 "name": data.get("name"),
                 "label": data.get("name"),
-                "bundled": is_bundled,
+                "bundled": is_readonly,
                 "structured": "stages" in data,
                 "createdAt": created_at,
                 "modifiedAt": modified_at,
@@ -1633,7 +1680,7 @@ async def list_profiles():
                 "id": str(path.relative_to(profile_dir)),
                 "name": data.get("title", path.stem),
                 "label": data.get("title", path.stem),
-                "bundled": is_bundled,
+                "bundled": is_readonly,
                 "structured": "stages" in data,
                 "createdAt": created_at,
                 "modifiedAt": modified_at,
@@ -1765,8 +1812,8 @@ async def save_profile(payload: ProfileSave):
         profile_path = profile_dir / payload.profile_id
         if not profile_path.name.endswith(".json"):
             profile_path = profile_path.with_suffix(".json")
-        if "bundled" in profile_path.parts:
-            raise HTTPException(status_code=403, detail="Bundled profiles are read-only.")
+        if "bundled" in profile_path.parts or "managed" in profile_path.parts:
+            raise HTTPException(status_code=403, detail="Managed profiles are read-only.")
 
     base_profile = None
     if profile_path and profile_path.exists():

--- a/aquila_web/profile_sync.py
+++ b/aquila_web/profile_sync.py
@@ -1,0 +1,38 @@
+"""On-device Managed Profile sync — the decision core of the sync agent.
+
+``reconcile`` takes the per-device Profile Assignment (the list of S3 keys from
+the ``profiles`` Device Shadow) plus an injected ``fetch`` (bytes for a key) and
+brings the local ``managed/`` directory in line with it (acorn-fleet ADR-0002).
+
+IO is injected so the logic is testable without Greengrass IPC or the network.
+This is the *add* path only: a desired key with no local file is fetched and
+written. Delete / edit-detection / reported state are added in 4b.
+"""
+from pathlib import Path
+from typing import Callable
+
+
+def _filename(key: str) -> str:
+    """The on-disk basename for an S3 key (e.g. ``profiles/X.json`` -> ``X.json``)."""
+    return key.rsplit("/", 1)[-1]
+
+
+def reconcile(
+    desired: list[dict],
+    managed_dir: Path,
+    fetch: Callable[[str], bytes],
+) -> None:
+    """Reconcile ``managed_dir`` against the desired Profile Assignment.
+
+    Each entry in ``desired`` is a dict with at least a ``key`` (the S3 object
+    key). A key whose file is not already present is fetched and written.
+    ``local/`` profiles are not represented here and are never touched.
+    """
+    managed_dir = Path(managed_dir)
+    managed_dir.mkdir(parents=True, exist_ok=True)
+
+    for entry in desired:
+        key = entry["key"]
+        dest = managed_dir / _filename(key)
+        if not dest.exists():
+            dest.write_bytes(fetch(key))

--- a/tests/contract/test_managed_profiles.py
+++ b/tests/contract/test_managed_profiles.py
@@ -1,0 +1,102 @@
+"""
+test_managed_profiles.py
+========================
+Contract tests for Managed Profiles (acorn-fleet ADR-0002, issue #457).
+
+A Managed Profile lives in <profiles_dir>/managed/ (populated by the on-device
+sync agent from the `profiles` Device Shadow + S3). It must:
+  - appear in GET /profiles, and
+  - be read-only (editing it is rejected), like the legacy bundled/ profiles.
+
+Mirrors test_bundled_profiles.py's client fixture (repo profiles/ dir).
+"""
+import json
+import os
+import sys
+from pathlib import Path
+
+import pytest
+from fastapi.testclient import TestClient
+
+REPO_ROOT = Path(__file__).resolve().parent
+
+MANAGED_NAME = "pytest_managed_test_profile"
+MANAGED_FILENAME = f"{MANAGED_NAME}.json"
+MANAGED_CONTENT = {
+    "title": MANAGED_NAME,
+    "post_in_gui": "True",
+    "steps": [
+        {"disable": 0, "duration": 1, "description": "Start"},
+        {"setpoint": 37, "duration": 5, "description": "Hold 37 C"},
+    ],
+}
+
+
+@pytest.fixture(scope="module")
+def client():
+    os.environ.setdefault("AQ_SRC_BASEDIR", str(REPO_ROOT))
+    sys.path.insert(0, str(REPO_ROOT))
+    sys.path.insert(0, str(REPO_ROOT / "aquila_web"))
+    from aquila_web.main import app  # noqa: PLC0415
+    with TestClient(app) as c:
+        yield c
+
+
+@pytest.fixture(scope="module")
+def managed_test_profile(client):
+    from aquila_web import main as web_main
+    managed_dir = web_main.profile_dir / "managed"
+    managed_dir.mkdir(parents=True, exist_ok=True)
+    profile_path = managed_dir / MANAGED_FILENAME
+    profile_path.write_text(json.dumps(MANAGED_CONTENT, indent=2))
+    yield profile_path
+    profile_path.unlink(missing_ok=True)
+
+
+def test_managed_profile_appears_in_listing(client, managed_test_profile):
+    resp = client.get("/profiles")
+    assert resp.status_code == 200
+    profiles = resp.json()
+    ids = [p.get("id", "") for p in profiles]
+    names = [p.get("name", "") for p in profiles]
+    assert MANAGED_NAME in names or any(MANAGED_NAME in str(i) for i in ids), (
+        f"Managed profile not found in /profiles.\nids: {ids}\nnames: {names}"
+    )
+
+
+def _managed_entry(client):
+    profiles = client.get("/profiles").json()
+    return next(
+        (p for p in profiles
+         if MANAGED_NAME in str(p.get("id", "")) or MANAGED_NAME in str(p.get("name", ""))),
+        None,
+    )
+
+
+def test_managed_profile_is_marked_read_only(client, managed_test_profile):
+    """Managed Profiles are read-only; the listing flags them so the UI locks
+    editing (same treatment as legacy bundled profiles)."""
+    entry = _managed_entry(client)
+    assert entry is not None
+    assert entry.get("bundled") is True
+
+
+def test_editing_a_managed_profile_is_rejected(client, managed_test_profile):
+    """Saving over a Managed Profile is forbidden (403) — they are controlled,
+    S3-backed artifacts, not on-device editable."""
+    resp = client.post("/profiles", json={
+        "profile_id": f"managed/{MANAGED_FILENAME}",
+        "name": MANAGED_NAME,
+        "steps": [{"setpoint": 99, "duration": 1}],
+    })
+    assert resp.status_code == 403
+
+
+def test_managed_profile_is_selectable_for_a_run(client, managed_test_profile):
+    """A Managed Profile can be selected to run — the delivery path feeds the
+    run selection just like any other profile."""
+    resp = client.post("/profile/select", json={"profile": f"managed/{MANAGED_FILENAME}"})
+    assert resp.status_code == 200
+    assert resp.json().get("ok") is True
+    status = client.get("/button_status").json()
+    assert MANAGED_NAME in str(status.get("profile", ""))

--- a/tests/unit/test_managed_run_provenance.py
+++ b/tests/unit/test_managed_run_provenance.py
@@ -1,0 +1,54 @@
+"""
+Unit tests for the run-provenance resolver used by the run paths (issue #457).
+
+A Run records the canonical content hash of the Profile it ran. The hardware
+path (state_run_assay, 1b) hashes the doc it loads directly; the simulate path
+only has the selected profile *reference*, so it resolves the profile to its
+bytes via ``_profile_sha256_for`` and hashes them. This proves the recipe
+recorded for a run is the exact bytes of the profile that was selected —
+including Managed Profiles delivered into ``managed/``.
+"""
+import json
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+for _hw in ("serial", "serial.tools", "serial.tools.list_ports"):
+    sys.modules.setdefault(_hw, MagicMock())
+sys.modules.setdefault("aq_lib.config_module", MagicMock())
+
+from aq_lib.profile_hash import canonical_profile_hash  # noqa: E402
+
+pytestmark = pytest.mark.unit
+
+
+@pytest.fixture
+def managed_profile():
+    """A Managed Profile on disk in the resolved profile dir; cleaned up after."""
+    from aquila_web import main as web_main
+    content = {"title": "MgdRunProv", "post_in_gui": "True",
+               "steps": [{"setpoint": 95, "duration": 1}]}
+    managed = web_main.resolve_profile_dir() / "managed"
+    managed.mkdir(parents=True, exist_ok=True)
+    path = managed / "MgdRunProv.json"
+    path.write_text(json.dumps(content))
+    yield web_main, content, path
+    path.unlink(missing_ok=True)
+
+
+def test_resolves_managed_profile_by_id_and_hashes_bytes(managed_profile):
+    web_main, content, _ = managed_profile
+    expected = canonical_profile_hash(content)
+    assert web_main._profile_sha256_for("managed/MgdRunProv.json") == expected
+
+
+def test_resolves_managed_profile_by_name(managed_profile):
+    web_main, content, _ = managed_profile
+    assert web_main._profile_sha256_for("MgdRunProv") == canonical_profile_hash(content)
+
+
+def test_returns_none_for_unknown_profile(managed_profile):
+    web_main, _, _ = managed_profile
+    assert web_main._profile_sha256_for("does_not_exist") is None

--- a/unit_tests/test_profile_sync.py
+++ b/unit_tests/test_profile_sync.py
@@ -1,0 +1,47 @@
+"""
+Unit tests for aquila_web/profile_sync.py — reconcile(desired, managed_dir, fetch).
+
+The on-device sync agent's decision core (acorn-fleet ADR-0002, issue #457):
+given the per-device Profile Assignment (a list of S3 keys from the `profiles`
+shadow) and a way to fetch an object's bytes, it reconciles the local
+``managed/`` directory. 3b covers the *add* path only; delete / edit-detection /
+reported state are 4b. IO is injected, so no network or Greengrass IPC is needed.
+Marked ``unit``.
+"""
+import pytest
+
+from aquila_web.profile_sync import reconcile
+
+pytestmark = pytest.mark.unit
+
+
+def test_writes_a_newly_assigned_profile_into_managed(tmp_path):
+    """A desired key with no local file is fetched from S3 and written."""
+    managed = tmp_path / "managed"
+    body = b'{"title": "Beer Spoilers", "steps": []}'
+
+    reconcile(
+        desired=[{"key": "profiles/Beer_Spoilers.json"}],
+        managed_dir=managed,
+        fetch=lambda key: body,
+    )
+
+    assert (managed / "Beer_Spoilers.json").read_bytes() == body
+
+
+def test_does_not_refetch_a_profile_already_present(tmp_path):
+    """An already-present managed profile is left as-is (no redundant fetch)."""
+    managed = tmp_path / "managed"
+    managed.mkdir()
+    (managed / "Beer_Spoilers.json").write_bytes(b"original")
+
+    def _fetch(key):
+        raise AssertionError(f"should not fetch already-present {key}")
+
+    reconcile(
+        desired=[{"key": "profiles/Beer_Spoilers.json"}],
+        managed_dir=managed,
+        fetch=_fetch,
+    )
+
+    assert (managed / "Beer_Spoilers.json").read_bytes() == b"original"


### PR DESCRIPTION
## What this does

Implements **3b — the tracer bullet** for per-device profiles (ADR-0002): a Managed Profile assigned via the `profiles` shadow lands in `managed/`, appears in the picker **read-only**, and is **selectable to run** — proving the delivery path end-to-end. Built test-first (RED→GREEN per behavior).

### Behaviors covered
1. **Sync-agent reconcile (add-path)** — `profile_sync.reconcile(desired, managed_dir, fetch)`: a desired S3 key with no local file is fetched + written into `managed/`; already-present ones aren't re-fetched; `local/` is never touched. IO is injected (no Greengrass IPC / network in tests).
2. **Listing** — `list_profiles` searches `managed/`, marks Managed Profiles **read-only**, and does **not** hostname-filter them (the shadow already scopes them to this device). Editing a Managed Profile is rejected (403).
3. **Selectable + provenance** — a Managed Profile is selectable and reflected in status; `_profile_sha256_for` resolves the selected profile (by id or name) to its exact bytes and hashes them, wired into the simulate run's `run_complete` so a Managed Profile run is provenance-stamped.

### Scope notes
- **`managed/` and `bundled/` coexist.** The `bundled/` → `managed/` rename and baked-path removal are deferred to **7b's cutover** (avoids churning code 7b deletes).
- **Behavior 3 is proved as selectable + a unit-tested provenance resolver + the sim-enqueue wiring**, rather than driving the full 8-second simulation (drawer/optics/analysis) — which the codebase's own tests never do (they post result fixtures to the endpoint). Same guarantee, no brittleness; the endpoint-level "run_complete carries the hash" is locked by 1b.

## Testing
- 9 new tests green (`unit_tests/test_profile_sync.py`, `tests/contract/test_managed_profiles.py`, `tests/unit/test_managed_run_provenance.py`).
- Full non-e2e suite: **982→991 passing, 0 new failures** (the 51 failures present are pre-existing on the base — hardware/background_sync test-isolation, e2e needs playwright).

## Notes
- Targets **`feat/greengrass-migration`** directly. 1b (#462) is already merged there (squash), so this diff is clean 3b-only — no `profile_hash.py` (it lives on the base via 1b).
- Depends on **2b** (acorn-fleet#29, merged) for the live shadow sync / bucket versioning; not needed to review this code (reconcile IO is injected).
- `Closes #457` won't auto-fire on merge into `feat/greengrass-migration` (not the default branch) — close manually or when greengrass lands on `main`.

Closes #457

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012hUuWrV3xi3FCn7MyFCztf
