### PR TITLE
4b — Reconcile hardening: detach, edit-detection, reported state

### DIFF
--- a/aquila_web/profile_sync.py
+++ b/aquila_web/profile_sync.py
@@ -8,8 +8,27 @@ IO is injected so the logic is testable without Greengrass IPC or the network.
 This is the *add* path only: a desired key with no local file is fetched and
 written. Delete / edit-detection / reported state are added in 4b.
 """
+import hashlib
+import json
+from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Callable
+from typing import Callable, Optional
+
+
+@dataclass
+class ReconcileResult:
+    """Outcome of a reconcile, written to the shadow's ``reported`` state.
+
+    ``present`` is the set actually on disk after syncing (``{name, version}``);
+    ``mismatches`` flags advisory-sha failures so drift is visible, not silent.
+    """
+    present: list = field(default_factory=list)
+    mismatches: list = field(default_factory=list)
+
+# Sidecar recording the S3 version last synced per managed file, so an in-place
+# edit (same key, new version) is re-pulled without a hand-maintained hash. Not
+# a *.json name, so list_profiles() never mistakes it for a Profile.
+_SIDECAR = ".sync_state"
 
 
 def _filename(key: str) -> str:
@@ -17,22 +36,79 @@ def _filename(key: str) -> str:
     return key.rsplit("/", 1)[-1]
 
 
+def _load_state(managed_dir: Path) -> dict:
+    path = managed_dir / _SIDECAR
+    if path.exists():
+        try:
+            return json.loads(path.read_text())
+        except Exception:
+            return {}
+    return {}
+
+
+def _save_state(managed_dir: Path, state: dict) -> None:
+    (managed_dir / _SIDECAR).write_text(json.dumps(state))
+
+
 def reconcile(
     desired: list[dict],
     managed_dir: Path,
     fetch: Callable[[str], bytes],
-) -> None:
+    remote_version: Optional[Callable[[str], str]] = None,
+) -> ReconcileResult:
     """Reconcile ``managed_dir`` against the desired Profile Assignment.
 
     Each entry in ``desired`` is a dict with at least a ``key`` (the S3 object
-    key). A key whose file is not already present is fetched and written.
-    ``local/`` profiles are not represented here and are never touched.
+    key). A key is (re-)fetched when its file is missing, or — when
+    ``remote_version`` is supplied — when the object's current version differs
+    from the last synced one (in-place edit detection). A managed profile no
+    longer in ``desired`` is deleted. ``local/`` profiles are a separate
+    directory reconcile is never handed, so they are never touched.
     """
     managed_dir = Path(managed_dir)
     managed_dir.mkdir(parents=True, exist_ok=True)
+    state = _load_state(managed_dir)
+    mismatches = []
 
+    desired_filenames = {_filename(entry["key"]) for entry in desired}
+
+    # Add / update: fetch when missing, or when the remote version changed.
     for entry in desired:
         key = entry["key"]
-        dest = managed_dir / _filename(key)
-        if not dest.exists():
-            dest.write_bytes(fetch(key))
+        name = _filename(key)
+        dest = managed_dir / name
+        version = remote_version(key) if remote_version is not None else None
+        needs_fetch = (not dest.exists()) or (
+            version is not None and state.get(name) != version
+        )
+        if needs_fetch:
+            body = fetch(key)
+            # Advisory sha256 (optional): if declared and the fetched bytes
+            # don't match, surface the mismatch and do NOT install — a wrong or
+            # corrupt object should be visible, never silently applied.
+            declared = entry.get("sha256")
+            if declared is not None:
+                actual = hashlib.sha256(body).hexdigest()
+                if actual != declared.split(":")[-1]:
+                    mismatches.append(
+                        {"name": name, "expected": declared, "actual": actual}
+                    )
+                    continue
+            dest.write_bytes(body)
+            if version is not None:
+                state[name] = version
+
+    # Detach: a managed profile no longer in desired is removed. Only *.json
+    # profiles are considered (never the sync sidecar).
+    for path in managed_dir.glob("*.json"):
+        if path.name not in desired_filenames:
+            path.unlink()
+            state.pop(path.name, None)
+
+    _save_state(managed_dir, state)
+
+    present = [
+        {"name": path.name, "version": state.get(path.name)}
+        for path in sorted(managed_dir.glob("*.json"))
+    ]
+    return ReconcileResult(present=present, mismatches=mismatches)

--- a/unit_tests/test_profile_sync.py
+++ b/unit_tests/test_profile_sync.py
@@ -45,3 +45,121 @@ def test_does_not_refetch_a_profile_already_present(tmp_path):
     )
 
     assert (managed / "Beer_Spoilers.json").read_bytes() == b"original"
+
+
+def test_detaches_a_profile_removed_from_desired(tmp_path):
+    """A managed profile whose key left the shadow's desired list is deleted."""
+    managed = tmp_path / "managed"
+    managed.mkdir()
+    (managed / "Keep.json").write_bytes(b"keep")
+    (managed / "Drop.json").write_bytes(b"drop")
+
+    reconcile(
+        desired=[{"key": "profiles/Keep.json"}],
+        managed_dir=managed,
+        fetch=lambda key: b"keep",
+    )
+
+    assert (managed / "Keep.json").exists()
+    assert not (managed / "Drop.json").exists()
+
+
+def test_refetches_when_remote_version_changed(tmp_path):
+    """An in-place edit (same key, new S3 version) is detected and re-pulled."""
+    managed = tmp_path / "managed"
+    bodies = {"v1": b"old recipe", "v2": b"new recipe"}
+    state = {"cur": "v1"}
+
+    def fetch(key):
+        return bodies[state["cur"]]
+
+    def remote_version(key):
+        return state["cur"]
+
+    desired = [{"key": "profiles/P.json"}]
+    reconcile(desired, managed, fetch, remote_version)
+    assert (managed / "P.json").read_bytes() == b"old recipe"
+
+    state["cur"] = "v2"
+    reconcile(desired, managed, fetch, remote_version)
+    assert (managed / "P.json").read_bytes() == b"new recipe"
+
+
+def test_does_not_refetch_when_remote_version_unchanged(tmp_path):
+    """An unchanged S3 version is not re-downloaded on the next reconcile."""
+    managed = tmp_path / "managed"
+    fetches = []
+
+    def fetch(key):
+        fetches.append(key)
+        return b"x"
+
+    desired = [{"key": "profiles/P.json"}]
+    reconcile(desired, managed, fetch, remote_version=lambda key: "v1")
+    reconcile(desired, managed, fetch, remote_version=lambda key: "v1")
+
+    assert fetches == ["profiles/P.json"]  # fetched once, not twice
+
+
+def test_reports_the_applied_set(tmp_path):
+    """reconcile returns what is actually on disk after syncing — the payload
+    the agent writes to the shadow's reported state."""
+    managed = tmp_path / "managed"
+    reconcile(
+        [{"key": "profiles/A.json"}, {"key": "profiles/B.json"}],
+        managed, fetch=lambda key: b"x",
+    )
+
+    result = reconcile([{"key": "profiles/A.json"}], managed, fetch=lambda key: b"x")
+
+    assert {p["name"] for p in result.present} == {"A.json"}  # B was detached
+
+
+def test_reconcile_is_idempotent(tmp_path):
+    """A second reconcile with unchanged inputs fetches nothing, deletes
+    nothing, and reports the same set."""
+    managed = tmp_path / "managed"
+    desired = [{"key": "profiles/A.json"}, {"key": "profiles/B.json"}]
+    fetches = []
+
+    def fetch(key):
+        fetches.append(key)
+        return b"x"
+
+    reconcile(desired, managed, fetch, remote_version=lambda key: "v1")
+    result = reconcile(desired, managed, fetch, remote_version=lambda key: "v1")
+
+    assert len(fetches) == 2  # only the initial two, no re-fetch
+    assert {p["name"] for p in result.present} == {"A.json", "B.json"}
+    assert (managed / "A.json").exists() and (managed / "B.json").exists()
+
+
+def test_advisory_sha_mismatch_is_flagged_not_installed(tmp_path):
+    """If a desired entry declares a sha256 that the fetched bytes don't match,
+    the mismatch is surfaced (not silently installed) so drift is visible."""
+    managed = tmp_path / "managed"
+    result = reconcile(
+        [{"key": "profiles/P.json", "sha256": "0" * 64}],  # deliberately wrong
+        managed,
+        fetch=lambda key: b"actual bytes that hash to something else",
+    )
+
+    assert any(m["name"] == "P.json" for m in result.mismatches)
+    assert not (managed / "P.json").exists()
+
+
+def test_matching_advisory_sha_installs_normally(tmp_path):
+    """A correct advisory sha256 installs the profile with no mismatch."""
+    import hashlib
+    managed = tmp_path / "managed"
+    body = b'{"title": "P"}'
+    good = hashlib.sha256(body).hexdigest()
+
+    result = reconcile(
+        [{"key": "profiles/P.json", "sha256": good}],
+        managed,
+        fetch=lambda key: body,
+    )
+
+    assert result.mismatches == []
+    assert (managed / "P.json").read_bytes() == body


