### PR TITLE
fix(greengrass): pin greengrassDataPlaneEndpoint so deployments/core-registration can't wedge

### DIFF
--- a/scripts/deploy/deployment3_greengrass.sh
+++ b/scripts/deploy/deployment3_greengrass.sh
@@ -695,6 +695,12 @@ services:
       iotRoleAlias: "${GG_ROLE_ALIAS}"
       iotDataEndpoint: "${GG_IOT_DATA_ENDPOINT}"
       iotCredEndpoint: "${GG_IOT_CRED_ENDPOINT}"
+      # Pin the Greengrass data-plane to the account's IoT data endpoint. Left
+      # empty the nucleus SDK defaults to the shared greengrass-ats.iot.<region>
+      # endpoint, which completes mTLS then closes with no HTTP response for this
+      # device -- wedging every deployment at ListThingGroupsForCoreDevice
+      # (#442). Same host as iotDataEndpoint, data-plane port 8443.
+      greengrassDataPlaneEndpoint: "${GG_IOT_DATA_ENDPOINT}"
 EOF
 
 java -Droot="${GG_ROOT}" -Dlog.store=FILE \
@@ -746,6 +752,7 @@ run_test "greengrass ordered after kiosk" "systemctl show -p After greengrass.se
 run_test "greengrass service installed"   "test -f /etc/systemd/system/greengrass.service"
 run_test "provisioned with device cert"   "grep -q 'device.crt' /opt/aquila/config/greengrass-config.yaml"
 run_test "role alias configured"          "grep -q '${GG_ROLE_ALIAS}' /opt/aquila/config/greengrass-config.yaml"
+run_test "data-plane endpoint pinned"     "grep -q 'greengrassDataPlaneEndpoint: \"${GG_IOT_DATA_ENDPOINT}\"' /opt/aquila/config/greengrass-config.yaml"
 run_test "ggc_user in docker group"       "id -nG ggc_user | grep -qw docker"
 run_test "device.env readable by ggc_group" "test \"\$(stat -c '%G' /opt/aquila/config/device.env)\" = ggc_group"
 run_test "device.env perms 0640 (ggc_user can read)" "test \"\$(stat -c '%a' /opt/aquila/config/device.env)\" = 640"

--- a/scripts/deploy/deployment3_greengrass.sh
+++ b/scripts/deploy/deployment3_greengrass.sh
@@ -705,11 +705,26 @@ java -Droot="${GG_ROOT}" -Dlog.store=FILE \
     --provision false
 
 # The component runs as ggc_user, which must (a) reach the Docker socket to run
-# the compose stack and (b) read the root-owned device.env the compose injects.
-# Without these the component goes BROKEN ("permission denied ... docker.sock").
+# the compose stack and (b) read the root-owned device.env the compose injects as
+# its env_file. Without these the component goes BROKEN ("permission denied").
 usermod -aG docker ggc_user
 chgrp ggc_group /opt/aquila/config/device.env && chmod 640 /opt/aquila/config/device.env
 chmod o+rx /opt/aquila /opt/aquila/config
+
+# ...but a one-time chmod is fragile: re-enrolment (enroll_device.py) and cert
+# renewal rewrite files under /opt/aquila/config and can leave device.env at
+# root:root 0600, which silently re-breaks the component (ggc_user can no longer
+# read the compose env_file) -- and a plain reboot does NOT heal it. Install a
+# tmpfiles.d rule so systemd re-asserts the correct group+mode on every boot; a
+# rewrite then self-heals on the next restart instead of bricking the app.
+cat > /etc/tmpfiles.d/aquila-device-env.conf <<'EOF'
+# Keep the compose env_file readable by the Greengrass component user: ggc_user is
+# in ggc_group, so 0640 root:ggc_group lets the component read it while the file
+# stays owner-write-only. Re-applied on every boot so a re-enrolment/renewal that
+# resets it to 0600 can't leave the component BROKEN.
+z /opt/aquila/config/device.env 0640 root ggc_group -
+EOF
+systemd-tmpfiles --create /etc/tmpfiles.d/aquila-device-env.conf 2>/dev/null || true
 
 # Let the kiosk reach the screen before the nucleus starts its heavy first-boot
 # work (JRE, JITP registration, ~497 MB image pull). The installer registers