### PR DESCRIPTION
## What this does

Implements **4b — reconcile hardening** (ADR-0002): grows the sync-agent decision core from add-only (3b) into a full two-way reconcile. Built test-first (RED→GREEN per behavior).

### Behaviors covered
1. **Detach** — a managed profile no longer in the shadow's `desired` list is deleted; `local/` is never touched.
2. **Edit detection** — an in-place edit (same key, new S3 version) is re-pulled; an unchanged version is not re-fetched. Tracked via a `.sync_state` sidecar (non-`.json`, so `list_profiles` ignores it).
3. **Reported** — `reconcile` returns `ReconcileResult.present` (the applied set) for the agent to write into the shadow's `reported` state.
4. **Idempotence** — an identical rerun fetches nothing, deletes nothing, reports the same set.
5. **Advisory sha256** — a declared hash that doesn't match the fetched bytes is surfaced in `mismatches`, never silently installed.

Pure decision core with injected `fetch`/`remote_version` — no IPC or network in tests.

## Testing
- 9 `profile_sync` unit tests green (7 new here + the 2 add-path from 3b).
- Full non-e2e suite: **991→998 passing, 0 new failures** (the 51 present are pre-existing on the base — hardware/background_sync test-isolation).

## Notes
- Targets **`feat/greengrass-migration`** directly. 3b (#463) is already merged there (squash), so this diff is clean 4b-only.
- **`reconcile` is not yet called by production code.** The on-device agent shell (IPC read of the `profiles` shadow → S3 fetch + version → `reconcile` → write `reported`) is untestable CI glue and is tracked as a separate follow-up. Until it lands, this is proven logic with no runtime caller — the last wiring step before the 7b cutover.

Closes #458

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012hUuWrV3xi3FCn7MyFCztf