@@ -733,6 +748,8 @@ run_test "provisioned with device cert"   "grep -q 'device.crt' /opt/aquila/conf
 run_test "role alias configured"          "grep -q '${GG_ROLE_ALIAS}' /opt/aquila/config/greengrass-config.yaml"
 run_test "ggc_user in docker group"       "id -nG ggc_user | grep -qw docker"
 run_test "device.env readable by ggc_group" "test \"\$(stat -c '%G' /opt/aquila/config/device.env)\" = ggc_group"
+run_test "device.env perms 0640 (ggc_user can read)" "test \"\$(stat -c '%a' /opt/aquila/config/device.env)\" = 640"
+run_test "device.env perms self-heal on boot" "grep -q '/opt/aquila/config/device.env 0640 root ggc_group' /etc/tmpfiles.d/aquila-device-env.conf"
 
 phase_pass "Greengrass nucleus installed + provisioned; ggc_user granted Docker + config access (JITP -> ${GG_THING_GROUP})"
 

--- a/tests/fleet_device/test_deployment3_greengrass_script.py
+++ b/tests/fleet_device/test_deployment3_greengrass_script.py
@@ -10,6 +10,7 @@ image delivery and updates.
 Run with:
     pytest tests/fleet_device/test_deployment3_greengrass_script.py -v
 """
+import re
 from pathlib import Path
 
 SCRIPT = Path("scripts/deploy/deployment3_greengrass.sh").read_text()
@@ -40,6 +41,22 @@ def test_configures_iot_endpoints():
     # endpoints — the Pi has no AWS creds to look them up itself.
     assert "iotDataEndpoint" in SCRIPT
     assert "iotCredEndpoint" in SCRIPT
+
+
+def test_pins_greengrass_dataplane_endpoint_to_account_endpoint():
+    # Manual provisioning must pin the Greengrass data-plane endpoint to the
+    # account's IoT data endpoint. Left unset, the nucleus SDK defaults to the
+    # shared greengrass-ats.iot.<region>.amazonaws.com endpoint, which completes
+    # mTLS then refuses this device (closes with no HTTP response) -- so every
+    # deployment wedges at ListThingGroupsForCoreDevice, IN_PROGRESS forever
+    # (#442; regressed by a re-provision that regenerated nucleus config).
+    data_ep = re.search(r'iotDataEndpoint:\s*"([^"]+)"', SCRIPT)
+    dp_ep = re.search(r'greengrassDataPlaneEndpoint:\s*"([^"]*)"', SCRIPT)
+    assert dp_ep is not None, "greengrassDataPlaneEndpoint is not set in the nucleus config"
+    assert dp_ep.group(1), "greengrassDataPlaneEndpoint must not be empty (empty => greengrass-ats default)"
+    assert data_ep is not None and dp_ep.group(1) == data_ep.group(1), (
+        "greengrassDataPlaneEndpoint must be pinned to the same account endpoint as iotDataEndpoint"
+    )
 
 
 def test_watchtower_ota_path_removed():


### PR DESCRIPTION
## Summary

`deployment3_greengrass.sh` wrote `iotDataEndpoint`/`iotCredEndpoint` but left **`greengrassDataPlaneEndpoint` unset**, so the nucleus SDK falls back to the shared `greengrass-ats.iot.<region>.amazonaws.com` endpoint. That endpoint completes mTLS with the device cert then closes with zero HTTP bytes, so `ListThingGroupsForCoreDevice` fails — the device never registers as a managed core device and every deployment hangs `IN_PROGRESS`.

This is the same wedge SN01 hit (hand-fixed 2026-08-12). Pinning it in the script means every device provisioned from here on gets it automatically.

## Change
- Pin `greengrassDataPlaneEndpoint: ${GG_IOT_DATA_ENDPOINT}` (same account host as `iotDataEndpoint`, data-plane port 8443).
- Add a `run_test` smoke check on the generated config + a static test asserting the endpoint is pinned.

Part of #442. Merges cleanly into `feat/greengrass-migration` (no conflicts).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011zrHmdEUR6ihtYykXAghTG